### PR TITLE
feat: add admin dashboard entrypoint

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,5 +11,10 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0"
   }
 }

--- a/frontend/pages/admin/index.tsx
+++ b/frontend/pages/admin/index.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import AdminApp from '../../src/admin/App';
+
+function isAuthenticated(): boolean {
+  const jwt = localStorage.getItem('jwt');
+  const hasSession = document.cookie.split(';').some((c) =>
+    c.trim().startsWith('session=')
+  );
+  return Boolean(jwt || hasSession);
+}
+
+const AdminPage: React.FC = () => {
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    if (isAuthenticated()) {
+      setAuthorized(true);
+    } else {
+      window.location.href = '/login';
+    }
+  }, []);
+
+  return authorized ? <AdminApp /> : null;
+};
+
+export default AdminPage;

--- a/frontend/src/admin/App.tsx
+++ b/frontend/src/admin/App.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Sidebar from './components/Sidebar';
+
+const App: React.FC = () => (
+  <div className="flex min-h-screen">
+    <Sidebar />
+    <main className="flex-1 p-4">
+      <h1 className="text-2xl font-bold mb-4">Admin Dashboard</h1>
+      <p className="text-gray-700">Select a module from the sidebar to begin.</p>
+    </main>
+  </div>
+);
+
+export default App;

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface NavItem {
+  label: string;
+  href: string;
+}
+
+const navItems: NavItem[] = [
+  { label: 'NPCs', href: '/admin/npcs' },
+  { label: 'Quests', href: '/admin/quests' },
+  { label: 'Economy', href: '/admin/economy' },
+  { label: 'Venues', href: '/admin/venues' },
+];
+
+const Sidebar: React.FC = () => (
+  <aside className="w-64 bg-gray-800 text-white h-screen p-4">
+    <nav>
+      <ul>
+        {navItems.map((item) => (
+          <li key={item.href} className="mb-2">
+            <a
+              href={item.href}
+              className="block px-2 py-1 rounded hover:bg-gray-700"
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  </aside>
+);
+
+export default Sidebar;

--- a/frontend/src/admin/index.tsx
+++ b/frontend/src/admin/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import '../index.css';
+
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<App />);
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add React admin SPA with Tailwind styling
- create sidebar navigation for NPCs, quests, economy, and venues modules
- protect `/admin/*` route via simple JWT/session check

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not find required file index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a1c75d083259aa7c0f450ddd2ef