### PR TITLE
Add analytics time-series service and tests

### DIFF
--- a/backend/models/analytics.py
+++ b/backend/models/analytics.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import List
+from pydantic import BaseModel
+
+
+class MetricPoint(BaseModel):
+    """Single point in a time series."""
+
+    date: str
+    value: int
+
+
+class AggregatedMetrics(BaseModel):
+    """Time-series metrics across several domains."""
+
+    economy: List[MetricPoint]
+    events: List[MetricPoint]
+    skills: List[MetricPoint]

--- a/backend/routes/analytics_routes.py
+++ b/backend/routes/analytics_routes.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter
+
+try:  # FastAPI stub in tests may not expose Depends
+    from fastapi import Depends
+except Exception:  # pragma: no cover - fallback for stubs
+    def Depends(dependency):  # type: ignore
+        return dependency
+
+from auth.dependencies import require_role
+from services.analytics_service import AnalyticsService
+from models.analytics import AggregatedMetrics
+
+router = APIRouter(prefix="/analytics", tags=["Analytics"])
+svc = AnalyticsService()
+
+
+@router.get("/time-series")
+async def get_time_series(
+    start_date: str,
+    end_date: str,
+    _: bool = Depends(require_role(["admin"])),
+) -> AggregatedMetrics:
+    """Return aggregated metrics across domains for the given date range."""
+    return svc.time_series(start_date, end_date)

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -5,6 +5,20 @@ class HTTPException(Exception):
         self.detail = detail
 
 
+def Depends(dep):  # pragma: no cover - testing stub
+    return dep
+
+
+class Request:  # minimal request used in tests
+    def __init__(self, headers: dict | None = None):
+        self.headers = headers or {}
+
+
+class status:  # pragma: no cover - constants for tests
+    HTTP_401_UNAUTHORIZED = 401
+    HTTP_403_FORBIDDEN = 403
+
+
 class APIRouter:
     def __init__(self, *args, **kwargs):
         self.routes = []


### PR DESCRIPTION
## Summary
- add pydantic models for time-series metrics
- implement cached analytics service aggregating economy, event, and skill stats
- expose secured `/analytics/time-series` route and tests for metrics and permissions

## Testing
- `pytest backend/tests/analytics/test_analytics.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68af0909009483259699b7093ecaff5b