### PR TITLE
Add modding plugin system and marketplace service

### DIFF
--- a/backend/modding/__init__.py
+++ b/backend/modding/__init__.py
@@ -1,0 +1,4 @@
+from .interfaces import PluginMeta, ModPlugin
+from .loader import PluginLoader
+
+__all__ = ["PluginMeta", "ModPlugin", "PluginLoader"]

--- a/backend/modding/interfaces.py
+++ b/backend/modding/interfaces.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass
+class PluginMeta:
+    """Basic metadata describing a plugin."""
+
+    name: str
+    version: str
+    author: str | None = None
+
+
+class ModPlugin(Protocol):
+    """Simple protocol every mod plugin should implement."""
+
+    meta: PluginMeta
+
+    def activate(self) -> None:
+        """Called once when the plugin is registered."""
+        ...

--- a/backend/modding/loader.py
+++ b/backend/modding/loader.py
@@ -1,0 +1,45 @@
+"""Simple plugin loader for game mods."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Dict, Iterable
+
+from .interfaces import ModPlugin
+
+
+class PluginLoader:
+    """Loads and registers mod plugins.
+
+    Plugins are expected to expose a module-level ``plugin`` object that
+    implements :class:`ModPlugin`.
+    """
+
+    def __init__(self) -> None:
+        self.plugins: Dict[str, ModPlugin] = {}
+
+    # -----------------------------------------------------
+    def register(self, plugin: ModPlugin) -> None:
+        """Register a plugin instance and invoke its activate hook."""
+
+        self.plugins[plugin.meta.name] = plugin
+        # allow plugin to perform any setup
+        plugin.activate()
+
+    # -----------------------------------------------------
+    def load_from_module(self, module: ModuleType) -> None:
+        """Load a plugin from a Python module."""
+
+        plugin = getattr(module, "plugin", None)
+        if plugin is None:  # pragma: no cover - defensive branch
+            raise ValueError("Module does not define a 'plugin' attribute")
+        self.register(plugin)
+
+    # -----------------------------------------------------
+    def load_from_modules(self, module_names: Iterable[str]) -> None:
+        """Import modules by name and register contained plugins."""
+
+        for name in module_names:
+            mod = importlib.import_module(name)
+            self.load_from_module(mod)

--- a/backend/routes/modding_routes.py
+++ b/backend/routes/modding_routes.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+
+from backend.services.mod_marketplace_service import ModMarketplaceService
+
+router = APIRouter(prefix="/modding", tags=["modding"])
+service = ModMarketplaceService()
+
+
+@router.post("/mods")
+async def publish_mod(
+    author_id: int = Form(...),
+    name: str = Form(...),
+    description: str = Form(""),
+    price_cents: int = Form(0),
+    file: UploadFile = File(...),
+):
+    data = await file.read()
+    mod_id = service.publish_mod(author_id, name, description, price_cents, data, file.content_type or "application/octet-stream")
+    return {"id": mod_id}
+
+
+@router.post("/mods/{mod_id}/rate")
+def rate_mod(mod_id: int, user_id: int, rating: int):
+    try:
+        service.rate_mod(user_id, mod_id, rating)
+    except Exception as e:  # pragma: no cover - safety net
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"status": "ok"}
+
+
+@router.post("/mods/{mod_id}/download")
+def download_mod(mod_id: int, user_id: int):
+    try:
+        url = service.download_mod(user_id, mod_id)
+    except Exception as e:  # pragma: no cover - safety net
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"url": url}
+
+
+# ----------- admin review routes -----------
+@router.get("/admin/mods/pending")
+def pending_mods():
+    return service.list_pending_mods()
+
+
+@router.post("/admin/mods/{mod_id}/approve")
+def approve_mod(mod_id: int):
+    try:
+        service.approve_mod(mod_id)
+    except Exception as e:  # pragma: no cover
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"status": "ok"}

--- a/backend/services/mod_marketplace_service.py
+++ b/backend/services/mod_marketplace_service.py
@@ -1,0 +1,145 @@
+"""Service layer for publishing and purchasing mods from the marketplace."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+from backend.services.economy_service import EconomyService
+from backend.services.storage_service import get_storage_backend
+from backend.storage.base import StorageBackend
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class ModMarketplaceError(Exception):
+    pass
+
+
+class ModMarketplaceService:
+    def __init__(
+        self,
+        db_path: Optional[str] = None,
+        storage: Optional[StorageBackend] = None,
+        economy: Optional[EconomyService] = None,
+    ) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.storage = storage or get_storage_backend()
+        self.economy = economy or EconomyService(db_path=self.db_path)
+
+    # --------------------------- schema ---------------------------
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mods (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    author_id INTEGER NOT NULL,
+                    name TEXT NOT NULL,
+                    description TEXT,
+                    file_key TEXT NOT NULL,
+                    price_cents INTEGER NOT NULL,
+                    rating_sum INTEGER NOT NULL DEFAULT 0,
+                    rating_count INTEGER NOT NULL DEFAULT 0,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    created_at TEXT DEFAULT (datetime('now'))
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mod_ownership (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    mod_id INTEGER NOT NULL,
+                    user_id INTEGER NOT NULL,
+                    created_at TEXT DEFAULT (datetime('now')),
+                    UNIQUE(mod_id, user_id)
+                )
+                """
+            )
+            conn.commit()
+
+    # --------------------------- helpers ---------------------------
+    def _get_mod(self, cur: sqlite3.Cursor, mod_id: int) -> Dict:
+        cur.execute("SELECT * FROM mods WHERE id = ?", (mod_id,))
+        row = cur.fetchone()
+        if not row:
+            raise ModMarketplaceError("Mod not found")
+        columns = [d[0] for d in cur.description]
+        return dict(zip(columns, row))
+
+    # --------------------------- publishing ---------------------------
+    def publish_mod(
+        self,
+        author_id: int,
+        name: str,
+        description: str,
+        price_cents: int,
+        file_bytes: bytes,
+        content_type: str = "application/octet-stream",
+    ) -> int:
+        """Store the mod file and create a pending marketplace entry."""
+
+        key = f"mods/{uuid4().hex}.mod"
+        obj = self.storage.upload_bytes(file_bytes, key, content_type=content_type)
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO mods (author_id, name, description, file_key, price_cents)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (author_id, name, description, obj.key, price_cents),
+            )
+            conn.commit()
+            return int(cur.lastrowid or 0)
+
+    # --------------------------- reviews ---------------------------
+    def list_pending_mods(self) -> List[Dict]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("SELECT * FROM mods WHERE status = 'pending' ORDER BY created_at ASC")
+            return [dict(r) for r in cur.fetchall()]
+
+    def approve_mod(self, mod_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("UPDATE mods SET status = 'approved' WHERE id = ?", (mod_id,))
+            if cur.rowcount == 0:
+                raise ModMarketplaceError("Mod not found")
+            conn.commit()
+
+    # --------------------------- purchasing ---------------------------
+    def download_mod(self, user_id: int, mod_id: int) -> str:
+        """Purchase (transfer funds) and return a download URL."""
+
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            mod = self._get_mod(cur, mod_id)
+            if mod["status"] != "approved":
+                raise ModMarketplaceError("Mod not approved")
+            self.economy.transfer(user_id, mod["author_id"], mod["price_cents"])
+            cur.execute(
+                "INSERT OR IGNORE INTO mod_ownership (mod_id, user_id) VALUES (?, ?)",
+                (mod_id, user_id),
+            )
+            conn.commit()
+        return self.storage.url_for(mod["file_key"])
+
+    # --------------------------- ratings ---------------------------
+    def rate_mod(self, user_id: int, mod_id: int, rating: int) -> None:
+        if not (1 <= rating <= 5):
+            raise ModMarketplaceError("rating must be between 1 and 5")
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            # ensure mod exists
+            self._get_mod(cur, mod_id)
+            cur.execute(
+                "UPDATE mods SET rating_sum = rating_sum + ?, rating_count = rating_count + 1 WHERE id = ?",
+                (rating, mod_id),
+            )
+            conn.commit()

--- a/backend/tests/modding/test_marketplace.py
+++ b/backend/tests/modding/test_marketplace.py
@@ -1,0 +1,56 @@
+import sqlite3
+
+from backend.services.mod_marketplace_service import ModMarketplaceService
+from backend.services.economy_service import EconomyService
+from backend.storage.local import LocalStorage
+
+
+def test_marketplace_workflow(tmp_path):
+    db = tmp_path / "db.sqlite"
+    storage_root = tmp_path / "store"
+    storage = LocalStorage(root=str(storage_root), public_base_url="http://mods")
+    economy = EconomyService(db_path=str(db))
+    economy.ensure_schema()
+
+    svc = ModMarketplaceService(db_path=str(db), storage=storage, economy=economy)
+    svc.ensure_schema()
+
+    # give buyer some funds
+    economy.deposit(user_id=1, amount_cents=1000)
+
+    # author publishes a mod
+    mod_id = svc.publish_mod(
+        author_id=2,
+        name="Cool Mod",
+        description="",
+        price_cents=500,
+        file_bytes=b"hello mod",
+        content_type="text/plain",
+    )
+    pending = svc.list_pending_mods()
+    assert pending and pending[0]["id"] == mod_id
+
+    # admin approves
+    svc.approve_mod(mod_id)
+
+    # buyer purchases / downloads
+    url = svc.download_mod(user_id=1, mod_id=mod_id)
+    assert url.endswith(".mod")
+
+    # ownership recorded
+    with sqlite3.connect(str(db)) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM mod_ownership WHERE mod_id=? AND user_id=?", (mod_id, 1))
+        assert cur.fetchone()[0] == 1
+
+    # economy transfer
+    assert economy.get_balance(1) == 500
+    assert economy.get_balance(2) == 500
+
+    # rating
+    svc.rate_mod(user_id=1, mod_id=mod_id, rating=4)
+    with sqlite3.connect(str(db)) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT rating_sum, rating_count FROM mods WHERE id=?", (mod_id,))
+        rs, rc = cur.fetchone()
+        assert rs == 4 and rc == 1

--- a/backend/tests/modding/test_plugin_loader.py
+++ b/backend/tests/modding/test_plugin_loader.py
@@ -1,0 +1,24 @@
+import sys
+
+from backend.modding.loader import PluginLoader
+from backend.modding.interfaces import PluginMeta
+
+
+def test_plugin_registration(tmp_path, monkeypatch):
+    plugin_code = (
+        "from backend.modding.interfaces import PluginMeta\n"
+        "class Sample:\n"
+        "    meta = PluginMeta(name='sample', version='1.0', author='tester')\n"
+        "    activated = False\n"
+        "    def activate(self):\n"
+        "        self.activated = True\n"
+        "plugin = Sample()\n"
+    )
+    mod = tmp_path / "myplugin.py"
+    mod.write_text(plugin_code)
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    loader = PluginLoader()
+    loader.load_from_modules(["myplugin"])
+    assert "sample" in loader.plugins
+    assert loader.plugins["sample"].activated is True


### PR DESCRIPTION
## Summary
- Introduce modding package with plugin interfaces and loader
- Implement mod marketplace service for publishing, reviewing, purchasing and rating mods
- Expose modding routes including admin review endpoints and tests for plugin registration and marketplace workflow

## Testing
- `pytest backend/tests/modding -q`
- `pytest -q` *(fails: ImportError: cannot import name 'Depends' from 'fastapi', ModuleNotFoundError: No module named 'starlette', missing boto3, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aeffccb50c8325a8b9eb5a2b7575b4