### PR TITLE
Add property management models, services, routes, and tests

### DIFF
--- a/backend/models/property.py
+++ b/backend/models/property.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class PropertyType:
+    """Represents a kind of property that can be purchased."""
+    name: str
+    base_price: int
+    base_rent: int
+
+
+@dataclass
+class PropertyUpgrade:
+    """Describes an upgrade applied to a property."""
+    level: int
+    cost: int
+    rent_bonus: int
+    rehearsal_bonus: int = 0
+
+
+@dataclass
+class Property:
+    """A property owned by a band or user."""
+    id: Optional[int]
+    owner_id: int
+    name: str
+    property_type: str
+    location: str
+    purchase_price: int
+    base_rent: int
+    level: int = 1
+
+    def to_dict(self) -> dict:
+        return self.__dict__

--- a/backend/routes/property_routes.py
+++ b/backend/routes/property_routes.py
@@ -1,0 +1,67 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from typing import List
+
+from services.economy_service import EconomyService
+from services.property_service import PropertyService, PropertyError
+
+
+def require_role(roles):  # placeholder auth dependency
+    async def _noop():
+        return True
+    return _noop
+
+router = APIRouter(prefix="/properties", tags=["Properties"])
+svc = PropertyService(economy=EconomyService())
+svc.ensure_schema()
+
+
+class PropertyPurchaseIn(BaseModel):
+    owner_id: int
+    name: str
+    property_type: str
+    location: str
+    price_cents: int
+    base_rent: int
+
+
+class PropertyActionIn(BaseModel):
+    owner_id: int
+
+
+@router.post("/buy", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+def buy_property(payload: PropertyPurchaseIn):
+    try:
+        pid = svc.buy_property(
+            owner_id=payload.owner_id,
+            name=payload.name,
+            property_type=payload.property_type,
+            location=payload.location,
+            price_cents=payload.price_cents,
+            base_rent=payload.base_rent,
+        )
+        return {"property_id": pid}
+    except PropertyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/upgrade/{property_id}", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+def upgrade_property(property_id: int, payload: PropertyActionIn):
+    try:
+        return svc.upgrade_property(property_id, payload.owner_id)
+    except PropertyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/sell/{property_id}", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+def sell_property(property_id: int, payload: PropertyActionIn):
+    try:
+        amount = svc.sell_property(property_id, payload.owner_id)
+        return {"received_cents": amount}
+    except PropertyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/list/{owner_id}", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+def list_properties(owner_id: int):
+    return svc.list_properties(owner_id)

--- a/backend/services/property_service.py
+++ b/backend/services/property_service.py
@@ -1,0 +1,154 @@
+"""Service logic for property management."""
+from pathlib import Path
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+from .economy_service import EconomyService, EconomyError
+
+try:
+    from .fame_service import FameService  # type: ignore
+except Exception:  # pragma: no cover - fame service optional
+    FameService = None  # type: ignore
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class PropertyError(Exception):
+    pass
+
+
+class PropertyService:
+    def __init__(
+        self,
+        db_path: Optional[str] = None,
+        economy: Optional[EconomyService] = None,
+        fame: Optional[Any] = None,
+    ) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.economy = economy or EconomyService(db_path=self.db_path)
+        self.fame = fame
+        # ensure economy schema as well
+        self.economy.ensure_schema()
+
+    # ---------------- schema ----------------
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS properties (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    owner_id INTEGER NOT NULL,
+                    name TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    location TEXT NOT NULL,
+                    purchase_price INTEGER NOT NULL,
+                    base_rent INTEGER NOT NULL,
+                    level INTEGER NOT NULL DEFAULT 1,
+                    created_at TEXT DEFAULT (datetime('now')),
+                    updated_at TEXT
+                )
+                """
+            )
+            conn.commit()
+
+    # ---------------- helpers ----------------
+    def _fetch_property(self, property_id: int) -> Optional[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("SELECT * FROM properties WHERE id = ?", (property_id,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    # ---------------- operations ----------------
+    def buy_property(
+        self,
+        owner_id: int,
+        name: str,
+        property_type: str,
+        location: str,
+        price_cents: int,
+        base_rent: int,
+    ) -> int:
+        if price_cents <= 0:
+            raise PropertyError("Price must be positive")
+        try:
+            self.economy.withdraw(owner_id, price_cents)
+        except EconomyError as e:
+            raise PropertyError(str(e)) from e
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO properties (owner_id, name, type, location, purchase_price, base_rent)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (owner_id, name, property_type, location, price_cents, base_rent),
+            )
+            conn.commit()
+            return int(cur.lastrowid or 0)
+
+    def list_properties(self, owner_id: Optional[int] = None) -> List[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            q = "SELECT * FROM properties"
+            vals: List[Any] = []
+            if owner_id is not None:
+                q += " WHERE owner_id = ?"
+                vals.append(owner_id)
+            cur.execute(q, tuple(vals))
+            return [dict(r) for r in cur.fetchall()]
+
+    def upgrade_property(self, property_id: int, owner_id: int) -> Dict[str, Any]:
+        prop = self._fetch_property(property_id)
+        if not prop or prop["owner_id"] != owner_id:
+            raise PropertyError("Property not found")
+        new_level = prop["level"] + 1
+        cost = int(prop["purchase_price"] * 0.5 * new_level)
+        try:
+            self.economy.withdraw(owner_id, cost)
+        except EconomyError as e:
+            raise PropertyError(str(e)) from e
+        new_rent = int(prop["base_rent"] * 1.2)
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                UPDATE properties
+                SET level = ?, base_rent = ?, updated_at = datetime('now')
+                WHERE id = ?
+                """,
+                (new_level, new_rent, property_id),
+            )
+            if cur.rowcount == 0:
+                raise PropertyError("Upgrade failed")
+            conn.commit()
+        if self.fame:
+            try:
+                self.fame.award_fame(owner_id, "property_upgrade", new_level, f"Upgraded {prop['name']}")
+            except Exception:
+                pass
+        return self._fetch_property(property_id) or {}
+
+    def collect_rent(self, owner_id: int) -> int:
+        props = self.list_properties(owner_id)
+        total = sum(p["base_rent"] * p["level"] for p in props)
+        if total:
+            self.economy.deposit(owner_id, total)
+        return total
+
+    def sell_property(self, property_id: int, owner_id: int) -> int:
+        prop = self._fetch_property(property_id)
+        if not prop or prop["owner_id"] != owner_id:
+            raise PropertyError("Property not found")
+        sale_price = int(prop["purchase_price"] * 0.8)
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM properties WHERE id = ?", (property_id,))
+            if cur.rowcount == 0:
+                raise PropertyError("Sale failed")
+            conn.commit()
+        self.economy.deposit(owner_id, sale_price)
+        return sale_price

