### PR TITLE
Add jam session realtime support with economy integration

### DIFF
--- a/backend/models/jam_session.py
+++ b/backend/models/jam_session.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Set
+
+
+@dataclass
+class AudioStream:
+    """Represents a participant's outbound audio stream."""
+
+    user_id: int
+    stream_id: str
+    codec: str
+    started_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    premium: bool = False
+
+
+@dataclass
+class Participant:
+    user_id: int
+    joined_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+@dataclass
+class JamSession:
+    """In-memory representation of a jam session."""
+
+    id: str
+    host_id: int
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    participants: Dict[int, Participant] = field(default_factory=dict)
+    streams: Dict[int, AudioStream] = field(default_factory=dict)
+    invites: Set[int] = field(default_factory=set)
+
+    def add_participant(self, user_id: int) -> None:
+        self.participants[user_id] = Participant(user_id=user_id)
+
+    def remove_participant(self, user_id: int) -> None:
+        self.participants.pop(user_id, None)
+        self.streams.pop(user_id, None)

--- a/backend/realtime/jam_gateway.py
+++ b/backend/realtime/jam_gateway.py
@@ -1,0 +1,150 @@
+"""WebSocket relay for collaborative jam sessions."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict
+
+try:  # pragma: no cover - used in real app
+    from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, Header
+except Exception:  # pragma: no cover - fallback for tests without FastAPI
+    class APIRouter:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def websocket(self, path: str):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    def Depends(dep):  # type: ignore
+        return dep
+
+    class WebSocket:  # type: ignore
+        async def accept(self):
+            pass
+
+        async def send_text(self, text: str):
+            pass
+
+        async def receive_text(self) -> str:
+            return ""
+
+    class WebSocketDisconnect(Exception):
+        pass
+
+    def Header(default=None, alias=None):  # type: ignore
+        return default
+
+
+async def get_current_user_id_dep(  # pragma: no cover - simple fallback
+    x_user_id: str | None = Header(default=None, alias="X-User-Id"),
+    authorization: str | None = Header(default=None, alias="Authorization"),
+) -> int:
+    if x_user_id:
+        return int(x_user_id)
+    if authorization:
+        parts = authorization.split()
+        if len(parts) == 2 and parts[0].lower() == "bearer":
+            return int(parts[1])
+    return 0
+
+from backend.services.jam_service import JamService
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/jam", tags=["realtime"])
+
+# Shared service instance
+jam_service = JamService()
+
+
+class _Subscriber:
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def send(self, message: str) -> None:
+        await self.queue.put(message)
+
+    async def stream(self):
+        while True:
+            yield await self.queue.get()
+
+
+class JamSessionHub:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._subs: Dict[str, Dict[int, _Subscriber]] = {}
+
+    async def subscribe(self, session_id: str, user_id: int, sub: _Subscriber) -> None:
+        async with self._lock:
+            self._subs.setdefault(session_id, {})[user_id] = sub
+
+    async def unsubscribe(self, session_id: str, user_id: int) -> None:
+        async with self._lock:
+            subs = self._subs.get(session_id)
+            if subs:
+                subs.pop(user_id, None)
+                if not subs:
+                    self._subs.pop(session_id, None)
+
+    async def publish(self, session_id: str, payload: Dict[str, Any]) -> None:
+        message = json.dumps(payload, separators=(",", ":"))
+        async with self._lock:
+            subs = list(self._subs.get(session_id, {}).values())
+        for s in subs:
+            await s.send(message)
+
+
+hub = JamSessionHub()
+
+
+@router.websocket("/ws/{session_id}")
+async def jam_ws(ws: WebSocket, session_id: str, user_id: int = Depends(get_current_user_id_dep)) -> None:
+    await ws.accept()
+    sub = _Subscriber()
+    await hub.subscribe(session_id, user_id, sub)
+
+    async def pump() -> None:
+        async for msg in sub.stream():
+            await ws.send_text(msg)
+
+    outbound_task = asyncio.create_task(pump())
+    jam_service.join_session(session_id, user_id)
+    await hub.publish(session_id, {"type": "joined", "user_id": user_id})
+
+    try:
+        while True:
+            raw = await ws.receive_text()
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                await ws.send_text(json.dumps({"error": "invalid_json"}))
+                continue
+
+            op = msg.get("op")
+            if op == "start_stream":
+                stream = jam_service.start_stream(
+                    session_id,
+                    user_id,
+                    msg.get("stream_id", ""),
+                    msg.get("codec", ""),
+                    bool(msg.get("premium")),
+                )
+                await hub.publish(
+                    session_id,
+                    {"type": "stream_started", "user_id": user_id, "stream": stream.__dict__},
+                )
+            elif op == "stop_stream":
+                jam_service.stop_stream(session_id, user_id)
+                await hub.publish(session_id, {"type": "stream_stopped", "user_id": user_id})
+            elif op == "ping":
+                await ws.send_text(json.dumps({"op": "pong"}))
+    except WebSocketDisconnect:  # pragma: no cover - network
+        pass
+    finally:
+        await hub.unsubscribe(session_id, user_id)
+        jam_service.leave_session(session_id, user_id)
+        await hub.publish(session_id, {"type": "left", "user_id": user_id})
+        outbound_task.cancel()

--- a/backend/services/jam_service.py
+++ b/backend/services/jam_service.py
@@ -1,0 +1,78 @@
+"""Service layer for managing jam sessions and economy hooks."""
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from backend.models.jam_session import AudioStream, JamSession
+from backend.services.economy_service import EconomyService
+
+STUDIO_RENTAL_CENTS = 100
+PREMIUM_STREAM_CENTS = 25
+
+
+class JamService:
+    """Simple in-memory jam session management."""
+
+    def __init__(self, economy: Optional[EconomyService] = None):
+        self.economy = economy or EconomyService()
+        try:
+            self.economy.ensure_schema()
+        except Exception:
+            pass
+        self.sessions: Dict[str, JamSession] = {}
+        self._session_seq = 0
+
+    # ------------------------------------------------------------------
+    def create_session(self, host_id: int) -> JamSession:
+        """Create a new session and charge the host studio rental."""
+        self.economy.withdraw(host_id, STUDIO_RENTAL_CENTS)
+        self._session_seq += 1
+        session_id = str(self._session_seq)
+        session = JamSession(id=session_id, host_id=host_id)
+        session.add_participant(host_id)
+        self.sessions[session_id] = session
+        return session
+
+    def invite(self, session_id: str, inviter_id: int, invitee_id: int) -> None:
+        session = self.sessions.get(session_id)
+        if not session:
+            raise KeyError("session_not_found")
+        if inviter_id != session.host_id and inviter_id not in session.participants:
+            raise PermissionError("not_participant")
+        session.invites.add(invitee_id)
+
+    def join_session(self, session_id: str, user_id: int) -> None:
+        session = self.sessions.get(session_id)
+        if not session:
+            raise KeyError("session_not_found")
+        if user_id != session.host_id and user_id not in session.invites:
+            raise PermissionError("not_invited")
+        session.add_participant(user_id)
+
+    def leave_session(self, session_id: str, user_id: int) -> None:
+        session = self.sessions.get(session_id)
+        if not session:
+            return
+        session.remove_participant(user_id)
+        if not session.participants:
+            self.sessions.pop(session_id, None)
+
+    def start_stream(
+        self, session_id: str, user_id: int, stream_id: str, codec: str, premium: bool = False
+    ) -> AudioStream:
+        session = self.sessions.get(session_id)
+        if not session:
+            raise KeyError("session_not_found")
+        if user_id not in session.participants:
+            raise PermissionError("not_participant")
+        stream = AudioStream(user_id=user_id, stream_id=stream_id, codec=codec, premium=premium)
+        session.streams[user_id] = stream
+        if premium:
+            self.economy.withdraw(user_id, PREMIUM_STREAM_CENTS)
+        return stream
+
+    def stop_stream(self, session_id: str, user_id: int) -> None:
+        session = self.sessions.get(session_id)
+        if not session:
+            return
+        session.streams.pop(user_id, None)

--- a/backend/tests/jam_sessions/__init__.py
+++ b/backend/tests/jam_sessions/__init__.py
@@ -1,0 +1,1 @@
+# Package for jam session tests

--- a/backend/tests/jam_sessions/test_jam_gateway.py
+++ b/backend/tests/jam_sessions/test_jam_gateway.py
@@ -1,0 +1,75 @@
+import asyncio
+import json
+from contextlib import suppress
+
+import pytest
+
+from backend.realtime.jam_gateway import jam_ws, jam_service
+
+
+class FakeWebSocket:
+    def __init__(self):
+        self.sent_queue: asyncio.Queue[str] = asyncio.Queue()
+        self.receive_queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def accept(self):
+        pass
+
+    async def send_text(self, text: str):
+        await self.sent_queue.put(text)
+
+    async def receive_text(self) -> str:
+        return await self.receive_queue.get()
+
+    def queue(self, text: str) -> None:
+        self.receive_queue.put_nowait(text)
+
+
+def test_jam_session_flow(tmp_path):
+    async def run() -> None:
+        jam_service.sessions.clear()
+        jam_service.economy.db_path = str(tmp_path / "jam.db")
+        jam_service.economy.ensure_schema()
+
+        host_id = 1
+        user_id = 2
+        jam_service.economy.deposit(host_id, 500)
+        jam_service.economy.deposit(user_id, 500)
+
+        session = jam_service.create_session(host_id)
+        jam_service.invite(session.id, host_id, user_id)
+
+        host_ws = FakeWebSocket()
+        user_ws = FakeWebSocket()
+
+        host_task = asyncio.create_task(jam_ws(host_ws, session.id, user_id=host_id))
+        host_join = json.loads(await host_ws.sent_queue.get())
+        assert host_join["type"] == "joined" and host_join["user_id"] == host_id
+
+        user_task = asyncio.create_task(jam_ws(user_ws, session.id, user_id=user_id))
+        msg_host = json.loads(await host_ws.sent_queue.get())
+        msg_user = json.loads(await user_ws.sent_queue.get())
+        assert msg_host["type"] == "joined" and msg_host["user_id"] == user_id
+        assert msg_user["type"] == "joined" and msg_user["user_id"] == user_id
+
+        user_ws.queue(
+            json.dumps(
+                {"op": "start_stream", "stream_id": "s1", "codec": "opus", "premium": True}
+            )
+        )
+        stream_msg = json.loads(await host_ws.sent_queue.get())
+        assert stream_msg["type"] == "stream_started"
+        assert stream_msg["user_id"] == user_id
+        assert stream_msg["stream"]["stream_id"] == "s1"
+
+        host_task.cancel()
+        user_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await host_task
+        with suppress(asyncio.CancelledError):
+            await user_task
+
+        assert jam_service.economy.get_balance(host_id) == 400
+        assert jam_service.economy.get_balance(user_id) == 475
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add dataclasses for jam sessions, participants and audio streams
- implement jam service with session lifecycle and premium economy deductions
- provide websocket-based jam gateway with auth fallback
- test jam flows with mocked websocket channels

## Testing
- `pytest backend/tests/jam_sessions/test_jam_gateway.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af042ca70c83259f212e85e05b6ab4