### PR TITLE
Add economy module and integrate with ticketing and merch

### DIFF
--- a/backend/economy/__init__.py
+++ b/backend/economy/__init__.py
@@ -1,0 +1,1 @@
+"""Economy models package."""

--- a/backend/economy/models.py
+++ b/backend/economy/models.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class Account:
+    """Represents a user's currency account."""
+
+    id: int
+    user_id: int
+    currency: str
+    balance_cents: int
+    created_at: datetime
+
+
+@dataclass
+class Transaction:
+    """Record of money moving between accounts or external sources."""
+
+    id: int
+    type: str  # deposit, withdrawal, transfer
+    amount_cents: int
+    currency: str
+    src_account_id: int | None
+    dest_account_id: int | None
+    created_at: datetime
+
+
+@dataclass
+class LedgerEntry:
+    """Account-level delta for a transaction."""
+
+    id: int
+    account_id: int
+    transaction_id: int
+    delta_cents: int
+    balance_after: int
+    created_at: datetime

--- a/backend/routes/economy_routes.py
+++ b/backend/routes/economy_routes.py
@@ -1,0 +1,75 @@
+"""FastAPI routes for the economy service."""
+
+from typing import List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from services.economy_service import EconomyError, EconomyService, TransactionRecord
+
+router = APIRouter(prefix="/economy", tags=["Economy"])
+
+svc = EconomyService()
+svc.ensure_schema()
+
+
+class AccountCreateIn(BaseModel):
+    user_id: int
+    currency: str = "USD"
+
+
+class AmountIn(BaseModel):
+    amount_cents: int
+    currency: str = "USD"
+
+
+class TransferIn(BaseModel):
+    from_user_id: int
+    to_user_id: int
+    amount_cents: int
+    currency: str = "USD"
+
+
+@router.post("/accounts")
+def create_account(payload: AccountCreateIn):
+    try:
+        svc.deposit(payload.user_id, 0, currency=payload.currency)
+        return {"user_id": payload.user_id}
+    except EconomyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/accounts/{user_id}")
+def get_balance(user_id: int):
+    return {"user_id": user_id, "balance_cents": svc.get_balance(user_id)}
+
+
+@router.post("/accounts/{user_id}/deposit")
+def deposit(user_id: int, payload: AmountIn):
+    try:
+        svc.deposit(user_id, payload.amount_cents, currency=payload.currency)
+        return {"balance_cents": svc.get_balance(user_id)}
+    except EconomyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/accounts/{user_id}/withdraw")
+def withdraw(user_id: int, payload: AmountIn):
+    try:
+        svc.withdraw(user_id, payload.amount_cents, currency=payload.currency)
+        return {"balance_cents": svc.get_balance(user_id)}
+    except EconomyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/transfer")
+def transfer(payload: TransferIn):
+    try:
+        svc.transfer(payload.from_user_id, payload.to_user_id, payload.amount_cents, currency=payload.currency)
+        return {"ok": True}
+    except EconomyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/accounts/{user_id}/transactions", response_model=List[TransactionRecord])
+def list_transactions(user_id: int, limit: int = 50):
+    return svc.list_transactions(user_id, limit=limit)

--- a/backend/routes/merch_routes.py
+++ b/backend/routes/merch_routes.py
@@ -1,36 +1,34 @@
-from auth.dependencies import get_current_user_id, require_role
-# File: backend/routes/merch_routes.py
-from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel
-from typing import Optional, List
-from services.merch_service import MerchService, MerchError, ProductIn, SKUIn
+from typing import List
 
-# Auth dep (replace with your real one as needed)
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from services.economy_service import EconomyService
+from services.merch_service import MerchError, MerchService, ProductIn, SKUIn
+
 try:
     from auth.dependencies import require_role
-except Exception:
+except Exception:  # pragma: no cover
     def require_role(roles):
         async def _noop():
             return True
         return _noop
 
 router = APIRouter(prefix="/merch", tags=["Merch Store"])
-svc = MerchService()
+svc = MerchService(economy=EconomyService())
 svc.ensure_schema()
 
-# -------- Models for API --------
+
 class ProductCreateIn(BaseModel):
-    
-name: str
+    name: str
     category: str
     band_id: int | None = None
     description: str | None = None
     image_url: str | None = None
     is_active: bool = True
 
+
 class SKUCreateIn(BaseModel):
-    
-product_id: int
+    product_id: int
     price_cents: int
     stock_qty: int
     option_size: str | None = None
@@ -39,19 +37,19 @@ product_id: int
     barcode: str | None = None
     is_active: bool = True
 
+
 class PurchaseItemIn(BaseModel):
-    
-sku_id: int
+    sku_id: int
     qty: int
 
