### PR TITLE
Expand test coverage and CI reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest
+          pip install pytest pytest-cov
 
       - name: Run tests
         run: |
-          pytest -q
+          pytest --cov=backend --cov-report=term-missing -q

--- a/README.MD
+++ b/README.MD
@@ -113,6 +113,15 @@ This document outlines the current state of implemented features, the roadmap fo
 5. Run the server: `uvicorn main:app --reload`
 6. Access the API docs at `http://localhost:8000/docs`
 
+## Testing
+Run the test suite from the project root:
+
+```bash
+pytest
+```
+
+The tests will automatically create a temporary SQLite database and seed sample data. Coverage information is printed after the run.
+
 ---
 
 ## Contributing

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,68 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.db import get_conn
+from auth.service import AuthService
+from routes import payment_routes
+from services.economy_service import EconomyService
+from services.payment_service import PaymentService
+
+@pytest.fixture(scope="session")
+def db_path(tmp_path_factory, monkeypatch):
+    db_file = tmp_path_factory.mktemp("db") / "test.db"
+    os.environ["ROCKMUNDO_DB_PATH"] = str(db_file)
+    import utils.db as db_module
+    db_module.DEFAULT_DB = str(db_file)
+    with get_conn(str(db_file)) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              email TEXT NOT NULL UNIQUE,
+              password_hash TEXT NOT NULL,
+              display_name TEXT,
+              is_active INTEGER NOT NULL DEFAULT 1,
+              created_at TEXT DEFAULT (datetime('now')),
+              updated_at TEXT DEFAULT (datetime('now'))
+            );
+            CREATE TABLE IF NOT EXISTS roles (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE, description TEXT);
+            CREATE TABLE IF NOT EXISTS user_roles (user_id INTEGER NOT NULL, role_id INTEGER NOT NULL, PRIMARY KEY (user_id, role_id));
+            CREATE TABLE IF NOT EXISTS refresh_tokens (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              user_id INTEGER NOT NULL,
+              token_hash TEXT NOT NULL,
+              issued_at TEXT DEFAULT (datetime('now')),
+              expires_at TEXT NOT NULL,
+              revoked_at TEXT,
+              user_agent TEXT,
+              ip TEXT
+            );
+            CREATE TABLE IF NOT EXISTS audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, action TEXT NOT NULL, meta JSON, created_at TEXT DEFAULT (datetime('now')));
+            INSERT OR IGNORE INTO roles (id, name) VALUES (1,'admin'),(2,'moderator'),(3,'band_member'),(4,'user');
+            """
+        )
+    # patch services to use this db
+    from auth import routes as auth_routes
+    auth_routes.svc = AuthService(str(db_file))
+    economy = EconomyService(str(db_file))
+    economy.ensure_schema()
+    payment_routes._economy = economy
+    payment_routes.svc = PaymentService(payment_routes._gateway, economy)
+    return str(db_file)
+
+@pytest.fixture
+def client(db_path):
+    from fastapi import FastAPI
+    from auth.routes import router as auth_router
+    from routes import event_routes, payment_routes
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    app.include_router(auth_router)
+    app.include_router(event_routes.router)
+    app.include_router(payment_routes.router)
+    return TestClient(app)

--- a/backend/tests/integration/test_user_flows.py
+++ b/backend/tests/integration/test_user_flows.py
@@ -1,0 +1,25 @@
+from services import event_service
+
+
+def test_registration_event_transaction_flow(client, db_path, monkeypatch):
+    # register user
+    r = client.post("/auth/register", json={"email": "user@example.com", "password": "Secretpass1", "display_name": "User"})
+    assert r.status_code == 200
+    uid = r.json()["id"]
+
+    # trigger event with deterministic outcome
+    monkeypatch.setattr(event_service.random, "random", lambda: 0.0)
+    r = client.post("/events/daily-roll", params={"user_id": uid})
+    assert r.status_code == 200
+    assert r.json()["event"]["event"] == "vocal fatigue"
+
+    # transaction flow
+    r = client.post("/payment/purchase", json={"user_id": uid, "amount_cents": 500})
+    pid = r.json()["payment_id"]
+    r = client.post("/payment/callback", json={"payment_id": pid})
+    assert r.status_code == 200
+    assert r.json()["status"] == "completed"
+
+    from services.economy_service import EconomyService
+    econ = EconomyService(db_path)
+    assert econ.get_balance(uid) > 0

--- a/backend/tests/models/test_payment_models.py
+++ b/backend/tests/models/test_payment_models.py
@@ -1,0 +1,6 @@
+from models.payment import SubscriptionPlan
+
+
+def test_subscription_plan_defaults():
+    plan = SubscriptionPlan(id="basic", name="Basic", price_cents=100, currency="USD", interval="monthly")
+    assert plan.benefits == []

--- a/backend/tests/routes/test_payment_routes.py
+++ b/backend/tests/routes/test_payment_routes.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from routes import payment_routes
+from services.economy_service import EconomyService
+from services.payment_service import PaymentService
+
+
+def create_app(tmp_path):
+    db = tmp_path / "test.db"
+    economy = EconomyService(str(db))
+    economy.ensure_schema()
+    payment_routes._economy = economy
+    payment_routes.svc = PaymentService(payment_routes._gateway, economy)
+    app = FastAPI()
+    app.include_router(payment_routes.router)
+    return app, economy
+
+
+def test_purchase_and_callback(tmp_path):
+    app, economy = create_app(tmp_path)
+    client = TestClient(app)
+    r = client.post("/payment/purchase", json={"user_id": 1, "amount_cents": 500})
+    assert r.status_code == 200
+    pid = r.json()["payment_id"]
+    r = client.post("/payment/callback", json={"payment_id": pid})
+    assert r.status_code == 200
+    assert r.json()["status"] == "completed"
+    assert economy.get_balance(1) > 0

--- a/backend/tests/services/test_event_service.py
+++ b/backend/tests/services/test_event_service.py
@@ -1,0 +1,13 @@
+from services import event_service
+
+def test_roll_for_daily_event_trigger(monkeypatch):
+    monkeypatch.setattr(event_service.random, "random", lambda: 0.0)
+    event = event_service.roll_for_daily_event(1, {"drinking": "high"}, ["vocals"])
+    assert event is not None
+    assert event["event"] == "vocal fatigue"
+
+
+def test_roll_for_daily_event_none(monkeypatch):
+    monkeypatch.setattr(event_service.random, "random", lambda: 1.0)
+    event = event_service.roll_for_daily_event(1, {"drinking": "low"}, [])
+    assert event is None


### PR DESCRIPTION
## Summary
- add unit and integration tests for events, payments and user flows
- configure pytest fixtures with temp database seeding
- enable coverage reporting in CI and document how to run tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi pytest pytest-cov pydantic uvicorn` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68aee4eaa9d08325aa86ae4caabd80fb