### PR TITLE
Return user role in authentication token

### DIFF
--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -1,20 +1,21 @@
-from auth.dependencies import get_current_user_id, require_role
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
-from utils.auth_utils import create_access_token, verify_user_credentials
 from pydantic import BaseModel
+from utils.auth_utils import create_access_token, verify_user_credentials
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
+
 class TokenResponse(BaseModel):
-    
-access_token: str
+    access_token: str
     token_type: str = "bearer"
+    role: str
+
 
 @router.post("/login", response_model=TokenResponse)
 async def login(form_data: OAuth2PasswordRequestForm = Depends()):
     user = verify_user_credentials(form_data.username, form_data.password)
     if not user:
         raise HTTPException(status_code=401, detail="Invalid credentials")
-    token = create_access_token(user["username"])
-    return TokenResponse(access_token=token)
+    token = create_access_token(user["username"], user["role"])
+    return TokenResponse(access_token=token, token_type="bearer", role=user["role"])


### PR DESCRIPTION
## Summary
- Include `role` in `TokenResponse` for login endpoint
- Pass username and role to `create_access_token`
- Return token, token type, and user role in login response

## Testing
- `ruff check backend/routes/auth_routes.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68aed6d88f7483259a8b5d34175138d3