### PR TITLE
Add NPC service and admin routes

### DIFF
--- a/backend/models/npc.py
+++ b/backend/models/npc.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+
+@dataclass
+class NPC:
+    """Simple data model representing a non-player character."""
+
+    id: int | None
+    identity: str
+    npc_type: str
+    dialogue_hooks: Dict[str, str] = field(default_factory=dict)
+    stats: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "identity": self.identity,
+            "npc_type": self.npc_type,
+            "dialogue_hooks": dict(self.dialogue_hooks),
+            "stats": dict(self.stats),
+        }

--- a/backend/routes/admin_npc_routes.py
+++ b/backend/routes/admin_npc_routes.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, HTTPException, Request
+
+from auth.dependencies import get_current_user_id, require_role
+from services.npc_service import NPCService
+
+router = APIRouter(prefix="/npcs", tags=["AdminNPCs"])
+svc = NPCService()
+
+
+@router.post("/")
+async def create_npc(data: dict, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    return svc.create_npc(
+        identity=data.get("identity", "unknown"),
+        npc_type=data.get("npc_type", "generic"),
+        dialogue_hooks=data.get("dialogue_hooks"),
+        stats=data.get("stats"),
+    )
+
+
+@router.put("/{npc_id}")
+async def edit_npc(npc_id: int, data: dict, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    npc = svc.update_npc(npc_id, **data)
+    if not npc:
+        raise HTTPException(status_code=404, detail="NPC not found")
+    return npc
+
+
+@router.delete("/{npc_id}")
+async def delete_npc(npc_id: int, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    if not svc.delete_npc(npc_id):
+        raise HTTPException(status_code=404, detail="NPC not found")
+    return {"status": "deleted"}
+
+
+@router.post("/{npc_id}/simulate")
+async def simulate_npc(npc_id: int, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    result = svc.simulate_npc(npc_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="NPC not found")
+    return result

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter
 from .admin_analytics_routes import router as analytics_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
+from .admin_npc_routes import router as npc_router
 
 
 router = APIRouter()
@@ -13,4 +14,5 @@ router = APIRouter()
 router.include_router(analytics_router)
 router.include_router(jobs_router)
 router.include_router(media_router)
+router.include_router(npc_router)
 

--- a/backend/routes/npc_band_routes.py
+++ b/backend/routes/npc_band_routes.py
@@ -1,27 +1,13 @@
-from auth.dependencies import get_current_user_id, require_role
+"""Deprecated module for NPC band routes.
 
-from flask import Blueprint, request, jsonify
-from services.npc_band_service import NPCBandService
+The old Flask blueprint has been removed in favour of the FastAPI
+implementation in :mod:`backend.routes.admin_npc_routes` and the
+``NPCService`` class. This file remains only to avoid import errors.
+"""
 
-npc_routes = Blueprint('npc_band_routes', __name__)
-npc_service = NPCBandService(db=None)
+from warnings import warn
 
-@npc_routes.route('/npc/create', methods=['POST'])
-def create_npc_band():
-    data = request.json
-    try:
-        result = npc_service.create_npc_band(
-            name=data['name'],
-            genre=data['genre']
-        )
-        return jsonify(result), 201
-    except Exception as e:
-        return jsonify({'error': str(e)}), 400
-
-@npc_routes.route('/npc/simulate', methods=['POST'])
-def simulate_npc_activity():
-    try:
-        npc_service.run_simulation_loop()
-        return jsonify({'status': 'NPC simulation complete'}), 200
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+warn(
+    "backend.routes.npc_band_routes is deprecated; use admin_npc_routes instead",
+    DeprecationWarning,
+)

--- a/backend/services/npc_service.py
+++ b/backend/services/npc_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import random
+from typing import Dict, Optional
+
+from models.npc import NPC
+
+
+class _InMemoryNPCDB:
+    """Very small in-memory storage used for tests and local use."""
+
+    def __init__(self):
+        self._npcs: Dict[int, NPC] = {}
+        self._next_id = 1
+
+    def add(self, npc: NPC) -> NPC:
+        npc.id = self._next_id
+        self._npcs[self._next_id] = npc
+        self._next_id += 1
+        return npc
+
+    def get(self, npc_id: int) -> Optional[NPC]:
+        return self._npcs.get(npc_id)
+
+    def delete(self, npc_id: int) -> bool:
+        return self._npcs.pop(npc_id, None) is not None
+
+    def all(self):
+        return list(self._npcs.values())
+
+
+class NPCService:
+    """Service providing CRUD operations and simple stat simulations for NPCs."""
+
+    def __init__(self, db: Optional[_InMemoryNPCDB] = None):
+        self.db = db or _InMemoryNPCDB()
+
+    # ---- CRUD ------------------------------------------------------------
+    def create_npc(self, identity: str, npc_type: str, dialogue_hooks=None, stats=None) -> Dict:
+        npc = NPC(
+            id=None,
+            identity=identity,
+            npc_type=npc_type,
+            dialogue_hooks=dialogue_hooks or {},
+            stats=stats or {},
+        )
+        self.db.add(npc)
+        return npc.to_dict()
+
+    def get_npc(self, npc_id: int) -> Optional[Dict]:
+        npc = self.db.get(npc_id)
+        return npc.to_dict() if npc else None
+
+    def update_npc(self, npc_id: int, **updates) -> Optional[Dict]:
+        npc = self.db.get(npc_id)
+        if not npc:
+            return None
+        if 'identity' in updates:
+            npc.identity = updates['identity']
+        if 'npc_type' in updates:
+            npc.npc_type = updates['npc_type']
+        if 'dialogue_hooks' in updates and updates['dialogue_hooks'] is not None:
+            npc.dialogue_hooks = updates['dialogue_hooks']
+        if 'stats' in updates and updates['stats'] is not None:
+            npc.stats = updates['stats']
+        return npc.to_dict()
+
+    def delete_npc(self, npc_id: int) -> bool:
+        return self.db.delete(npc_id)
+
+    # ---- Simulation ------------------------------------------------------
+    def simulate_npc(self, npc_id: int) -> Optional[Dict]:
+        npc = self.db.get(npc_id)
+        if not npc:
+            return None
+        fame_gain = random.randint(0, npc.stats.get('activity', 5))
+        npc.stats['fame'] = npc.stats.get('fame', 0) + fame_gain
+        return {"id": npc.id, "fame_gain": fame_gain, "stats": npc.stats}
+
+    def simulate_all(self):
+        for npc in self.db.all():
+            self.simulate_npc(npc.id)

--- a/backend/tests/admin/test_npc_routes.py
+++ b/backend/tests/admin/test_npc_routes.py
@@ -1,0 +1,51 @@
+import asyncio
+
+import pytest
+from fastapi import HTTPException, Request
+
+from backend.routes.admin_npc_routes import (
+    create_npc,
+    delete_npc,
+    edit_npc,
+    simulate_npc,
+    svc,
+)
+
+
+def test_admin_npc_routes_require_admin():
+    req = Request({})
+    with pytest.raises(HTTPException):
+        asyncio.run(create_npc({"identity": "x", "npc_type": "type"}, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(edit_npc(1, {"identity": "y"}, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(delete_npc(1, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(simulate_npc(1, req))
+
+
+def test_admin_npc_routes_flow(monkeypatch):
+    async def fake_current_user(req):
+        return 1
+
+    async def fake_require_role(roles, user_id):
+        return True
+
+    monkeypatch.setattr(
+        "backend.routes.admin_npc_routes.get_current_user_id", fake_current_user
+    )
+    monkeypatch.setattr(
+        "backend.routes.admin_npc_routes.require_role", fake_require_role
+    )
+
+    req = Request({})
+    npc = asyncio.run(create_npc({"identity": "A", "npc_type": "merchant"}, req))
+    npc_id = npc["id"]
+    updated = asyncio.run(edit_npc(npc_id, {"identity": "B"}, req))
+    assert updated["identity"] == "B"
+    sim = asyncio.run(simulate_npc(npc_id, req))
+    assert "fame_gain" in sim
+    res = asyncio.run(delete_npc(npc_id, req))
+    assert res == {"status": "deleted"}
+    # ensure service removed npc
+    assert svc.get_npc(npc_id) is None

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -41,6 +41,12 @@ class APIRouter:
             return func
         return decorator
 
+    def put(self, path: str):
+        def decorator(func):
+            self.routes.append(("PUT", path, func))
+            return func
+        return decorator
+
 
 class FastAPI:
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- define NPC dataclass model and in-memory NPCService for CRUD and simulation
- add FastAPI admin NPC routes with create, edit, delete and simulate actions
- retire legacy Flask npc_band_routes and extend FastAPI stub

## Testing
- `pytest backend/tests/admin/test_npc_routes.py backend/tests/admin/test_admin_router.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af0f42de84832599a990eaec49d4ce