+
 class PurchaseIn(BaseModel):
-    
-buyer_user_id: int
+    buyer_user_id: int
     items: List[PurchaseItemIn]
     shipping_address: str | None = None
 
-# -------- Product endpoints --------
-@router.post("/products", dependencies=[Depends(require_role(["admin","moderator"]))])
+
+@router.post("/products", dependencies=[Depends(require_role(["admin", "moderator"]))])
 def create_product(payload: ProductCreateIn):
     try:
         pid = svc.create_product(ProductIn(**payload.model_dump()))
@@ -59,11 +57,13 @@ def create_product(payload: ProductCreateIn):
     except MerchError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-@router.get("/products", dependencies=[Depends(require_role(["admin","moderator","band_member"]))])
+
+@router.get("/products", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
 def list_products(only_active: bool = True, category: str | None = None, band_id: int | None = None):
     return svc.list_products(only_active=only_active, category=category, band_id=band_id)
 
-@router.patch("/products/{product_id}", dependencies=[Depends(require_role(["admin","moderator"]))])
+
+@router.patch("/products/{product_id}", dependencies=[Depends(require_role(["admin", "moderator"]))])
 def update_product(product_id: int, fields: dict):
     try:
         svc.update_product(product_id, **fields)
@@ -71,8 +71,8 @@ def update_product(product_id: int, fields: dict):
     except MerchError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-# -------- SKU endpoints --------
-@router.post("/skus", dependencies=[Depends(require_role(["admin","moderator"]))])
+
+@router.post("/skus", dependencies=[Depends(require_role(["admin", "moderator"]))])
 def create_sku(payload: SKUCreateIn):
     try:
         sid = svc.create_sku(SKUIn(**payload.model_dump()))
@@ -80,11 +80,13 @@ def create_sku(payload: SKUCreateIn):
     except MerchError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-@router.get("/skus/{product_id}", dependencies=[Depends(require_role(["admin","moderator","band_member"]))])
+
+@router.get("/skus/{product_id}", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
 def list_skus(product_id: int, only_active: bool = True):
     return svc.list_skus(product_id, only_active=only_active)
 
-@router.patch("/skus/{sku_id}", dependencies=[Depends(require_role(["admin","moderator"]))])
+
+@router.patch("/skus/{sku_id}", dependencies=[Depends(require_role(["admin", "moderator"]))])
 def update_sku(sku_id: int, fields: dict):
     try:
         svc.update_sku(sku_id, **fields)
@@ -92,8 +94,8 @@ def update_sku(sku_id: int, fields: dict):
     except MerchError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-# -------- Orders --------
-@router.post("/purchase", dependencies=[Depends(require_role(["band_member","admin","moderator"]))])
+
+@router.post("/purchase", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
 def purchase(payload: PurchaseIn):
     try:
         order_id = svc.purchase(
@@ -105,20 +107,23 @@ def purchase(payload: PurchaseIn):
     except MerchError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-@router.post("/refund/{order_id}", dependencies=[Depends(require_role(["admin","moderator"]))])
+
+@router.post("/refund/{order_id}", dependencies=[Depends(require_role(["admin", "moderator"]))])
 def refund(order_id: int, reason: str = ""):
     try:
         return svc.refund_order(order_id, reason)
     except MerchError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-@router.get("/orders/{order_id}", dependencies=[Depends(require_role(["admin","moderator","band_member"]))])
+
+@router.get("/orders/{order_id}", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
 def get_order(order_id: int):
     try:
         return svc.get_order(order_id)
     except MerchError as e:
         raise HTTPException(status_code=404, detail=str(e))
 
-@router.get("/orders/user/{buyer_user_id}", dependencies=[Depends(require_role(["admin","moderator","band_member"]))])
+
+@router.get("/orders/user/{buyer_user_id}", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
 def list_orders_for_user(buyer_user_id: int):
     return svc.list_orders_for_user(buyer_user_id)

--- a/backend/services/economy_service.py
+++ b/backend/services/economy_service.py
@@ -1,0 +1,218 @@
+"""EconomyService provides basic account and transaction management."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class EconomyError(Exception):
+    """Generic economy related failure."""
+
+
+@dataclass
+class TransactionRecord:
+    id: int
+    type: str
+    amount_cents: int
+    currency: str
+    src_account_id: Optional[int]
+    dest_account_id: Optional[int]
+    created_at: str
+
+
+class EconomyService:
+    def __init__(self, db_path: Optional[str] = None):
+        self.db_path = str(db_path or DB_PATH)
+
+    # ---------------- schema ----------------
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS accounts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL UNIQUE,
+                    balance_cents INTEGER NOT NULL DEFAULT 0,
+                    currency TEXT NOT NULL DEFAULT 'USD',
+                    created_at TEXT DEFAULT (datetime('now'))
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS transactions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    type TEXT NOT NULL,
+                    amount_cents INTEGER NOT NULL,
+                    currency TEXT NOT NULL,
+                    src_account_id INTEGER,
+                    dest_account_id INTEGER,
+                    created_at TEXT DEFAULT (datetime('now')),
+                    FOREIGN KEY(src_account_id) REFERENCES accounts(id),
+                    FOREIGN KEY(dest_account_id) REFERENCES accounts(id)
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ledger_entries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    account_id INTEGER NOT NULL,
+                    transaction_id INTEGER NOT NULL,
+                    delta_cents INTEGER NOT NULL,
+                    balance_after INTEGER NOT NULL,
+                    created_at TEXT DEFAULT (datetime('now')),
+                    FOREIGN KEY(account_id) REFERENCES accounts(id),
+                    FOREIGN KEY(transaction_id) REFERENCES transactions(id)
+                )
+                """
+            )
+            conn.commit()
+
+    # ---------------- helpers ----------------
+    def _get_account(self, cur: sqlite3.Cursor, user_id: int) -> Optional[int]:
+        cur.execute("SELECT id FROM accounts WHERE user_id = ?", (user_id,))
+        row = cur.fetchone()
+        return int(row[0]) if row else None
+
+    def _require_account(self, cur: sqlite3.Cursor, user_id: int, currency: str) -> int:
+        acc_id = self._get_account(cur, user_id)
+        if acc_id is None:
+            cur.execute(
+                "INSERT INTO accounts (user_id, currency) VALUES (?, ?)",
+                (user_id, currency),
+            )
+            acc_id = int(cur.lastrowid or 0)
+        cur.execute("SELECT currency FROM accounts WHERE id = ?", (acc_id,))
+        row = cur.fetchone()
+        if row and row[0] != currency:
+            raise EconomyError("Currency mismatch for account")
+        return acc_id
+
+    def get_balance(self, user_id: int) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT balance_cents FROM accounts WHERE user_id = ?", (user_id,))
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
+
+    # ---------------- operations ----------------
+    def deposit(self, user_id: int, amount_cents: int, currency: str = "USD") -> int:
+        if amount_cents <= 0:
+            raise EconomyError("Deposit must be positive")
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("BEGIN IMMEDIATE")
+            acc_id = self._require_account(cur, user_id, currency)
+            cur.execute(
+                "INSERT INTO transactions (type, amount_cents, currency, dest_account_id) VALUES ('deposit', ?, ?, ?)",
+                (amount_cents, currency, acc_id),
+            )
+            tid = int(cur.lastrowid or 0)
+            cur.execute(
+                "UPDATE accounts SET balance_cents = balance_cents + ? WHERE id = ?",
+                (amount_cents, acc_id),
+            )
+            cur.execute("SELECT balance_cents FROM accounts WHERE id = ?", (acc_id,))
+            balance = int(cur.fetchone()[0])
+            cur.execute(
+                "INSERT INTO ledger_entries (account_id, transaction_id, delta_cents, balance_after) VALUES (?, ?, ?, ?)",
+                (acc_id, tid, amount_cents, balance),
+            )
+            conn.commit()
+            return tid
+
+    def withdraw(self, user_id: int, amount_cents: int, currency: str = "USD") -> int:
+        if amount_cents <= 0:
+            raise EconomyError("Withdrawal must be positive")
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("BEGIN IMMEDIATE")
+            acc_id = self._require_account(cur, user_id, currency)
+            cur.execute("SELECT balance_cents FROM accounts WHERE id = ?", (acc_id,))
+            balance = int(cur.fetchone()[0])
+            if balance < amount_cents:
+                raise EconomyError("Insufficient funds")
+            cur.execute(
+                "INSERT INTO transactions (type, amount_cents, currency, src_account_id) VALUES ('withdrawal', ?, ?, ?)",
+                (amount_cents, currency, acc_id),
+            )
+            tid = int(cur.lastrowid or 0)
+            cur.execute(
+                "UPDATE accounts SET balance_cents = balance_cents - ? WHERE id = ?",
+                (amount_cents, acc_id),
+            )
+            balance -= amount_cents
+            cur.execute(
+                "INSERT INTO ledger_entries (account_id, transaction_id, delta_cents, balance_after) VALUES (?, ?, ?, ?)",
+                (acc_id, tid, -amount_cents, balance),
+            )
+            conn.commit()
+            return tid
+
+    def transfer(self, from_user: int, to_user: int, amount_cents: int, currency: str = "USD") -> int:
+        if amount_cents <= 0:
+            raise EconomyError("Transfer amount must be positive")
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("BEGIN IMMEDIATE")
+            src_id = self._require_account(cur, from_user, currency)
+            dest_id = self._require_account(cur, to_user, currency)
+            cur.execute("SELECT balance_cents FROM accounts WHERE id = ?", (src_id,))
+            balance = int(cur.fetchone()[0])
+            if balance < amount_cents:
+                raise EconomyError("Insufficient funds")
+            cur.execute(
+                "INSERT INTO transactions (type, amount_cents, currency, src_account_id, dest_account_id) VALUES ('transfer', ?, ?, ?, ?)",
+                (amount_cents, currency, src_id, dest_id),
+            )
+            tid = int(cur.lastrowid or 0)
+            # update accounts
+            cur.execute(
+                "UPDATE accounts SET balance_cents = balance_cents - ? WHERE id = ?",
+                (amount_cents, src_id),
+            )
+            cur.execute(
+                "UPDATE accounts SET balance_cents = balance_cents + ? WHERE id = ?",
+                (amount_cents, dest_id),
+            )
+            # ledger entries
+            cur.execute("SELECT balance_cents FROM accounts WHERE id = ?", (src_id,))
+            src_balance = int(cur.fetchone()[0])
+            cur.execute(
+                "INSERT INTO ledger_entries (account_id, transaction_id, delta_cents, balance_after) VALUES (?, ?, ?, ?)",
+                (src_id, tid, -amount_cents, src_balance),
+            )
+            cur.execute("SELECT balance_cents FROM accounts WHERE id = ?", (dest_id,))
+            dest_balance = int(cur.fetchone()[0])
+            cur.execute(
+                "INSERT INTO ledger_entries (account_id, transaction_id, delta_cents, balance_after) VALUES (?, ?, ?, ?)",
+                (dest_id, tid, amount_cents, dest_balance),
+            )
+            conn.commit()
+            return tid
+
+    # ---------------- queries ----------------
+    def list_transactions(self, user_id: int, limit: int = 50) -> List[TransactionRecord]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT t.* FROM transactions t
+                JOIN ledger_entries le ON le.transaction_id = t.id
+                JOIN accounts a ON a.id = le.account_id
+                WHERE a.user_id = ?
+                ORDER BY t.created_at DESC, t.id DESC
+                LIMIT ?
+                """,
+                (user_id, limit),
+            )
+            rows = cur.fetchall()
+            return [TransactionRecord(**dict(r)) for r in rows]

--- a/backend/tests/economy/test_economy_service.py
+++ b/backend/tests/economy/test_economy_service.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.services.economy_service import EconomyError, EconomyService
+
+
+def setup_service():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    svc = EconomyService(db_path=path)
+    svc.ensure_schema()
+    return svc
+
+
+def test_deposit_withdraw_transfer():
+    svc = setup_service()
+    svc.deposit(1, 1000)
+    assert svc.get_balance(1) == 1000
+    svc.withdraw(1, 200)
+    assert svc.get_balance(1) == 800
+    svc.deposit(2, 500)
+    svc.transfer(1, 2, 300)
+    assert svc.get_balance(1) == 500
+    assert svc.get_balance(2) == 800
+
+
+def test_withdraw_insufficient_funds():
+    svc = setup_service()
+    svc.deposit(1, 100)
+    with pytest.raises(EconomyError):
+        svc.withdraw(1, 200)
+
+
+def test_transaction_history():
+    svc = setup_service()
+    svc.deposit(1, 100)
+    svc.withdraw(1, 50)
+    txns = svc.list_transactions(1)
+    assert len(txns) == 2
+    assert txns[0].type in {"deposit", "withdrawal", "transfer"}


### PR DESCRIPTION
## Summary
- implement EconomyService with SQLite-backed accounts, transactions and ledger entries
- expose new economy REST API for account management and transfers
- charge and refund ticket and merch orders through the economy service
- add unit tests for typical deposit/withdraw/transfer flows

## Testing
- `ruff check backend/economy backend/services/economy_service.py backend/routes/economy_routes.py backend/services/ticketing_service.py backend/routes/ticketing_routes.py backend/services/merch_service.py backend/routes/merch_routes.py backend/tests/economy/test_economy_service.py`
- `mypy backend/economy backend/services/economy_service.py backend/routes/economy_routes.py backend/services/ticketing_service.py backend/routes/ticketing_routes.py backend/services/merch_service.py backend/routes/merch_routes.py backend/tests/economy/test_economy_service.py`
- `pytest backend/tests/economy/test_economy_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed8e1b1b8832594776326c87a1b00