### PR TITLE
Add quest system with branching logic and rewards

### DIFF
--- a/backend/models/quest.py
+++ b/backend/models/quest.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from pydantic import BaseModel
+
+
+class QuestReward(BaseModel):
+    """Represents a reward granted for completing a quest stage."""
+
+    type: str
+    amount: int
+
+
+class QuestStage(BaseModel):
+    """A single stage within a quest.
+
+    Each stage can branch into other stages depending on the player's
+    choice and may optionally grant a reward when reached.
+    """
+
+    id: str
+    description: str
+    branches: Dict[str, str] = {}
+    reward: Optional[QuestReward] = None
+
+
+class Quest(BaseModel):
+    """Definition of a quest with multiple stages and branching paths."""
+
+    id: str
+    name: str
+    stages: Dict[str, QuestStage]
+    initial_stage: str
+
+    def get_stage(self, stage_id: str) -> QuestStage:
+        return self.stages[stage_id]

--- a/backend/routes/quest_routes.py
+++ b/backend/routes/quest_routes.py
@@ -1,0 +1,45 @@
+from flask import Blueprint, jsonify, request
+
+from services.quest_service import QuestService
+from seeds.quest_data import get_seed_quests
+
+quest_routes = Blueprint("quest_routes", __name__)
+quest_service = QuestService()
+QUESTS = {quest.id: quest for quest in get_seed_quests()}
+
+
+@quest_routes.route("/quests/start/<quest_id>", methods=["POST"])
+def start_quest(quest_id):
+    data = request.get_json()
+    user_id = data["user_id"]
+    quest = QUESTS.get(quest_id)
+    if quest is None:
+        return jsonify({"error": "quest not found"}), 404
+    quest_service.assign_quest(user_id, quest)
+    stage = quest.get_stage(quest.initial_stage)
+    return jsonify(stage.dict()), 200
+
+
+@quest_routes.route("/quests/progress/<quest_id>", methods=["POST"])
+def report_progress(quest_id):
+    data = request.get_json()
+    user_id = data["user_id"]
+    choice = data["choice"]
+    quest = QUESTS.get(quest_id)
+    if quest is None:
+        return jsonify({"error": "quest not found"}), 404
+    try:
+        stage = quest_service.report_progress(user_id, quest, choice)
+        return jsonify(stage.dict()), 200
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+
+@quest_routes.route("/quests/claim/<quest_id>", methods=["POST"])
+def claim_reward(quest_id):
+    data = request.get_json()
+    user_id = data["user_id"]
+    reward = quest_service.claim_reward(user_id, quest_id)
+    if reward:
+        return jsonify(reward.dict()), 200
+    return jsonify({"error": "no reward"}), 404

--- a/backend/seeds/event_seed.py
+++ b/backend/seeds/event_seed.py
@@ -1,9 +1,45 @@
-# seeds/event_seed.py
+"""Seed data for random in-game events."""
+
+from seeds.quest_data import get_seed_quests
+
+
+QUESTS = {quest.id: quest for quest in get_seed_quests()}
+
 
 def get_seed_events():
+    """Return a list of random events, some tied to quests."""
     return [
-        {"name": "Sprained Wrist", "type": "injury", "effect_type": "block_skill", "skill_affected": "guitar", "duration_days": 5, "trigger_chance": 0.01},
-        {"name": "Lost Love for Guitar", "type": "burnout", "effect_type": "freeze_progress", "skill_affected": "guitar", "duration_days": 3, "trigger_chance": 0.01},
-        {"name": "Throat Infection", "type": "illness", "effect_type": "block_skill", "skill_affected": "vocals", "duration_days": 4, "trigger_chance": 0.01},
-        {"name": "Emotional Slump", "type": "emotional", "effect_type": "decay_skill", "skill_affected": "songwriting", "duration_days": 2, "trigger_chance": 0.01}
+        {
+            "name": "Sprained Wrist",
+            "type": "injury",
+            "effect_type": "block_skill",
+            "skill_affected": "guitar",
+            "duration_days": 5,
+            "trigger_chance": 0.01,
+            "related_quest": QUESTS["first_gig"].id,
+        },
+        {
+            "name": "Lost Love for Guitar",
+            "type": "burnout",
+            "effect_type": "freeze_progress",
+            "skill_affected": "guitar",
+            "duration_days": 3,
+            "trigger_chance": 0.01,
+        },
+        {
+            "name": "Throat Infection",
+            "type": "illness",
+            "effect_type": "block_skill",
+            "skill_affected": "vocals",
+            "duration_days": 4,
+            "trigger_chance": 0.01,
+        },
+        {
+            "name": "Emotional Slump",
+            "type": "emotional",
+            "effect_type": "decay_skill",
+            "skill_affected": "songwriting",
+            "duration_days": 2,
+            "trigger_chance": 0.01,
+        },
     ]

