### PR TITLE
Add payment system with models, service, routes and tests

### DIFF
--- a/backend/models/payment.py
+++ b/backend/models/payment.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
+
+
+@dataclass
+class PurchaseRecord:
+    """Record representing a real-money purchase."""
+
+    id: str
+    user_id: int
+    amount_cents: int
+    currency: str
+    status: str  # pending, completed, failed
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class SubscriptionPlan:
+    """Represents a subscription plan offering premium features."""
+
+    id: str
+    name: str
+    price_cents: int
+    currency: str
+    interval: str  # e.g. 'monthly', 'yearly'
+    benefits: List[str] = field(default_factory=list)
+
+
+@dataclass
+class PremiumCurrency:
+    """Describes a premium currency purchasable with real money."""
+
+    code: str
+    name: str
+    exchange_rate: int  # number of premium units per 100 cents (1 USD)

--- a/backend/routes/payment_routes.py
+++ b/backend/routes/payment_routes.py
@@ -1,0 +1,78 @@
+"""FastAPI routes for payment operations."""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.models.payment import SubscriptionPlan
+from backend.services.economy_service import EconomyService
+from backend.services.payment_service import (
+    PaymentError,
+    PaymentGateway,
+    PaymentService,
+)
+
+router = APIRouter(prefix="/payment", tags=["Payment"])
+
+
+class MockGateway(PaymentGateway):
+    """Simple in-process gateway used for tests and local development."""
+
+    def __init__(self, succeed: bool = True):
+        self.succeed = succeed
+        self.counter = 0
+
+    def create_payment(self, amount_cents: int, currency: str) -> str:
+        self.counter += 1
+        return f"pay_{self.counter}"
+
+    def verify_payment(self, payment_id: str) -> bool:
+        return self.succeed
+
+
+# instantiate services
+_economy = EconomyService()
+_economy.ensure_schema()
+_gateway = MockGateway()
+svc = PaymentService(_gateway, _economy)
+
+
+class PurchaseIn(BaseModel):
+    user_id: int
+    amount_cents: int
+
+
+class CallbackIn(BaseModel):
+    payment_id: str
+
+
+class SubscriptionIn(BaseModel):
+    user_id: int
+    plan_id: str
+
+
+@router.post("/purchase")
+def initiate_purchase(payload: PurchaseIn):
+    payment_id = svc.initiate_purchase(payload.user_id, payload.amount_cents)
+    return {"payment_id": payment_id}
+
+
+@router.post("/callback")
+def verify_callback(payload: CallbackIn):
+    try:
+        record = svc.verify_callback(payload.payment_id)
+        return {"status": record.status}
+    except PaymentError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/subscribe")
+def subscribe(payload: SubscriptionIn):
+    plan = SubscriptionPlan(id=payload.plan_id, name=payload.plan_id, price_cents=0, currency="USD", interval="monthly")
+    svc.create_subscription(payload.user_id, plan)
+    return {"status": "subscribed"}
+
+
+@router.post("/unsubscribe")
+def unsubscribe(payload: SubscriptionIn):
+    svc.cancel_subscription(payload.user_id)
+    return {"status": "unsubscribed"}

--- a/backend/services/economy_service.py
+++ b/backend/services/economy_service.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
+from backend.models.payment import PremiumCurrency
+
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 
 
@@ -197,6 +199,13 @@ class EconomyService:
             )
             conn.commit()
             return tid
