### PR TITLE
Add basic social features with realtime notifications

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,7 @@
 # backend/main.py
 
 from fastapi import FastAPI
-from routes import event_routes, lifestyle_routes, sponsorship  # ← added sponsorship import
+from routes import event_routes, lifestyle_routes, sponsorship, social_routes  # ← added social_routes import
 from database import init_db
 
 app = FastAPI(title="RockMundo API with Events, Lifestyle, and Sponsorships")
@@ -16,6 +16,7 @@ app.include_router(lifestyle_routes.router, prefix="/api", tags=["Lifestyle"])
 
 # New sponsorship router
 app.include_router(sponsorship.router, prefix="/api/sponsorships", tags=["Sponsorships"])
+app.include_router(social_routes.router, prefix="/api/social", tags=["Social"])
 
 @app.get("/")
 def root():

--- a/backend/models/social.py
+++ b/backend/models/social.py
@@ -1,0 +1,62 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Text, DateTime, func
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+class Friendship(Base):
+    __tablename__ = "friendships"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, index=True)
+    friend_id = Column(Integer, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class FriendRequest(Base):
+    __tablename__ = "friend_requests"
+
+    id = Column(Integer, primary_key=True, index=True)
+    from_user_id = Column(Integer, index=True)
+    to_user_id = Column(Integer, index=True)
+    status = Column(String, default="pending")  # 'pending','accepted','rejected'
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class Group(Base):
+    __tablename__ = "groups"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+    owner_id = Column(Integer, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class GroupMembership(Base):
+    __tablename__ = "group_memberships"
+
+    id = Column(Integer, primary_key=True, index=True)
+    group_id = Column(Integer, ForeignKey("groups.id"))
+    user_id = Column(Integer, index=True)
+    role = Column(String, default="member")  # 'owner','member'
+    joined_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class ForumThread(Base):
+    __tablename__ = "forum_threads"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String)
+    creator_id = Column(Integer, index=True)
+    group_id = Column(Integer, ForeignKey("groups.id"), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class ForumPost(Base):
+    __tablename__ = "forum_posts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    thread_id = Column(Integer, ForeignKey("forum_threads.id"))
+    author_id = Column(Integer, index=True)
+    content = Column(Text)
+    parent_post_id = Column(Integer, ForeignKey("forum_posts.id"), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/realtime/publish.py
+++ b/backend/realtime/publish.py
@@ -35,3 +35,16 @@ async def publish_admin_job_status(event: Dict[str, Any]) -> int:
     """
     payload: Dict[str, Any] = {"type": "admin_job", **event}
     return await hub.publish(ADMIN_JOBS_TOPIC, payload)
+
+async def publish_friend_request(target_user_id: int, from_user_id: int) -> int:
+    """Notify a user of a new friend request."""
+    payload: Dict[str, Any] = {"type": "friend_request", "from_user_id": int(from_user_id)}
+    topic = topic_for_user(int(target_user_id))
+    return await hub.publish(topic, payload)
+
+
+async def publish_forum_reply(target_user_id: int, thread_id: int, post_id: int) -> int:
+    """Notify a user that someone replied to their forum post."""
+    payload: Dict[str, Any] = {"type": "forum_reply", "thread_id": int(thread_id), "post_id": int(post_id)}
+    topic = topic_for_user(int(target_user_id))
+    return await hub.publish(topic, payload)

--- a/backend/routes/social_routes.py
+++ b/backend/routes/social_routes.py
@@ -1,0 +1,112 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from auth.dependencies import get_current_user_id
+from backend.services.social_service import social_service
+
+router = APIRouter(prefix="/social", tags=["social"])
+
+
+# ----- Friend endpoints -----
+class FriendRequestIn(BaseModel):
+    to_user_id: int
+
+
+@router.post("/friends/request")
+async def send_friend_request(data: FriendRequestIn, user_id: int = Depends(get_current_user_id)):
+    req = await social_service.send_friend_request(user_id, data.to_user_id)
+    return req
+
+
+@router.post("/friends/{request_id}/accept")
+async def accept_friend_request(request_id: int, user_id: int = Depends(get_current_user_id)):
+    try:
+        await social_service.accept_friend_request(request_id, user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid friend request")
+    return {"status": "accepted"}
+
+
+@router.post("/friends/{request_id}/reject")
+async def reject_friend_request(request_id: int, user_id: int = Depends(get_current_user_id)):
+    try:
+        await social_service.reject_friend_request(request_id, user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid friend request")
+    return {"status": "rejected"}
+
+
+@router.get("/friends")
+async def list_friends(user_id: int = Depends(get_current_user_id)):
+    return social_service.list_friends(user_id)
+
+
+# ----- Group endpoints -----
+class GroupCreateIn(BaseModel):
+    name: str
+
+
+@router.post("/groups")
+async def create_group(data: GroupCreateIn, user_id: int = Depends(get_current_user_id)):
+    grp = social_service.create_group(user_id, data.name)
+    return grp
+
+
+@router.post("/groups/{group_id}/join")
+async def join_group(group_id: int, user_id: int = Depends(get_current_user_id)):
+    try:
+        social_service.join_group(group_id, user_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Group not found")
+    return {"status": "joined"}
+
+
+@router.post("/groups/{group_id}/leave")
+async def leave_group(group_id: int, user_id: int = Depends(get_current_user_id)):
+    try:
+        social_service.leave_group(group_id, user_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"status": "left"}
+
+
+@router.get("/groups/{group_id}/members")
+async def list_group_members(group_id: int, user_id: int = Depends(get_current_user_id)):
+    # ensure group exists
+    if group_id not in social_service._groups:
+        raise HTTPException(status_code=404, detail="Group not found")
+    return social_service.list_group_members(group_id)
+
+
+# ----- Forum endpoints -----
+class ThreadCreateIn(BaseModel):
+    title: str
+    group_id: int | None = None
+
+
+@router.post("/threads")
+async def create_thread(data: ThreadCreateIn, user_id: int = Depends(get_current_user_id)):
+    thread = social_service.create_thread(user_id, data.title, data.group_id)
+    return thread
+
+
+class PostCreateIn(BaseModel):
+    content: str
+    parent_post_id: int | None = None
+
+
+@router.post("/threads/{thread_id}/posts")
+async def add_post(thread_id: int, data: PostCreateIn, user_id: int = Depends(get_current_user_id)):
+    try:
+        post = await social_service.add_post(thread_id, user_id, data.content, data.parent_post_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return post
+
+
+@router.get("/threads/{thread_id}")
+async def get_thread(thread_id: int, user_id: int = Depends(get_current_user_id)):
+    if thread_id not in social_service._threads:
+        raise HTTPException(status_code=404, detail="Thread not found")
+    posts = social_service.get_thread_posts(thread_id)
+    return {"thread": social_service._threads[thread_id], "posts": posts}

--- a/backend/services/social_service.py
+++ b/backend/services/social_service.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set, Tuple
+
+from backend.realtime.publish import publish_friend_request, publish_forum_reply
+
+
+@dataclass
+class FriendRequest:
+    id: int
+    from_user_id: int
+    to_user_id: int
+    status: str = "pending"
+
+
+@dataclass
+class Group:
+    id: int
+    name: str
+    owner_id: int
+
+
+@dataclass
+class ForumThread:
+    id: int
+    title: str
+    creator_id: int
+    group_id: Optional[int]
+
+
+@dataclass
+class ForumPost:
+    id: int
+    thread_id: int
+    author_id: int
+    content: str
+    parent_post_id: Optional[int]
+
+
+class SocialService:
+    """In-memory social features for friend requests, groups and forums."""
+
+    def __init__(self) -> None:
+        self._friend_requests: Dict[int, FriendRequest] = {}
+        self._friendships: Set[Tuple[int, int]] = set()
+        self._groups: Dict[int, Group] = {}
+        self._group_members: Dict[int, Set[int]] = {}
+        self._threads: Dict[int, ForumThread] = {}
+        self._posts: Dict[int, ForumPost] = {}
+        self._ids = {"friend_request": 1, "group": 1, "thread": 1, "post": 1}
+
+    # ---- Friend requests ----
+    async def send_friend_request(self, from_user_id: int, to_user_id: int) -> FriendRequest:
+        rid = self._ids["friend_request"]
+        self._ids["friend_request"] += 1
+        req = FriendRequest(rid, from_user_id, to_user_id)
+        self._friend_requests[rid] = req
+        await publish_friend_request(to_user_id, from_user_id)
+        return req
+
+    def list_friends(self, user_id: int) -> List[int]:
+        friends: List[int] = []
+        for a, b in self._friendships:
+            if a == user_id:
+                friends.append(b)
+            elif b == user_id:
+                friends.append(a)
+        return friends
+
+    async def accept_friend_request(self, request_id: int, user_id: int) -> None:
+        req = self._friend_requests.get(request_id)
+        if not req or req.to_user_id != user_id or req.status != "pending":
+            raise ValueError("Invalid friend request")
+        req.status = "accepted"
+        self._friendships.add(tuple(sorted((req.from_user_id, req.to_user_id))))
+
+    async def reject_friend_request(self, request_id: int, user_id: int) -> None:
+        req = self._friend_requests.get(request_id)
+        if not req or req.to_user_id != user_id or req.status != "pending":
+            raise ValueError("Invalid friend request")
+        req.status = "rejected"
+
+    # ---- Groups ----
+    def create_group(self, owner_id: int, name: str) -> Group:
+        gid = self._ids["group"]
+        self._ids["group"] += 1
+        grp = Group(gid, name, owner_id)
+        self._groups[gid] = grp
+        self._group_members[gid] = {owner_id}
+        return grp
+
+    def join_group(self, group_id: int, user_id: int) -> None:
+        if group_id not in self._groups:
+            raise ValueError("Group not found")
+        self._group_members.setdefault(group_id, set()).add(user_id)
+
+    def leave_group(self, group_id: int, user_id: int) -> None:
+        members = self._group_members.get(group_id)
+        if not members or user_id not in members:
+            raise ValueError("Not a member")
+        if self._groups[group_id].owner_id == user_id:
+            raise ValueError("Owner cannot leave group")
+        members.remove(user_id)
+
+    def list_group_members(self, group_id: int) -> List[int]:
+        return sorted(self._group_members.get(group_id, set()))
+
+    # ---- Forum threads ----
+    def create_thread(self, creator_id: int, title: str, group_id: Optional[int] = None) -> ForumThread:
+        tid = self._ids["thread"]
+        self._ids["thread"] += 1
+        thread = ForumThread(tid, title, creator_id, group_id)
+        self._threads[tid] = thread
+        return thread
+
+    async def add_post(
+        self,
+        thread_id: int,
+        author_id: int,
+        content: str,
+        parent_post_id: Optional[int] = None,
+    ) -> ForumPost:
+        if thread_id not in self._threads:
+            raise ValueError("Thread not found")
+        pid = self._ids["post"]
+        self._ids["post"] += 1
+        post = ForumPost(pid, thread_id, author_id, content, parent_post_id)
+        self._posts[pid] = post
+        if parent_post_id:
+            parent = self._posts.get(parent_post_id)
+            if parent:
+                await publish_forum_reply(parent.author_id, thread_id, pid)
+        return post
+
+    def get_thread_posts(self, thread_id: int) -> List[ForumPost]:
+        return [p for p in self._posts.values() if p.thread_id == thread_id]
+
+
+social_service = SocialService()


### PR DESCRIPTION
## Summary
- define social models for friendships, group memberships, and forum threads
- add in-memory social service with friend requests, groups, and forum posts
- expose social API routes and wire up realtime friend and forum notifications

## Testing
- `python -m py_compile backend/models/social.py backend/services/social_service.py backend/routes/social_routes.py backend/realtime/publish.py`
- `pytest backend/tests/test_health.py backend/tests/test_realtime_ws.py` *(fails: ModuleNotFoundError: No module named 'fastapi'; pip install fastapi failed: Cannot connect to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aedca4715c8325adad7926cfa34040