--- a/backend/tests/property/test_property_service.py
+++ b/backend/tests/property/test_property_service.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.services.property_service import PropertyService
+from backend.services.economy_service import EconomyService
+
+
+class DummyFameService:
+    def __init__(self):
+        self.calls = []
+
+    def award_fame(self, band_id, source, amount, reason):
+        self.calls.append((band_id, source, amount, reason))
+
+
+def setup_service():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    econ = EconomyService(db_path=path)
+    econ.ensure_schema()
+    fame = DummyFameService()
+    svc = PropertyService(db_path=path, economy=econ, fame=fame)
+    svc.ensure_schema()
+    return svc, econ, fame
+
+
+def test_purchase_and_list():
+    svc, econ, fame = setup_service()
+    econ.deposit(1, 100000)
+    pid = svc.buy_property(1, "Studio", "studio", "NYC", 50000, 1000)
+    props = svc.list_properties(1)
+    assert len(props) == 1 and props[0]["id"] == pid
+    assert econ.get_balance(1) == 50000
+
+
+def test_upgrade_calls_fame():
+    svc, econ, fame = setup_service()
+    econ.deposit(1, 200000)
+    pid = svc.buy_property(1, "Studio", "studio", "NYC", 50000, 1000)
+    prop = svc.upgrade_property(pid, 1)
+    assert prop["level"] == 2
+    assert fame.calls
+
+
+def test_sell_property():
+    svc, econ, fame = setup_service()
+    econ.deposit(1, 100000)
+    pid = svc.buy_property(1, "Studio", "studio", "NYC", 50000, 1000)
+    sale = svc.sell_property(pid, 1)
+    assert sale == int(50000 * 0.8)
+    assert svc.list_properties(1) == []
+    assert econ.get_balance(1) == 100000 - 50000 + int(50000 * 0.8)


### PR DESCRIPTION
## Summary
- add dataclasses for property types, upgrades and ownership
- implement PropertyService for buying, upgrading, renting and selling properties with fame and economy integration
- expose property CRUD REST endpoints
- add tests covering purchase, upgrade and sale flows

## Testing
- `pytest backend/tests/property/test_property_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aedb53473483258c233594d7566f1e