### PR TITLE
Add Discord webhook service and notification integration

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -30,5 +30,6 @@ class Settings:
     JWT_ALG: str = os.getenv("ROCKMUNDO_JWT_ALG", "HS256")
     ACCESS_TOKEN_TTL_MIN: int = int(os.getenv("ROCKMUNDO_ACCESS_TTL_MIN", "30"))
     REFRESH_TOKEN_TTL_DAYS: int = int(os.getenv("ROCKMUNDO_REFRESH_TTL_DAYS", "30"))
+    DISCORD_WEBHOOK_URL: str = os.getenv("DISCORD_WEBHOOK_URL", "")
 
 settings = Settings()

--- a/backend/services/discord_service.py
+++ b/backend/services/discord_service.py
@@ -1,0 +1,26 @@
+# File: backend/services/discord_service.py
+
+from core.config import settings
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover
+    requests = None  # type: ignore[assignment]
+
+
+class DiscordServiceError(Exception):
+    pass
+
+
+def send_message(content: str) -> None:
+    """Send a message to a Discord webhook."""
+    url = getattr(settings, "DISCORD_WEBHOOK_URL", "")
+    if not url:
+        raise DiscordServiceError("DISCORD_WEBHOOK_URL is not configured")
+    if requests is None:
+        raise DiscordServiceError("requests library is not installed")
+    try:
+        resp = requests.post(url, json={"content": content}, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network errors handled
+        raise DiscordServiceError("Failed to send message to Discord") from exc

--- a/backend/tests/services/test_discord_service.py
+++ b/backend/tests/services/test_discord_service.py
@@ -1,0 +1,56 @@
+# File: backend/tests/services/test_discord_service.py
+
+import pytest
+from core.config import settings
+from services import discord_service
+
+
+def test_send_message_posts_content(monkeypatch):
+    sent = {}
+
+    class DummyRequests:
+        RequestException = Exception
+
+        def post(self, url, json, timeout):
+            sent["url"] = url
+            sent["json"] = json
+
+            class Resp:
+                def raise_for_status(self):
+                    return None
+
+            return Resp()
+
+    monkeypatch.setattr(settings, "DISCORD_WEBHOOK_URL", "https://example.com/webhook")
+    monkeypatch.setattr(discord_service, "requests", DummyRequests())
+
+    discord_service.send_message("hello world")
+
+    assert sent["url"] == "https://example.com/webhook"
+    assert sent["json"] == {"content": "hello world"}
+
+
+def test_send_message_raises_on_error(monkeypatch):
+    class DummyRequestsError(Exception):
+        pass
+
+    def fake_post(*args, **kwargs):
+        raise DummyRequestsError("boom")
+
+    class DummyRequests:
+        RequestException = DummyRequestsError
+
+        def post(self, *args, **kwargs):
+            return fake_post(*args, **kwargs)
+
+    monkeypatch.setattr(settings, "DISCORD_WEBHOOK_URL", "https://example.com/webhook")
+    monkeypatch.setattr(discord_service, "requests", DummyRequests())
+
+    with pytest.raises(discord_service.DiscordServiceError):
+        discord_service.send_message("fail")
+
+
+def test_send_message_requires_url(monkeypatch):
+    monkeypatch.setattr(settings, "DISCORD_WEBHOOK_URL", "")
+    with pytest.raises(discord_service.DiscordServiceError):
+        discord_service.send_message("oops")


### PR DESCRIPTION
## Summary
- add `DISCORD_WEBHOOK_URL` setting and Discord service for webhook messages
- send Discord messages when notifications are created with `send_to_discord`
- cover Discord service with unit tests

## Testing
- `ruff check backend/core/config.py backend/services/discord_service.py backend/services/notifications_service.py backend/tests/services/test_discord_service.py`
- `PYTHONPATH=backend pytest backend/tests/services/test_discord_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeda9a86388325b2355ac97aa7ea57