--- a/backend/seeds/quest_data.py
+++ b/backend/seeds/quest_data.py
@@ -1,0 +1,25 @@
+from models.quest import Quest, QuestStage, QuestReward
+
+
+def get_seed_quests():
+    """Return a list of predefined quests used for seeding the database."""
+    return [
+        Quest(
+            id="first_gig",
+            name="Play Your First Gig",
+            stages={
+                "start": QuestStage(
+                    id="start",
+                    description="Find a venue willing to host your band.",
+                    branches={"book": "perform"},
+                ),
+                "perform": QuestStage(
+                    id="perform",
+                    description="Put on an unforgettable show.",
+                    branches={},
+                    reward=QuestReward(type="fame", amount=10),
+                ),
+            },
+            initial_stage="start",
+        )
+    ]

--- a/backend/services/quest_service.py
+++ b/backend/services/quest_service.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from models.quest import Quest, QuestReward
+
+
+class QuestService:
+    """Service for assigning quests and tracking player progress."""
+
+    def __init__(self):
+        # user_id -> {quest_id: current_stage_id}
+        self.assignments: Dict[int, Dict[str, str]] = {}
+        # user_id -> {quest_id: QuestReward}
+        self.completed: Dict[int, Dict[str, QuestReward]] = {}
+
+    def assign_quest(self, user_id: int, quest: Quest) -> None:
+        """Assign a quest to a user starting at the initial stage."""
+        self.assignments.setdefault(user_id, {})[quest.id] = quest.initial_stage
+
+    def get_current_stage(self, user_id: int, quest: Quest):
+        stage_id = self.assignments.get(user_id, {}).get(quest.id)
+        if stage_id is None:
+            return None
+        return quest.get_stage(stage_id)
+
+    def report_progress(self, user_id: int, quest: Quest, choice: str):
+        """Advance the quest based on a branch choice and return the new stage."""
+        current_stage_id = self.assignments.get(user_id, {}).get(quest.id)
+        if current_stage_id is None:
+            raise ValueError("Quest not assigned")
+        current_stage = quest.get_stage(current_stage_id)
+        if choice not in current_stage.branches:
+            raise ValueError("Invalid branch choice")
+        next_stage_id = current_stage.branches[choice]
+        self.assignments[user_id][quest.id] = next_stage_id
+        next_stage = quest.get_stage(next_stage_id)
+        if next_stage.reward:
+            self.completed.setdefault(user_id, {})[quest.id] = next_stage.reward
+        return next_stage
+
+    def claim_reward(self, user_id: int, quest_id: str):
+        """Retrieve the reward for a completed quest stage if available."""
+        return self.completed.get(user_id, {}).pop(quest_id, None)
+
+    def resolve_outcome(self, user_id: int, quest: Quest):
+        """Return the reward for the current stage without claiming it."""
+        stage = self.get_current_stage(user_id, quest)
+        return stage.reward if stage else None

--- a/backend/tests/quest/__init__.py
+++ b/backend/tests/quest/__init__.py
@@ -1,0 +1,1 @@
+# Quest tests package

--- a/backend/tests/quest/test_quest_logic.py
+++ b/backend/tests/quest/test_quest_logic.py
@@ -1,0 +1,48 @@
+from models.quest import Quest, QuestStage, QuestReward
+from services.quest_service import QuestService
+
+
+def sample_quest():
+    return Quest(
+        id="q1",
+        name="Test Quest",
+        stages={
+            "start": QuestStage(
+                id="start",
+                description="Start",
+                branches={"left": "left_stage", "right": "right_stage"},
+            ),
+            "left_stage": QuestStage(
+                id="left_stage",
+                description="Left path",
+                branches={},
+                reward=QuestReward(type="xp", amount=10),
+            ),
+            "right_stage": QuestStage(
+                id="right_stage",
+                description="Right path",
+                branches={},
+                reward=QuestReward(type="item", amount=1),
+            ),
+        },
+        initial_stage="start",
+    )
+
+
+def test_branching_logic():
+    quest = sample_quest()
+    service = QuestService()
+    service.assign_quest(1, quest)
+    stage = service.report_progress(1, quest, "left")
+    assert stage.id == "left_stage"
+
+
+def test_reward_distribution():
+    quest = sample_quest()
+    service = QuestService()
+    service.assign_quest(1, quest)
+    service.report_progress(1, quest, "right")
+    reward = service.claim_reward(1, quest.id)
+    assert reward.type == "item"
+    assert reward.amount == 1
+    assert service.claim_reward(1, quest.id) is None


### PR DESCRIPTION
## Summary
- define Quest, QuestStage, and QuestReward models
- provide QuestService for assigning quests, progressing branches, and claiming rewards
- expose quest routes and seed initial quest data tied to events
- add unit tests validating branch navigation and reward distribution

## Testing
- `pytest backend/tests/quest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68aeec9be16083259444f945f59a25a7