### PR TITLE
Add dialogue service and realtime NPC chat gateway

### DIFF
--- a/backend/models/dialogue.py
+++ b/backend/models/dialogue.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class DialogueMessage(BaseModel):
+    """Represents a single message in a dialogue."""
+
+    role: str
+    content: str
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ConversationHistory(BaseModel):
+    """Container storing ordered dialogue messages."""
+
+    messages: List[DialogueMessage] = Field(default_factory=list)
+
+    def add(self, role: str, content: str) -> DialogueMessage:
+        msg = DialogueMessage(role=role, content=content)
+        self.messages.append(msg)
+        return msg

--- a/backend/realtime/dialogue_gateway.py
+++ b/backend/realtime/dialogue_gateway.py
@@ -1,0 +1,32 @@
+"""WebSocket gateway for live dialogue sessions with NPCs."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+
+from backend.models.dialogue import DialogueMessage
+from backend.realtime.gateway import get_current_user_id_dep
+from backend.services.dialogue_service import DialogueService
+
+router = APIRouter(prefix="/dialogue", tags=["dialogue"])
+
+
+@router.websocket("/ws/{npc_id}")
+async def dialogue_ws(
+    ws: WebSocket,
+    npc_id: str,
+    user_id: int = Depends(get_current_user_id_dep),
+) -> None:
+    await ws.accept()
+    service = DialogueService()
+    history: List[DialogueMessage] = []
+    try:
+        while True:
+            user_text = await ws.receive_text()
+            history.append(DialogueMessage(role="user", content=user_text))
+            reply = await service.generate_reply(history)
+            history.append(reply)
+            await ws.send_text(reply.content)
+    except WebSocketDisconnect:  # pragma: no cover - network event
+        return

--- a/backend/services/dialogue_service.py
+++ b/backend/services/dialogue_service.py
@@ -1,0 +1,32 @@
+"""Service layer for NPC/user dialogue via an LLM provider."""
+from __future__ import annotations
+
+from typing import List, Optional, Protocol
+
+from backend.models.dialogue import DialogueMessage
+from backend.services.moderation_service import moderate_content
+
+
+class LLMProvider(Protocol):
+    async def complete(self, history: List[DialogueMessage]) -> str: ...
+
+
+class EchoLLM:
+    """Fallback LLM provider that echoes the last user message."""
+
+    async def complete(self, history: List[DialogueMessage]) -> str:  # pragma: no cover - trivial
+        if history:
+            return f"Echo: {history[-1].content}"
+        return "..."
+
+
+class DialogueService:
+    """High level interface managing conversation state and generation."""
+
+    def __init__(self, llm_client: Optional[LLMProvider] = None) -> None:
+        self.llm = llm_client or EchoLLM()
+
+    async def generate_reply(self, history: List[DialogueMessage]) -> DialogueMessage:
+        raw = await self.llm.complete(history)
+        filtered = moderate_content(raw)
+        return DialogueMessage(role="npc", content=filtered)

--- a/backend/services/moderation_service.py
+++ b/backend/services/moderation_service.py
@@ -1,0 +1,26 @@
+"""Simple content moderation utilities for dialogue outputs."""
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+# Minimal list of banned words for demonstration/testing purposes.
+BANNED_WORDS: Iterable[str] = ["violence", "kill", "murder"]
+REPLACEMENT = "[filtered]"
+
+
+def moderate_content(text: str) -> str:
+    """Return text with banned words replaced."""
+    if not text:
+        return text
+    result = text
+    for word in BANNED_WORDS:
+        pattern = re.compile(re.escape(word), re.IGNORECASE)
+        result = pattern.sub(REPLACEMENT, result)
+    return result
+
+
+def is_clean(text: str) -> bool:
+    """Quick check if text contains banned words."""
+    lowered = text.lower()
+    return not any(word in lowered for word in BANNED_WORDS)

--- a/backend/tests/dialogue/test_dialogue.py
+++ b/backend/tests/dialogue/test_dialogue.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import backend.realtime.dialogue_gateway as dialogue_gateway
+from backend.models.dialogue import DialogueMessage
+from backend.realtime.dialogue_gateway import router as dialogue_router
+from backend.services.dialogue_service import DialogueService
+
+
+class EchoLLM:
+    async def complete(self, history):
+        return f"NPC says: {history[-1].content}"
+
+
+class BadLLM:
+    async def complete(self, history):
+        return "Violence is never the answer"
+
+
+def test_service_moderates_response():
+    service = DialogueService(llm_client=BadLLM())
+    history = [DialogueMessage(role="user", content="hello")]
+    reply = asyncio.get_event_loop().run_until_complete(service.generate_reply(history))
+    assert "violence" not in reply.content.lower()
+    assert reply.role == "npc"
+
+
+def test_dialogue_websocket_flow(monkeypatch):
+    app = FastAPI()
+    app.include_router(dialogue_router)
+    service = DialogueService(llm_client=EchoLLM())
+    monkeypatch.setattr(dialogue_gateway, "DialogueService", lambda: service)
+    client = TestClient(app)
+    with client.websocket_connect("/dialogue/ws/42", headers={"X-User-Id": "5"}) as ws:
+        ws.send_text("hi there")
+        resp = ws.receive_text()
+        assert "hi there" in resp.lower()


### PR DESCRIPTION
## Summary
- define dialogue conversation models
- add moderation and LLM-backed dialogue service
- expose websocket gateway for live NPC chat
- cover dialogue and moderation with tests

## Testing
- `ruff check backend/models/dialogue.py backend/services/moderation_service.py backend/services/dialogue_service.py backend/realtime/dialogue_gateway.py backend/tests/dialogue/test_dialogue.py`
- `pytest backend/tests/dialogue/test_dialogue.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68aef7151600832597f069b3438e7bbf