### PR TITLE
Add achievement system with service, routes and service hooks

### DIFF
--- a/backend/models/achievement.py
+++ b/backend/models/achievement.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Achievement:
+    """Definition of an achievement or badge."""
+    id: int
+    code: str
+    name: str
+    description: str
+
+
+@dataclass
+class PlayerAchievement:
+    """Track a player's progress toward an achievement."""
+    user_id: int
+    achievement_id: int
+    progress: int = 0
+    unlocked_at: Optional[datetime] = None

--- a/backend/routes/achievement_routes.py
+++ b/backend/routes/achievement_routes.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter
+
+from services.achievement_service import AchievementService
+
+router = APIRouter(prefix="/achievements", tags=["Achievements"])
+svc = AchievementService()
+
+
+@router.get("/")
+def list_achievements():
+    """Return all available achievements."""
+    return svc.list_achievements()
+
+
+@router.get("/user/{user_id}")
+def user_achievements(user_id: int):
+    """Return achievement progress for a specific user."""
+    return svc.get_user_achievements(user_id)

--- a/backend/routes/property_routes.py
+++ b/backend/routes/property_routes.py
@@ -4,6 +4,7 @@ from typing import List
 
 from services.economy_service import EconomyService
 from services.property_service import PropertyService, PropertyError
+from services.achievement_service import AchievementService
 
 
 def require_role(roles):  # placeholder auth dependency
@@ -12,7 +13,8 @@ def require_role(roles):  # placeholder auth dependency
     return _noop
 
 router = APIRouter(prefix="/properties", tags=["Properties"])
-svc = PropertyService(economy=EconomyService())
+_achievements = AchievementService()
+svc = PropertyService(economy=EconomyService(), achievements=_achievements)
 svc.ensure_schema()
 
 

--- a/backend/routes/tour_routes.py
+++ b/backend/routes/tour_routes.py
@@ -6,9 +6,11 @@ from pydantic import BaseModel, Field
 from typing import Optional, List
 
 from services.tour_service import TourService, TourError
+from services.achievement_service import AchievementService
 
 router = APIRouter(prefix="/tours", tags=["Tours"])
-svc = TourService()
+_achievements = AchievementService()
+svc = TourService(achievements=_achievements)
 
 # ---- Models ----
 class CreateTourIn(BaseModel):

