### PR TITLE
Enable runtime PO translation parsing and ignore compiled catalogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore node dependencies
+frontend/node_modules/
+
+# Ignore compiled message catalogs
+backend/locales/**/LC_MESSAGES/*.mo
+
+# Python caches
+__pycache__/
+*.pyc
+

--- a/backend/locales/en/LC_MESSAGES/messages.po
+++ b/backend/locales/en/LC_MESSAGES/messages.po
@@ -1,0 +1,69 @@
+msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "Welcome to RockMundo API"
+msgstr "Welcome to RockMundo API"
+
+msgid "Invalid credentials"
+msgstr "Invalid credentials"
+
+msgid "Invalid friend request"
+msgstr "Invalid friend request"
+
+msgid "Group not found"
+msgstr "Group not found"
+
+msgid "Thread not found"
+msgstr "Thread not found"
+
+msgid "Band name already exists"
+msgstr "Band name already exists"
+
+msgid "Band not found"
+msgstr "Band not found"
+
+msgid "Already a band member"
+msgstr "Already a band member"
+
+msgid "Member invited"
+msgstr "Member invited"
+
+msgid "A band cannot collaborate with itself"
+msgstr "A band cannot collaborate with itself"
+
+msgid "Skin not found"
+msgstr "Skin not found"
+
+msgid "Skin not owned"
+msgstr "Skin not owned"
+
+msgid "Skin equipped"
+msgstr "Skin equipped"
+
+msgid "Band not eligible for acoustic performance (min fame: 300, skill: 70)."
+msgstr "Band not eligible for acoustic performance (min fame: 300, skill: 70)."
+
+msgid "Venue not found"
+msgstr "Venue not found"
+
+msgid "No earnings recorded for this song"
+msgstr "No earnings recorded for this song"
+
+msgid "Must provide band_id or collaboration_id"
+msgstr "Must provide band_id or collaboration_id"
+
+msgid "Song not found"
+msgstr "Song not found"
+
+msgid "EPs can have a maximum of 4 songs"
+msgstr "EPs can have a maximum of 4 songs"
+
+msgid "Daily job not available"
+msgstr "Daily job not available"
+
+msgid "Weekly job not available"
+msgstr "Weekly job not available"
+
+msgid "No sponsorship set for this venue"
+msgstr "No sponsorship set for this venue"

--- a/backend/locales/es/LC_MESSAGES/messages.po
+++ b/backend/locales/es/LC_MESSAGES/messages.po
@@ -1,0 +1,69 @@
+msgid ""
+msgstr ""
+"Language: es\n"
+
+msgid "Welcome to RockMundo API"
+msgstr "Bienvenido a RockMundo API"
+
+msgid "Invalid credentials"
+msgstr "Credenciales inválidas"
+
+msgid "Invalid friend request"
+msgstr "Solicitud de amistad inválida"
+
+msgid "Group not found"
+msgstr "Grupo no encontrado"
+
+msgid "Thread not found"
+msgstr "Hilo no encontrado"
+
+msgid "Band name already exists"
+msgstr "El nombre de la banda ya existe"
+
+msgid "Band not found"
+msgstr "Banda no encontrada"
+
+msgid "Already a band member"
+msgstr "Ya es miembro de la banda"
+
+msgid "Member invited"
+msgstr "Miembro invitado"
+
+msgid "A band cannot collaborate with itself"
+msgstr "Una banda no puede colaborar consigo misma"
+
+msgid "Skin not found"
+msgstr "Skin no encontrado"
+
+msgid "Skin not owned"
+msgstr "Skin no adquirido"
+
+msgid "Skin equipped"
+msgstr "Skin equipado"
+
+msgid "Band not eligible for acoustic performance (min fame: 300, skill: 70)."
+msgstr "La banda no es apta para una actuación acústica (fama mínima: 300, habilidad: 70)."
+
+msgid "Venue not found"
+msgstr "Lugar no encontrado"
+
+msgid "No earnings recorded for this song"
+msgstr "No hay ganancias registradas para esta canción"
+
+msgid "Must provide band_id or collaboration_id"
+msgstr "Debe proporcionar band_id o collaboration_id"
+
+msgid "Song not found"
+msgstr "Canción no encontrada"
+
+msgid "EPs can have a maximum of 4 songs"
+msgstr "Los EPs pueden tener un máximo de 4 canciones"
+
+msgid "Daily job not available"
+msgstr "Trabajo diario no disponible"
+
+msgid "Weekly job not available"
+msgstr "Trabajo semanal no disponible"
+
+msgid "No sponsorship set for this venue"
+msgstr "No hay patrocinio establecido para este lugar"

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,8 +3,11 @@
 from fastapi import FastAPI
 from routes import event_routes, lifestyle_routes, sponsorship, social_routes  # ← added social_routes import
 from database import init_db
+from middleware.locale import LocaleMiddleware
+from utils.i18n import _
 
 app = FastAPI(title="RockMundo API with Events, Lifestyle, and Sponsorships")
+app.add_middleware(LocaleMiddleware)
 
 @app.on_event("startup")
 def startup():
@@ -20,4 +23,4 @@ app.include_router(social_routes.router, prefix="/api/social", tags=["Social"])
 
 @app.get("/")
 def root():
-    return {"message": "Welcome to RockMundo API"}
+    return {"message": _("Welcome to RockMundo API")}

--- a/backend/middleware/locale.py
+++ b/backend/middleware/locale.py
@@ -1,0 +1,14 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from utils.i18n import set_locale, DEFAULT_LOCALE
+
+
+class LocaleMiddleware(BaseHTTPMiddleware):
+    """Middleware that sets the locale for each request."""
+
+    async def dispatch(self, request, call_next):
+        lang = request.headers.get("Accept-Language", DEFAULT_LOCALE)
+        # take first language code before comma if multiple provided
+        lang = lang.split(",")[0]
+        set_locale(lang)
+        response = await call_next(request)
+        return response

--- a/backend/routes/admin_job_routes.py
+++ b/backend/routes/admin_job_routes.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import Depends
 from auth.dependencies import get_current_user_id, require_role
+from utils.i18n import _
 
 try:
     from jobs.world_pulse_jobs import run_daily_world_pulse, run_weekly_rollup
@@ -22,13 +23,13 @@ router = APIRouter(prefix="/admin/jobs", tags=["AdminJobs"])
 @router.post("/world-pulse/daily", dependencies=[Depends(require_role(["admin"]))])
 async def trigger_world_pulse_daily():
     if run_daily_world_pulse is None:
-        raise HTTPException(status_code=501, detail="Daily job not available")
+        raise HTTPException(status_code=501, detail=_("Daily job not available"))
     await run_daily_world_pulse()
     return {"status": "ok", "job": "world_pulse_daily"}
 
 @router.post("/world-pulse/weekly", dependencies=[Depends(require_role(["admin"]))])
 async def trigger_world_pulse_weekly():
     if run_weekly_rollup is None:
-        raise HTTPException(status_code=501, detail="Weekly job not available")
+        raise HTTPException(status_code=501, detail=_("Weekly job not available"))
     await run_weekly_rollup()
     return {"status": "ok", "job": "world_pulse_weekly"}

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 from utils.auth_utils import create_access_token, verify_user_credentials
+from utils.i18n import _
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -14,6 +15,6 @@ class TokenResponse(BaseModel):
 async def login(form_data: OAuth2PasswordRequestForm = Depends()):
     user = verify_user_credentials(form_data.username, form_data.password)
     if not user:
-        raise HTTPException(status_code=401, detail="Invalid credentials")
+        raise HTTPException(status_code=401, detail=_("Invalid credentials"))
     token = create_access_token(user["username"], user["role"])
     return TokenResponse(access_token=token)

--- a/backend/routes/band.py
+++ b/backend/routes/band.py
@@ -8,6 +8,7 @@ from schemas.band import (
     BandCollaborationCreate, BandCollaborationResponse
 )
 from database import get_db
+from utils.i18n import _
 
 router = APIRouter(prefix="/bands", tags=["Bands"])
 
@@ -15,7 +16,7 @@ router = APIRouter(prefix="/bands", tags=["Bands"])
 def create_band(band: BandCreate, db: Session = Depends(get_db)):
     existing = db.query(Band).filter_by(name=band.name).first()
     if existing:
-        raise HTTPException(status_code=400, detail="Band name already exists")
+        raise HTTPException(status_code=400, detail=_("Band name already exists"))
     new_band = Band(**band.dict())
     db.add(new_band)
     db.commit()
@@ -36,7 +37,7 @@ def create_band(band: BandCreate, db: Session = Depends(get_db)):
 def get_band(band_id: int, db: Session = Depends(get_db)):
     band = db.query(Band).get(band_id)
     if not band:
-        raise HTTPException(status_code=404, detail="Band not found")
+        raise HTTPException(status_code=404, detail=_("Band not found"))
     return band
 
 @router.post("/invite")
@@ -45,15 +46,15 @@ def invite_member(invite: BandMemberInvite, db: Session = Depends(get_db)):
         character_id=invite.character_id, band_id=invite.band_id
     ).first()
     if exists:
-        raise HTTPException(status_code=400, detail="Already a band member")
+        raise HTTPException(status_code=400, detail=_("Already a band member"))
     db.add(BandMember(**invite.dict()))
     db.commit()
-    return {"message": "Member invited"}
+    return {"message": _("Member invited")}
 
 @router.post("/collaborate", response_model=BandCollaborationResponse)
 def create_collaboration(collab: BandCollaborationCreate, db: Session = Depends(get_db)):
     if collab.band_1_id == collab.band_2_id:
-        raise HTTPException(status_code=400, detail="A band cannot collaborate with itself")
+        raise HTTPException(status_code=400, detail=_("A band cannot collaborate with itself"))
     new_collab = BandCollaboration(**collab.dict())
     db.add(new_collab)
     db.commit()

--- a/backend/routes/distribution.py
+++ b/backend/routes/distribution.py
@@ -5,6 +5,7 @@ from database import get_db
 from models.distribution import SongDistribution
 from models.music import Song
 from schemas.distribution import DistributionUpdate, DistributionResponse
+from utils.i18n import _
 
 router = APIRouter(prefix="/distribution", tags=["Distribution"])
 
@@ -43,7 +44,7 @@ def update_distribution(data: DistributionUpdate, db: Session = Depends(get_db))
 def get_song_earnings(song_id: int, db: Session = Depends(get_db)):
     dist = db.query(SongDistribution).filter_by(song_id=song_id).first()
     if not dist:
-        raise HTTPException(status_code=404, detail="No earnings recorded for this song")
+        raise HTTPException(status_code=404, detail=_("No earnings recorded for this song"))
     return dist
 
 @router.get("/charts")

--- a/backend/routes/gig.py
+++ b/backend/routes/gig.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from models.gig import Gig
 from schemas.gig import GigCreate, GigOut
 from database import get_db
+from utils.i18n import _
 
 # Simulated fame and skill lookup (to be replaced with real logic or DB queries)
 def get_band_fame(band_id: int, db: Session) -> int:
@@ -25,11 +26,11 @@ def book_gig(gig: GigCreate, db: Session = Depends(get_db), user_id: int = Depen
         else:
             fame = get_band_fame(gig.band_id, db)
             skill = get_band_acoustic_skill_score(gig.band_id, db)
-            if fame < 300 or skill < 70:
-                raise HTTPException(
-                    status_code=403,
-                    detail="Band not eligible for acoustic performance (min fame: 300, skill: 70)."
-                )
+              if fame < 300 or skill < 70:
+                  raise HTTPException(
+                      status_code=403,
+                      detail=_("Band not eligible for acoustic performance (min fame: 300, skill: 70).")
+                  )
 
     new_gig = Gig(**gig.dict())
     db.add(new_gig)

--- a/backend/routes/music.py
+++ b/backend/routes/music.py
@@ -9,13 +9,14 @@ from schemas.music import (
     AlbumCreate, AlbumResponse
 )
 from database import get_db
+from utils.i18n import _
 
 router = APIRouter(prefix="/music", tags=["Music"])
 
 @router.post("/songs", response_model=SongResponse, dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
 def create_song(song: SongCreate, db: Session = Depends(get_db, user_id: int = Depends(get_current_user_id))):
     if not (song.band_id or song.collaboration_id):
-        raise HTTPException(status_code=400, detail="Must provide band_id or collaboration_id")
+        raise HTTPException(status_code=400, detail=_("Must provide band_id or collaboration_id"))
     new_song = Song(**song.dict())
     db.add(new_song)
     db.commit()
@@ -26,16 +27,16 @@ def create_song(song: SongCreate, db: Session = Depends(get_db, user_id: int = D
 def get_song(song_id: int, db: Session = Depends(get_db, user_id: int = Depends(get_current_user_id))):
     song = db.query(Song).get(song_id)
     if not song:
-        raise HTTPException(status_code=404, detail="Song not found")
+        raise HTTPException(status_code=404, detail=_("Song not found"))
     return song
 
 @router.post("/albums", response_model=AlbumResponse)
 def create_album(album: AlbumCreate, db: Session = Depends(get_db, user_id: int = Depends(get_current_user_id))):
     if not (album.band_id or album.collaboration_id):
-        raise HTTPException(status_code=400, detail="Must provide band_id or collaboration_id")
+        raise HTTPException(status_code=400, detail=_("Must provide band_id or collaboration_id"))
     
     if album.type == "ep" and len(album.song_ids) > 4:
-        raise HTTPException(status_code=400, detail="EPs can have a maximum of 4 songs")
+        raise HTTPException(status_code=400, detail=_("EPs can have a maximum of 4 songs"))
 
     new_album = Album(
         title=album.title,

--- a/backend/routes/skin.py
+++ b/backend/routes/skin.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session, joinedload
 from models.skin import Skin, SkinInventory
 from schemas.skin import SkinCreate, SkinResponse, SkinEquipRequest, SkinInventoryItem
 from database import get_db
+from utils.i18n import _
 
 router = APIRouter(prefix="/skins", tags=["Skins"])
 
@@ -23,7 +24,7 @@ def list_all_skins(db: Session = Depends(get_db)):
 def approve_skin(skin_id: int, db: Session = Depends(get_db)):
     skin = db.query(Skin).get(skin_id)
     if not skin:
-        raise HTTPException(status_code=404, detail="Skin not found")
+        raise HTTPException(status_code=404, detail=_("Skin not found"))
     skin.is_approved = True
     db.commit()
     db.refresh(skin)
@@ -38,14 +39,14 @@ def equip_skin(req: SkinEquipRequest, db: Session = Depends(get_db)):
     # Check if owned
     inv = db.query(SkinInventory).filter_by(character_id=req.character_id, skin_id=req.skin_id).first()
     if not inv:
-        raise HTTPException(status_code=400, detail="Skin not owned")
+        raise HTTPException(status_code=400, detail=_("Skin not owned"))
 
     # Equip it
     inv.is_equipped = True
     inv.slot = req.slot
     db.commit()
     db.refresh(inv)
-    return {"message": "Skin equipped", "slot": inv.slot}
+    return {"message": _("Skin equipped"), "slot": inv.slot}
 
 @router.get("/inventory/{character_id}", response_model=list[SkinInventoryItem])
 def get_inventory(character_id: int, db: Session = Depends(get_db)):

--- a/backend/routes/social_routes.py
+++ b/backend/routes/social_routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from utils.i18n import _
 
 from auth.dependencies import get_current_user_id
 from backend.services.social_service import social_service
@@ -23,7 +24,7 @@ async def accept_friend_request(request_id: int, user_id: int = Depends(get_curr
     try:
         await social_service.accept_friend_request(request_id, user_id)
     except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid friend request")
+        raise HTTPException(status_code=400, detail=_("Invalid friend request"))
     return {"status": "accepted"}
 
 
@@ -32,7 +33,7 @@ async def reject_friend_request(request_id: int, user_id: int = Depends(get_curr
     try:
         await social_service.reject_friend_request(request_id, user_id)
     except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid friend request")
+        raise HTTPException(status_code=400, detail=_("Invalid friend request"))
     return {"status": "rejected"}
 
 
@@ -57,7 +58,7 @@ async def join_group(group_id: int, user_id: int = Depends(get_current_user_id))
     try:
         social_service.join_group(group_id, user_id)
     except ValueError:
-        raise HTTPException(status_code=404, detail="Group not found")
+        raise HTTPException(status_code=404, detail=_("Group not found"))
     return {"status": "joined"}
 
 
@@ -74,7 +75,7 @@ async def leave_group(group_id: int, user_id: int = Depends(get_current_user_id)
 async def list_group_members(group_id: int, user_id: int = Depends(get_current_user_id)):
     # ensure group exists
     if group_id not in social_service._groups:
-        raise HTTPException(status_code=404, detail="Group not found")
+        raise HTTPException(status_code=404, detail=_("Group not found"))
     return social_service.list_group_members(group_id)
 
 
@@ -107,6 +108,6 @@ async def add_post(thread_id: int, data: PostCreateIn, user_id: int = Depends(ge
 @router.get("/threads/{thread_id}")
 async def get_thread(thread_id: int, user_id: int = Depends(get_current_user_id)):
     if thread_id not in social_service._threads:
-        raise HTTPException(status_code=404, detail="Thread not found")
+        raise HTTPException(status_code=404, detail=_("Thread not found"))
     posts = social_service.get_thread_posts(thread_id)
     return {"thread": social_service._threads[thread_id], "posts": posts}

--- a/backend/routes/sponsorship.py
+++ b/backend/routes/sponsorship.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, Field
 from typing import Optional, List, Dict, Any
 import os
+from utils.i18n import _
 
 # Import style chosen to match many existing projects where routes/ and services/ are siblings
 from services.sponsorship_service import SponsorshipService
@@ -91,7 +92,7 @@ async def get_venue_with_sponsorship(venue_id: int, svc: SponsorshipService = De
     try:
         return await svc.get_venue_with_sponsorship(venue_id)
     except ValueError:
-        raise HTTPException(status_code=404, detail="Venue not found")
+        raise HTTPException(status_code=404, detail=_("Venue not found"))
 
 # ---------- Tracking ----------
 @router.post("/events")

--- a/backend/routes/venue_sponsorships_routes.py
+++ b/backend/routes/venue_sponsorships_routes.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, HttpUrl
 from typing import Optional, List, Dict, Any
 from services.venue_sponsorships_service import VenueSponsorshipsService, VenueSponsorshipError, SponsorshipIn
+from utils.i18n import _
 
 # Auth dependency
 try:
@@ -41,7 +42,7 @@ def upsert_sponsorship(payload: SponsorshipInModel):
 def get_sponsorship(venue_id: int):
     s = svc.get_sponsorship(venue_id)
     if not s:
-        raise HTTPException(status_code=404, detail="No sponsorship set for this venue")
+        raise HTTPException(status_code=404, detail=_("No sponsorship set for this venue"))
     return s
 
 @router.post("/{venue_id}/deactivate", dependencies=[Depends(require_role(["admin", "moderator"]))])

--- a/backend/tests/test_i18n.py
+++ b/backend/tests/test_i18n.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from middleware.locale import LocaleMiddleware
+from utils.i18n import _
+from routes.auth_routes import router as auth_router
+
+
+app = FastAPI()
+app.add_middleware(LocaleMiddleware)
+
+@app.get("/")
+def root():
+    return {"message": _("Welcome to RockMundo API")}
+
+app.include_router(auth_router)
+
+client = TestClient(app)
+
+
+def test_default_locale_fallback():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Welcome to RockMundo API"
+
+
+def test_spanish_locale_selection():
+    resp = client.get("/", headers={"Accept-Language": "es"})
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Bienvenido a RockMundo API"
+
+
+def test_error_translation():
+    resp = client.post(
+        "/auth/login", data={"username": "bad", "password": "bad"}, headers={"Accept-Language": "es"}
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Credenciales inválidas"

--- a/backend/utils/i18n.py
+++ b/backend/utils/i18n.py
@@ -1,0 +1,61 @@
+"""Minimal locale utilities.
+
+This module provides a lightweight translation helper that reads ``.po`` files
+directly.  Compiled ``.mo`` catalogs are intentionally omitted from the
+repository, so translations are parsed at runtime and cached per locale.
+"""
+
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Dict
+
+LOCALES_DIR = Path(__file__).resolve().parent.parent / "locales"
+DEFAULT_LOCALE = "en"
+
+_current_locale: ContextVar[str] = ContextVar("current_locale", default=DEFAULT_LOCALE)
+_translations: Dict[str, Dict[str, str]] = {}
+
+
+def set_locale(locale: str) -> None:
+    """Set the active locale for the current request."""
+
+    _current_locale.set(locale)
+
+
+def _load_translations(locale: str) -> Dict[str, str]:
+    """Load translations from a ``.po`` file for *locale*.
+
+    Only the simple ``msgid``/``msgstr`` pairs are supported which is
+    sufficient for the project's small catalogs.
+    """
+
+    catalog: Dict[str, str] = {}
+    po_path = LOCALES_DIR / locale / "LC_MESSAGES" / "messages.po"
+    with po_path.open("r", encoding="utf-8") as f:  # noqa: PTH123
+        msgid: str | None = None
+        for raw_line in f:
+            line = raw_line.strip()
+            if line.startswith("msgid "):
+                msgid = line[6:].strip().strip("\"")
+            elif line.startswith("msgstr ") and msgid is not None:
+                msgstr = line[7:].strip().strip("\"")
+                if msgid:
+                    catalog[msgid] = msgstr
+                msgid = None
+    return catalog
+
+
+def gettext_(message: str) -> str:
+    """Translate ``message`` for the current locale."""
+
+    locale = _current_locale.get()
+    if locale not in _translations:
+        try:
+            _translations[locale] = _load_translations(locale)
+        except FileNotFoundError:
+            _translations[locale] = _load_translations(DEFAULT_LOCALE)
+    return _translations[locale].get(message, message)
+
+
+_ = gettext_
+


### PR DESCRIPTION
## Summary
- parse locale `.po` files at runtime and cache per request
- ignore generated assets like `node_modules` and compiled `.mo` catalogs

## Testing
- ⚠️ `pytest backend/tests/test_i18n.py -q` (fails: ModuleNotFoundError: No module named 'fastapi')


------
https://chatgpt.com/codex/tasks/task_e_68aee79cc594832593927baa279644a6