### PR TITLE
refactor: use settings for auth constants

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
+
 def _load_dotenv(dotenv_path: Optional[str] = None) -> None:
     path = dotenv_path or (Path(__file__).resolve().parents[2] / ".env")
     try:
@@ -26,6 +27,7 @@ class Settings:
     JWT_SECRET: str = os.getenv("ROCKMUNDO_JWT_SECRET", "dev-change-me")
     JWT_ISS: str = os.getenv("ROCKMUNDO_JWT_ISS", "rockmundo")
     JWT_AUD: str = os.getenv("ROCKMUNDO_JWT_AUD", "rockmundo-app")
+    JWT_ALG: str = os.getenv("ROCKMUNDO_JWT_ALG", "HS256")
     ACCESS_TOKEN_TTL_MIN: int = int(os.getenv("ROCKMUNDO_ACCESS_TTL_MIN", "30"))
     REFRESH_TOKEN_TTL_DAYS: int = int(os.getenv("ROCKMUNDO_REFRESH_TTL_DAYS", "30"))
 

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -1,20 +1,19 @@
-from auth.dependencies import get_current_user_id, require_role
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
-from utils.auth_utils import create_access_token, verify_user_credentials
 from pydantic import BaseModel
+from utils.auth_utils import create_access_token, verify_user_credentials
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 class TokenResponse(BaseModel):
-    
-access_token: str
+    access_token: str
     token_type: str = "bearer"
+
 
 @router.post("/login", response_model=TokenResponse)
 async def login(form_data: OAuth2PasswordRequestForm = Depends()):
     user = verify_user_credentials(form_data.username, form_data.password)
     if not user:
         raise HTTPException(status_code=401, detail="Invalid credentials")
-    token = create_access_token(user["username"])
+    token = create_access_token(user["username"], user["role"])
     return TokenResponse(access_token=token)

--- a/backend/utils/auth_utils.py
+++ b/backend/utils/auth_utils.py
@@ -1,15 +1,14 @@
 from datetime import datetime, timedelta
+
+from core.config import settings
 from jose import jwt
 from services.auth_service import get_user_by_username, verify_password
 
-SECRET_KEY = "your-secret-key"
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 60
 
 def create_access_token(username: str, role: str) -> str:
-    expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    expire = datetime.utcnow() + timedelta(minutes=settings.ACCESS_TOKEN_TTL_MIN)
     to_encode = {"sub": username, "role": role, "exp": expire}
-    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return jwt.encode(to_encode, settings.JWT_SECRET, algorithm=settings.JWT_ALG)
 
 def verify_user_credentials(username: str, password: str) -> dict:
     user = get_user_by_username(username)


### PR DESCRIPTION
## Summary
- read auth config from central settings instead of hardcoded constants
- wire login route to include user role in token creation
- expose JWT algorithm in settings

## Testing
- `ruff check backend/core/config.py backend/utils/auth_utils.py backend/routes/auth_routes.py`
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68aed66ab4c08325ac7939b92fff398e