### PR TITLE
Add contract negotiation flow with economy integration

### DIFF
--- a/backend/models/label_management_models.py
+++ b/backend/models/label_management_models.py
@@ -1,5 +1,12 @@
 # Label & Management models
 
+"""Models for label, management and contract negotiations."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict
+
+
 class Label:
     def __init__(self, name, genre_focus, max_roster, reputation, npc_owned=True):
         self.name = name
@@ -24,3 +31,38 @@ class LabelContract:
         self.advance_payment = advance_payment
         self.min_releases = min_releases
         self.active = active
+
+
+class NegotiationStage(str, Enum):
+    """Simple state machine for contract negotiations."""
+
+    OFFER = "offer"
+    COUNTER = "counter"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+@dataclass
+class ClauseTemplate:
+    """Represents a negotiable contract clause with a default value."""
+
+    key: str
+    description: str
+    default: Any
+
+
+DEFAULT_CLAUSES = [
+    ClauseTemplate("advance_cents", "Upfront payment to the band", 0),
+    ClauseTemplate("royalty_rate", "Revenue percentage for the band", 0.0),
+]
+
+
+@dataclass
+class ContractNegotiation:
+    """In-memory record of an ongoing negotiation."""
+
+    id: int
+    label_id: int
+    band_id: int
+    terms: Dict[str, Any]
+    stage: NegotiationStage = NegotiationStage.OFFER

--- a/backend/routes/contract_routes.py
+++ b/backend/routes/contract_routes.py
@@ -1,0 +1,45 @@
+# Routes for contract negotiations.
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.services.contract_negotiation_service import ContractNegotiationService
+
+router = APIRouter(prefix="/contracts", tags=["Contracts"])
+
+svc = ContractNegotiationService()
+svc.economy.ensure_schema()
+
+
+class OfferIn(BaseModel):
+    label_id: int
+    band_id: int
+    terms: dict
+
+
+class CounterIn(BaseModel):
+    terms: dict
+
+
+@router.post("/offer")
+def create_offer(payload: OfferIn):
+    negotiation = svc.create_offer(payload.label_id, payload.band_id, payload.terms)
+    return negotiation.__dict__
+
+
+@router.post("/{negotiation_id}/counter")
+def counter_offer(negotiation_id: int, payload: CounterIn):
+    try:
+        negotiation = svc.counter_offer(negotiation_id, payload.terms)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return negotiation.__dict__
+
+
+@router.post("/{negotiation_id}/accept")
+def accept_offer(negotiation_id: int):
+    try:
+        negotiation = svc.accept_offer(negotiation_id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return negotiation.__dict__

--- a/backend/services/contract_negotiation_service.py
+++ b/backend/services/contract_negotiation_service.py
@@ -1,0 +1,94 @@
+"""Service handling contract negotiation flows."""
+
+from __future__ import annotations
+
+from typing import Dict, Any, Optional
+
+from backend.models.label_management_models import (
+    ContractNegotiation,
+    NegotiationStage,
+)
+from backend.services.economy_service import EconomyService
+
+
+class ContractNegotiationService:
+    """In-memory negotiation tracking with economy integration."""
+
+    def __init__(self, economy: Optional[EconomyService] = None):
+        self.economy = economy or EconomyService()
+        self.negotiations: Dict[int, ContractNegotiation] = {}
+        self._next_id = 1
+
+    def create_offer(self, label_id: int, band_id: int, terms: Dict[str, Any]) -> ContractNegotiation:
+        negotiation = ContractNegotiation(
+            id=self._next_id,
+            label_id=label_id,
+            band_id=band_id,
+            terms=dict(terms),
+            stage=NegotiationStage.OFFER,
+        )
+        self.negotiations[self._next_id] = negotiation
+        self._next_id += 1
+        return negotiation
+
+    def counter_offer(self, negotiation_id: int, terms: Dict[str, Any]) -> ContractNegotiation:
+        negotiation = self._get(negotiation_id)
+        if negotiation.stage == NegotiationStage.ACCEPTED:
+            raise ValueError("Negotiation already accepted")
+        negotiation.terms = dict(terms)
+        negotiation.stage = NegotiationStage.COUNTER
+        return negotiation
+
+    def accept_offer(self, negotiation_id: int) -> ContractNegotiation:
+        negotiation = self._get(negotiation_id)
+        if negotiation.stage == NegotiationStage.ACCEPTED:
+            raise ValueError("Negotiation already accepted")
+        advance = int(negotiation.terms.get("advance_cents", 0))
+        royalty = float(negotiation.terms.get("royalty_rate", 0))
+        # move advance funds
+        if advance:
+            self.economy.transfer(negotiation.label_id, negotiation.band_id, advance)
+        # record royalty agreement as zero-amount transaction
+        self._record_royalty_agreement(negotiation.label_id, negotiation.band_id, royalty)
+        negotiation.stage = NegotiationStage.ACCEPTED
+        return negotiation
+
+    # internal helpers -------------------------------------------------
+    def _get(self, negotiation_id: int) -> ContractNegotiation:
+        negotiation = self.negotiations.get(negotiation_id)
+        if not negotiation:
+            raise ValueError("Negotiation not found")
+        return negotiation
+
+    def _record_royalty_agreement(self, label_id: int, band_id: int, rate: float) -> None:
+        import sqlite3
+
+        with sqlite3.connect(self.economy.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("BEGIN IMMEDIATE")
+            src_id = self.economy._require_account(cur, label_id, "USD")
+            dest_id = self.economy._require_account(cur, band_id, "USD")
+            cur.execute(
+                "INSERT INTO transactions (type, amount_cents, currency, src_account_id, dest_account_id) VALUES ('royalty', 0, 'USD', ?, ?)",
+                (src_id, dest_id),
+            )
+            tid = cur.lastrowid
+            cur.execute(
+                "SELECT balance_cents FROM accounts WHERE id = ?",
+                (src_id,),
+            )
+            src_balance = int(cur.fetchone()[0])
+            cur.execute(
+                "INSERT INTO ledger_entries (account_id, transaction_id, delta_cents, balance_after) VALUES (?, ?, 0, ?)",
+                (src_id, tid, src_balance),
+            )
+            cur.execute(
+                "SELECT balance_cents FROM accounts WHERE id = ?",
+                (dest_id,),
+            )
+            dest_balance = int(cur.fetchone()[0])
+            cur.execute(
+                "INSERT INTO ledger_entries (account_id, transaction_id, delta_cents, balance_after) VALUES (?, ?, 0, ?)",
+                (dest_id, tid, dest_balance),
+            )
+            conn.commit()

--- a/backend/tests/contracts/test_negotiation_flow.py
+++ b/backend/tests/contracts/test_negotiation_flow.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.services.contract_negotiation_service import ContractNegotiationService
+from backend.services.economy_service import EconomyService
+from backend.routes import contract_routes
+from backend.models.label_management_models import NegotiationStage
+
+
+def setup_service():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    econ = EconomyService(db_path=path)
+    econ.ensure_schema()
+    svc = ContractNegotiationService(economy=econ)
+    return svc, econ
+
+
+def test_offer_counter_accept_flow():
+    svc, econ = setup_service()
+    econ.deposit(1, 10000)
+    offer = svc.create_offer(1, 2, {"advance_cents": 4000, "royalty_rate": 0.1})
+    assert offer.stage == NegotiationStage.OFFER
+    offer = svc.counter_offer(offer.id, {"advance_cents": 3000, "royalty_rate": 0.2})
+    assert offer.stage == NegotiationStage.COUNTER
+    offer = svc.accept_offer(offer.id)
+    assert offer.stage == NegotiationStage.ACCEPTED
+    assert econ.get_balance(1) == 7000
+    assert econ.get_balance(2) == 3000
+    txns = econ.list_transactions(2)
+    assert any(t.type == "royalty" for t in txns)
+
+
+def test_accept_invalid():
+    svc, _ = setup_service()
+    with pytest.raises(ValueError):
+        svc.accept_offer(999)
+
+
+def test_cannot_accept_twice():
+    svc, econ = setup_service()
+    econ.deposit(1, 5000)
+    offer = svc.create_offer(1, 2, {"advance_cents": 1000, "royalty_rate": 0.1})
+    svc.accept_offer(offer.id)
+    with pytest.raises(ValueError):
+        svc.accept_offer(offer.id)
+
+
+def test_route_flow(tmp_path):
+    db = tmp_path / "test.db"
+    economy = EconomyService(str(db))
+    economy.ensure_schema()
+    contract_routes.svc = ContractNegotiationService(economy)
+    economy.deposit(1, 10000)
+    offer = contract_routes.create_offer(contract_routes.OfferIn(label_id=1, band_id=2, terms={"advance_cents": 1000, "royalty_rate": 0.1}))
+    nid = offer["id"]
+    contract_routes.counter_offer(nid, contract_routes.CounterIn(terms={"advance_cents": 800, "royalty_rate": 0.15}))
+    contract_routes.accept_offer(nid)
+    assert economy.get_balance(2) == 800


### PR DESCRIPTION
## Summary
- add negotiation stages and clause templates to label/management models
- implement contract negotiation service with offer, counter and acceptance
- expose contract negotiation endpoints for offers, counters and acceptance
- track advance and royalty agreements in economy transactions
- test contract negotiation service and routes

## Testing
- `pytest backend/tests/contracts -q`


------
https://chatgpt.com/codex/tasks/task_e_68aefc2800508325a0f08521ad7d13ec