### PR TITLE
Add admin quest management with DB persistence

### DIFF
--- a/backend/models/quest.py
+++ b/backend/models/quest.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Dict, Optional
 
 from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models used by the gameplay services and tests. These remain the
+# same so existing quest logic continues to work. They represent an in-memory
+# quest definition.
+# ---------------------------------------------------------------------------
 
 
 class QuestReward(BaseModel):
@@ -35,3 +43,35 @@ class Quest(BaseModel):
 
     def get_stage(self, stage_id: str) -> QuestStage:
         return self.stages[stage_id]
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses that map directly to the persisted quest schema.  The admin
+# service uses these when reading/writing from the SQLite database.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class QuestDB:
+    id: Optional[int]
+    name: str
+    version: int
+    initial_stage: str
+
+
+@dataclass
+class QuestStageDB:
+    id: Optional[int]
+    quest_id: int
+    stage_id: str
+    description: str
+    reward_type: Optional[str] = None
+    reward_amount: Optional[int] = None
+
+
+@dataclass
+class QuestBranchDB:
+    id: Optional[int]
+    stage_id: int
+    choice: str
+    next_stage_id: str

--- a/backend/routes/admin_quest_routes.py
+++ b/backend/routes/admin_quest_routes.py
@@ -1,0 +1,59 @@
+from fastapi import APIRouter, HTTPException, Request
+
+from auth.dependencies import get_current_user_id, require_role
+from services.quest_admin_service import QuestAdminService
+
+router = APIRouter(prefix="/quests", tags=["AdminQuests"])
+svc = QuestAdminService()
+
+
+@router.post("/")
+async def create_quest(data: dict, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    try:
+        quest = svc.create_quest(
+            name=data.get("name", "Unnamed"),
+            stages=data.get("stages", []),
+            initial_stage=data.get("initial_stage", ""),
+        )
+        return quest
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.put("/{quest_id}/stage/{stage_id}")
+async def update_stage(quest_id: int, stage_id: str, data: dict, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    try:
+        stage = svc.update_stage(
+            quest_id,
+            stage_id,
+            description=data.get("description"),
+            branches=data.get("branches"),
+            reward=data.get("reward"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if not stage:
+        raise HTTPException(status_code=404, detail="Stage not found")
+    return stage
+
+
+@router.post("/{quest_id}/version")
+async def version_quest(quest_id: int, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    quest = svc.version_quest(quest_id)
+    if not quest:
+        raise HTTPException(status_code=404, detail="Quest not found")
+    return quest
+
+
+@router.delete("/{quest_id}")
+async def delete_quest(quest_id: int, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    svc.delete_quest(quest_id)
+    return {"status": "deleted"}

--- a/backend/services/quest_admin_service.py
+++ b/backend/services/quest_admin_service.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from models.quest import QuestDB, QuestStageDB, QuestBranchDB, QuestReward, Quest, QuestStage
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class QuestAdminService:
+    """CRUD operations for quest definitions stored in SQLite."""
+
+    def __init__(self, db_path: Optional[str] = None):
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    # ------------------------------------------------------------------
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS quests (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    version INTEGER NOT NULL DEFAULT 1,
+                    initial_stage TEXT NOT NULL
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS quest_stages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    quest_id INTEGER NOT NULL REFERENCES quests(id),
+                    stage_id TEXT NOT NULL,
+                    description TEXT NOT NULL,
+                    reward_type TEXT,
+                    reward_amount INTEGER
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS quest_branches (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    stage_id INTEGER NOT NULL REFERENCES quest_stages(id),
+                    choice TEXT NOT NULL,
+                    next_stage_id TEXT NOT NULL
+                )
+                """
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def _validate_branches(self, stages: List[Dict[str, any]]) -> None:
+        stage_ids = {s["id"] for s in stages}
+        for st in stages:
+            for dest in st.get("branches", {}).values():
+                if dest not in stage_ids:
+                    raise ValueError(f"Invalid branch destination: {dest}")
+
+    # ------------------------------------------------------------------
+    def create_quest(self, name: str, stages: List[Dict[str, any]], initial_stage: str) -> Dict[str, any]:
+        self._validate_branches(stages)
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO quests (name, version, initial_stage) VALUES (?, 1, ?)",
+                (name, initial_stage),
+            )
+            quest_id = cur.lastrowid
+            stage_row_ids: Dict[str, int] = {}
+            for st in stages:
+                reward = st.get("reward")
+                cur.execute(
+                    """
+                    INSERT INTO quest_stages (quest_id, stage_id, description, reward_type, reward_amount)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        quest_id,
+                        st["id"],
+                        st["description"],
+                        reward.get("type") if reward else None,
+                        reward.get("amount") if reward else None,
+                    ),
+                )
+                stage_row_ids[st["id"]] = cur.lastrowid
+            for st in stages:
+                for choice, dest in st.get("branches", {}).items():
+                    cur.execute(
+                        "INSERT INTO quest_branches (stage_id, choice, next_stage_id) VALUES (?, ?, ?)",
+                        (stage_row_ids[st["id"]], choice, dest),
+                    )
+            conn.commit()
+        return self.get_quest(quest_id)
+
+    # ------------------------------------------------------------------
+    def get_quest(self, quest_id: int) -> Optional[Dict[str, any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, name, version, initial_stage FROM quests WHERE id = ?",
+                (quest_id,),
+            )
+            qrow = cur.fetchone()
+            if not qrow:
+                return None
+            cur.execute(
+                "SELECT id, stage_id, description, reward_type, reward_amount FROM quest_stages WHERE quest_id = ?",
+                (quest_id,),
+            )
+            stages = {}
+            id_map = {}
+            for row in cur.fetchall():
+                id_map[row["id"]] = row["stage_id"]
+                reward = None
+                if row["reward_type"]:
+                    reward = {"type": row["reward_type"], "amount": row["reward_amount"]}
+                stages[row["stage_id"]] = {
+                    "id": row["stage_id"],
+                    "description": row["description"],
+                    "reward": reward,
+                    "branches": {},
+                }
+            for db_id, code in id_map.items():
+                cur.execute(
+                    "SELECT choice, next_stage_id FROM quest_branches WHERE stage_id = ?",
+                    (db_id,),
+                )
+                branches = {r["choice"]: r["next_stage_id"] for r in cur.fetchall()}
+                stages[code]["branches"] = branches
+            return {
+                "id": qrow["id"],
+                "name": qrow["name"],
+                "version": qrow["version"],
+                "initial_stage": qrow["initial_stage"],
+                "stages": stages,
+            }
+
+    # ------------------------------------------------------------------
+    def update_stage(
+        self,
+        quest_id: int,
+        stage_id: str,
+        description: Optional[str] = None,
+        branches: Optional[Dict[str, str]] = None,
+        reward: Optional[Dict[str, any]] = None,
+    ) -> Optional[Dict[str, any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id FROM quest_stages WHERE quest_id = ? AND stage_id = ?",
+                (quest_id, stage_id),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            stage_db_id = row["id"]
+            if description is not None or reward is not None:
+                cur.execute(
+                    """
+                    UPDATE quest_stages
+                    SET description = COALESCE(?, description),
+                        reward_type = ?,
+                        reward_amount = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        description,
+                        reward.get("type") if reward else None,
+                        reward.get("amount") if reward else None,
+                        stage_db_id,
+                    ),
+                )
+            if branches is not None:
+                # validate branch destinations
+                cur.execute(
+                    "SELECT stage_id FROM quest_stages WHERE quest_id = ?",
+                    (quest_id,),
+                )
+                valid = {r["stage_id"] for r in cur.fetchall()}
+                for dest in branches.values():
+                    if dest not in valid:
+                        raise ValueError(f"Invalid branch destination: {dest}")
+                cur.execute("DELETE FROM quest_branches WHERE stage_id = ?", (stage_db_id,))
+                for choice, dest in branches.items():
+                    cur.execute(
+                        "INSERT INTO quest_branches (stage_id, choice, next_stage_id) VALUES (?, ?, ?)",
+                        (stage_db_id, choice, dest),
+                    )
+            conn.commit()
+        quest = self.get_quest(quest_id)
+        return quest["stages"].get(stage_id) if quest else None
+
+    # ------------------------------------------------------------------
+    def version_quest(self, quest_id: int) -> Optional[Dict[str, any]]:
+        quest = self.get_quest(quest_id)
+        if not quest:
+            return None
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO quests (name, version, initial_stage) VALUES (?, ?, ?)",
+                (quest["name"], quest["version"] + 1, quest["initial_stage"]),
+            )
+            new_id = cur.lastrowid
+            stage_map: Dict[str, int] = {}
+            for st in quest["stages"].values():
+                reward = st.get("reward")
+                cur.execute(
+                    """
+                    INSERT INTO quest_stages (quest_id, stage_id, description, reward_type, reward_amount)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        new_id,
+                        st["id"],
+                        st["description"],
+                        reward.get("type") if reward else None,
+                        reward.get("amount") if reward else None,
+                    ),
+                )
+                stage_map[st["id"]] = cur.lastrowid
+            for st in quest["stages"].values():
+                for choice, dest in st.get("branches", {}).items():
+                    cur.execute(
+                        "INSERT INTO quest_branches (stage_id, choice, next_stage_id) VALUES (?, ?, ?)",
+                        (stage_map[st["id"]], choice, dest),
+                    )
+            conn.commit()
+        return self.get_quest(new_id)
+
+    # ------------------------------------------------------------------
+    def delete_quest(self, quest_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "DELETE FROM quest_branches WHERE stage_id IN (SELECT id FROM quest_stages WHERE quest_id = ?)",
+                (quest_id,),
+            )
+            cur.execute("DELETE FROM quest_stages WHERE quest_id = ?", (quest_id,))
+            cur.execute("DELETE FROM quests WHERE id = ?", (quest_id,))
+            conn.commit()

--- a/backend/tests/admin/test_quest_routes.py
+++ b/backend/tests/admin/test_quest_routes.py
@@ -1,0 +1,62 @@
+import asyncio
+import pytest
+from fastapi import HTTPException, Request
+
+from backend.routes.admin_quest_routes import create_quest, update_stage, svc
+
+
+def sample_payload():
+    return {
+        "name": "Dragon Hunt",
+        "initial_stage": "start",
+        "stages": [
+            {
+                "id": "start",
+                "description": "Start",
+                "branches": {"go": "fight"},
+            },
+            {
+                "id": "fight",
+                "description": "Fight the dragon",
+                "branches": {},
+            },
+        ],
+    }
+
+
+def test_admin_quest_routes_require_admin():
+    req = Request({})
+    with pytest.raises(HTTPException):
+        asyncio.run(create_quest(sample_payload(), req))
+    with pytest.raises(HTTPException):
+        asyncio.run(update_stage(1, "start", {"description": "x"}, req))
+
+
+def test_admin_quest_create_and_update(monkeypatch):
+    async def fake_current_user(req):
+        return 1
+
+    async def fake_require_role(roles, user_id):
+        return True
+
+    monkeypatch.setattr(
+        "backend.routes.admin_quest_routes.get_current_user_id", fake_current_user
+    )
+    monkeypatch.setattr(
+        "backend.routes.admin_quest_routes.require_role", fake_require_role
+    )
+
+    req = Request({})
+    quest = asyncio.run(create_quest(sample_payload(), req))
+    quest_id = quest["id"]
+    updated = asyncio.run(
+        update_stage(
+            quest_id,
+            "start",
+            {"description": "New start", "branches": {"go": "fight"}},
+            req,
+        )
+    )
+    assert updated["description"] == "New start"
+    stored = svc.get_quest(quest_id)
+    assert stored["stages"]["start"]["description"] == "New start"


### PR DESCRIPTION
## Summary
- store quest definitions, stages and branches in SQLite tables
- provide QuestAdminService for CRUD and validation
- expose admin-only quest routes and tests covering create/update

## Testing
- `pytest backend/tests/admin/test_quest_routes.py -q`
- `pytest backend/tests/quest/test_quest_logic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1170d5e48325a219f7f50b0c7179