### PR TITLE
Handle Discord notification errors gracefully

### DIFF
--- a/.github/workflows/discord-on-push.yml
+++ b/.github/workflows/discord-on-push.yml
@@ -20,6 +20,7 @@ jobs:
           printf '%s' "{\"content\":\"${MSG}\"}" > payload.json
 
       - name: Post to Discord
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |

--- a/backend/services/notifications_service.py
+++ b/backend/services/notifications_service.py
@@ -35,8 +35,8 @@ class NotificationsService:
             try:
                 content = f"{title}\n{body}".strip()
                 send_message(content)
-            except DiscordServiceError:
-                pass
+            except DiscordServiceError as exc:
+                print(f"Discord notification failed: {exc}")
 
         return notif_id
 


### PR DESCRIPTION
## Summary
- log Discord failures when sending notifications
- avoid failing workflow if Discord webhook post fails

## Testing
- `ruff check backend/services/notifications_service.py`
- `mypy backend/services/notifications_service.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68aee2c70f4c8325babb2b848af960ef