### PR TITLE
Use shared database for auth service

### DIFF
--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -1,8 +1,14 @@
 import sqlite3
-from passlib.hash import bcrypt
 from pathlib import Path
 
-DB_PATH = Path(__file__).resolve().parent.parent / "database.db"
+from passlib.hash import bcrypt
+
+# Use the shared application database so auth data stays consistent with
+# other services.  The previous path pointed to ``database.db`` which is not
+# used anywhere else in the project and would create a separate, empty
+# database file.  This caused newly created users to be invisible to
+# components that relied on the main ``rockmundo.db`` file.
+DB_PATH = Path(__file__).resolve().parent.parent / "rockmundo.db"
 
 def get_db_connection():
     conn = sqlite3.connect(DB_PATH)


### PR DESCRIPTION
## Summary
- fix auth service to use shared `rockmundo.db`
- document rationale in code comments

## Testing
- `ruff check backend/services/auth_service.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68aecf798480832595e42253e1e5c663