+
+    def credit_purchase(self, user_id: int, amount_cents: int, currency: PremiumCurrency) -> int:
+        """Convert real money into premium currency and deposit it."""
+        coins = (amount_cents // 100) * currency.exchange_rate
+        if coins <= 0:
+            raise EconomyError('Purchase amount too low')
+        return self.deposit(user_id, coins, currency=currency.code)
 
     # ---------------- queries ----------------
     def list_transactions(self, user_id: int, limit: int = 50) -> List[TransactionRecord]:

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -1,0 +1,72 @@
+"""Service for handling purchases and subscriptions via a payment gateway."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from backend.models.payment import PremiumCurrency, PurchaseRecord, SubscriptionPlan
+
+from .economy_service import EconomyService
+
+
+class PaymentError(Exception):
+    """Raised when a payment operation fails."""
+
+
+@dataclass
+class PaymentGateway:
+    """Minimal gateway interface used for testing.
+
+    Real implementations would integrate with providers like Stripe or PayPal.
+    """
+
+    def create_payment(self, amount_cents: int, currency: str) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def verify_payment(self, payment_id: str) -> bool:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class PaymentService:
+    def __init__(self, gateway: PaymentGateway, economy_service: EconomyService,
+                 premium_currency: Optional[PremiumCurrency] = None):
+        self.gateway = gateway
+        self.economy_service = economy_service
+        self.premium_currency = premium_currency or PremiumCurrency(
+            code="COIN", name="Coins", exchange_rate=100
+        )
+        self.purchases: Dict[str, PurchaseRecord] = {}
+        self.subscriptions: Dict[int, str] = {}  # user_id -> plan_id
+
+    # -------- purchases --------
+    def initiate_purchase(self, user_id: int, amount_cents: int, currency: str = "USD") -> str:
+        payment_id = self.gateway.create_payment(amount_cents, currency)
+        self.purchases[payment_id] = PurchaseRecord(
+            id=payment_id,
+            user_id=user_id,
+            amount_cents=amount_cents,
+            currency=currency,
+            status="pending",
+        )
+        return payment_id
+
+    def verify_callback(self, payment_id: str) -> PurchaseRecord:
+        record = self.purchases.get(payment_id)
+        if not record:
+            raise PaymentError("Unknown payment")
+        if not self.gateway.verify_payment(payment_id):
+            record.status = "failed"
+            raise PaymentError("Verification failed")
+        record.status = "completed"
+        # credit premium currency
+        self.economy_service.credit_purchase(record.user_id, record.amount_cents,
+                                             self.premium_currency)
+        return record
+
+    # -------- subscriptions --------
+    def create_subscription(self, user_id: int, plan: SubscriptionPlan) -> None:
+        self.subscriptions[user_id] = plan.id
+
+    def cancel_subscription(self, user_id: int) -> None:
+        self.subscriptions.pop(user_id, None)

--- a/backend/tests/payment/test_payment_service.py
+++ b/backend/tests/payment/test_payment_service.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.services.economy_service import EconomyService
+from backend.services.payment_service import PaymentError, PaymentGateway, PaymentService
+
+
+class DummyGateway(PaymentGateway):
+    def __init__(self, succeed: bool = True):
+        self.succeed = succeed
+        self.counter = 0
+
+    def create_payment(self, amount_cents: int, currency: str) -> str:
+        self.counter += 1
+        return f"pay_{self.counter}"
+
+    def verify_payment(self, payment_id: str) -> bool:
+        return self.succeed
+
+
+def setup_service(success: bool):
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    econ = EconomyService(db_path=path)
+    econ.ensure_schema()
+    gateway = DummyGateway(succeed=success)
+    svc = PaymentService(gateway, econ)
+    return svc
+
+
+def test_purchase_success():
+    svc = setup_service(True)
+    pid = svc.initiate_purchase(user_id=1, amount_cents=500)
+    svc.verify_callback(pid)
+    assert svc.economy_service.get_balance(1) == 500
+
+
+def test_purchase_failure():
+    svc = setup_service(False)
+    pid = svc.initiate_purchase(user_id=1, amount_cents=500)
+    with pytest.raises(PaymentError):
+        svc.verify_callback(pid)
+    assert svc.economy_service.get_balance(1) == 0


### PR DESCRIPTION
## Summary
- Add dataclass models for purchase records, subscription plans, and premium currency
- Implement PaymentService integrating a gateway and EconomyService to credit purchases
- Expose FastAPI payment routes and update EconomyService for real-money conversion
- Cover purchase success and failure flows with tests

## Testing
- `ruff check backend/models/payment.py backend/services/payment_service.py backend/services/economy_service.py backend/routes/payment_routes.py backend/tests/payment/test_payment_service.py`
- `pytest backend/tests/payment/test_payment_service.py backend/tests/economy/test_economy_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee177a6748325ab16b5a5afa29ace