--- a/backend/services/achievement_service.py
+++ b/backend/services/achievement_service.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from backend.models.achievement import Achievement, PlayerAchievement
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class AchievementService:
+    """Service to manage achievements and player progress."""
+
+    def __init__(self, db_path: Optional[str] = None):
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+        self._ensure_default_definitions()
+
+    # -------------------- schema --------------------
+    def _conn(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def ensure_schema(self) -> None:
+        with self._conn() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS achievements (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    code TEXT UNIQUE NOT NULL,
+                    name TEXT NOT NULL,
+                    description TEXT NOT NULL
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS user_achievements (
+                    user_id INTEGER NOT NULL,
+                    achievement_id INTEGER NOT NULL,
+                    progress INTEGER NOT NULL DEFAULT 0,
+                    unlocked_at TEXT,
+                    PRIMARY KEY (user_id, achievement_id),
+                    FOREIGN KEY (achievement_id) REFERENCES achievements(id)
+                )
+                """
+            )
+            conn.commit()
+
+    def _ensure_default_definitions(self) -> None:
+        """Insert default achievement definitions if missing."""
+        defaults = [
+            ("chart_topper", "Chart Topper", "Reach #1 on any chart"),
+            ("first_tour", "On the Road", "Confirm your first tour"),
+            ("first_property", "Property Owner", "Purchase your first property"),
+        ]
+        with self._conn() as conn:
+            cur = conn.cursor()
+            for code, name, desc in defaults:
+                cur.execute(
+                    "INSERT OR IGNORE INTO achievements (code, name, description) VALUES (?, ?, ?)",
+                    (code, name, desc),
+                )
+            conn.commit()
+
+    # -------------------- operations --------------------
+    def _achievement_id(self, code: str) -> int:
+        with self._conn() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT id FROM achievements WHERE code = ?", (code,))
+            row = cur.fetchone()
+            if not row:
+                raise ValueError(f"Unknown achievement code: {code}")
+            return int(row[0])
+
+    def grant(self, user_id: int, code: str) -> bool:
+        """Grant an achievement to a user. Returns True if newly unlocked."""
+        aid = self._achievement_id(code)
+        now = datetime.utcnow().isoformat()
+        with self._conn() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT unlocked_at FROM user_achievements WHERE user_id=? AND achievement_id=?",
+                (user_id, aid),
+            )
+            row = cur.fetchone()
+            if row and row[0]:
+                return False
+            if row:
+                cur.execute(
+                    "UPDATE user_achievements SET unlocked_at=?, progress=progress WHERE user_id=? AND achievement_id=?",
+                    (now, user_id, aid),
+                )
+            else:
+                cur.execute(
+                    "INSERT INTO user_achievements (user_id, achievement_id, progress, unlocked_at) VALUES (?, ?, 0, ?)",
+                    (user_id, aid, now),
+                )
+            conn.commit()
+            return True
+
+    def revoke(self, user_id: int, code: str) -> bool:
+        aid = self._achievement_id(code)
+        with self._conn() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "DELETE FROM user_achievements WHERE user_id=? AND achievement_id=?",
+                (user_id, aid),
+            )
+            conn.commit()
+            return cur.rowcount > 0
+
+    def list_achievements(self) -> List[Dict[str, str]]:
+        with self._conn() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT code, name, description FROM achievements ORDER BY id")
+            rows = cur.fetchall()
+            return [dict(zip(["code", "name", "description"], r)) for r in rows]
+
+    def get_user_achievements(self, user_id: int) -> List[Dict[str, Optional[str]]]:
+        with self._conn() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT a.code, a.name, a.description, ua.unlocked_at, ua.progress
+                FROM achievements a
+                LEFT JOIN user_achievements ua ON ua.achievement_id = a.id AND ua.user_id = ?
+                ORDER BY a.id
+                """,
+                (user_id,),
+            )
+            rows = cur.fetchall()
+            return [
+                dict(zip(["code", "name", "description", "unlocked_at", "progress"], r)) for r in rows
+            ]

--- a/backend/tests/achievements/test_achievements.py
+++ b/backend/tests/achievements/test_achievements.py
@@ -1,0 +1,114 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.services.achievement_service import AchievementService
+from backend.services.property_service import PropertyService
+from backend.services.economy_service import EconomyService
+import pydantic
+
+if not hasattr(pydantic, "Field"):
+    def Field(default=None, **kwargs):
+        return default
+    pydantic.Field = Field
+
+import types
+
+core_errors = types.ModuleType("core.errors")
+
+class AppError(Exception):
+    pass
+
+class VenueConflictError(AppError):
+    pass
+
+class TourMinStopsError(AppError):
+    pass
+
+core_errors.AppError = AppError
+core_errors.VenueConflictError = VenueConflictError
+core_errors.TourMinStopsError = TourMinStopsError
+sys.modules["core.errors"] = core_errors
+
+from backend.services.tour_service import TourService
+from backend.services.chart_service import calculate_weekly_chart
+from backend.routes import achievement_routes
+
+
+def setup_db(tmp_path):
+    db = tmp_path / "test.db"
+    return str(db)
+
+
+def test_property_unlock(tmp_path):
+    db = setup_db(tmp_path)
+    ach = AchievementService(db)
+    econ = EconomyService(db)
+    econ.ensure_schema()
+    svc = PropertyService(db_path=db, economy=econ, achievements=ach)
+    svc.ensure_schema()
+    econ.deposit(1, 100000)
+    svc.buy_property(1, "Studio", "studio", "NYC", 50000, 1000)
+    progress = ach.get_user_achievements(1)
+    assert any(p["code"] == "first_property" and p["unlocked_at"] for p in progress)
+
+
+def test_tour_unlock(tmp_path):
+    db = setup_db(tmp_path)
+    ach = AchievementService(db)
+    svc = TourService(db_path=db, achievements=ach)
+    tour = svc.create_tour(1, "Road Trip")
+    v = svc.create_venue("Club")
+    svc.add_stop(tour["id"], v["id"], "2024-01-01", "2024-01-02", 0)
+    svc.add_stop(tour["id"], v["id"], "2024-01-03", "2024-01-04", 1)
+    svc.confirm_tour(tour["id"])
+    progress = ach.get_user_achievements(1)
+    assert any(p["code"] == "first_tour" and p["unlocked_at"] for p in progress)
+
+
+def test_chart_topper_unlock(tmp_path):
+    db = setup_db(tmp_path)
+    ach = AchievementService(db)
+    # patch chart_service globals
+    from backend.services import chart_service
+    chart_service.DB_PATH = db
+    chart_service.achievement_service = ach
+
+    with sqlite3.connect(db) as conn:
+        cur = conn.cursor()
+        cur.executescript(
+            """
+            CREATE TABLE bands (id INTEGER PRIMARY KEY, name TEXT);
+            CREATE TABLE songs (id INTEGER PRIMARY KEY, title TEXT, band_id INTEGER);
+            CREATE TABLE streams (id INTEGER PRIMARY KEY AUTOINCREMENT, song_id INTEGER, timestamp TEXT);
+            CREATE TABLE earnings (id INTEGER PRIMARY KEY AUTOINCREMENT, source_type TEXT, source_id INTEGER, amount REAL, timestamp TEXT);
+            CREATE TABLE chart_entries (id INTEGER PRIMARY KEY AUTOINCREMENT, chart_type TEXT, week_start TEXT, position INTEGER, song_id INTEGER, band_name TEXT, score REAL, generated_at TEXT);
+            """
+        )
+        cur.execute("INSERT INTO bands (id, name) VALUES (1, 'Band A')")
+        cur.execute("INSERT INTO songs (id, title, band_id) VALUES (1, 'Hit', 1)")
+        cur.execute("INSERT INTO streams (song_id, timestamp) VALUES (1, datetime('now'))")
+        conn.commit()
+
+    calculate_weekly_chart(start_date="2024-01-01")
+    progress = ach.get_user_achievements(1)
+    assert any(p["code"] == "chart_topper" and p["unlocked_at"] for p in progress)
+
+
+def test_routes(tmp_path):
+    db = setup_db(tmp_path)
+    ach = AchievementService(db)
+    achievement_routes.svc = ach
+
+    ach.grant(1, "first_property")
+
+    all_achs = achievement_routes.list_achievements()
+    assert any(a["code"] == "first_property" for a in all_achs)
+
+    data = achievement_routes.user_achievements(1)
+    assert any(a["code"] == "first_property" and a["unlocked_at"] for a in data)
+


### PR DESCRIPTION
## Summary
- add models and service for achievements with default badge definitions
- expose achievements via new API routes
- grant achievements for chart toppers, tour confirmations, and property purchases
- tests covering unlock conditions and API listing

## Testing
- `pytest backend/tests/achievements/test_achievements.py`
- `pytest backend/tests/property/test_property_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0101bed48325b2f3e6a8827c1d4f