### PR TITLE
feat: add admin schema and preview endpoints

### DIFF
--- a/backend/routes/admin_economy_routes.py
+++ b/backend/routes/admin_economy_routes.py
@@ -35,6 +35,18 @@ async def update_config(payload: ConfigUpdateIn, req: Request):
         raise HTTPException(status_code=400, detail=str(exc))
 
 
+@router.put("/config/preview")
+async def preview_config(payload: ConfigUpdateIn, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    current = svc.get_config()
+    preview = current.__dict__.copy()
+    for k, v in payload.dict().items():
+        if v is not None:
+            preview[k] = v
+    return preview
+
+
 @router.get("/transactions")
 async def recent_transactions(req: Request, limit: int = 50):
     admin_id = await get_current_user_id(req)

--- a/backend/routes/admin_npc_routes.py
+++ b/backend/routes/admin_npc_routes.py
@@ -38,6 +38,18 @@ async def delete_npc(npc_id: int, req: Request):
     return {"status": "deleted"}
 
 
+@router.post("/preview")
+async def preview_npc(data: dict, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    return svc.preview_npc(
+        identity=data.get("identity", "unknown"),
+        npc_type=data.get("npc_type", "generic"),
+        dialogue_hooks=data.get("dialogue_hooks"),
+        stats=data.get("stats"),
+    )
+
+
 @router.post("/{npc_id}/simulate")
 async def simulate_npc(npc_id: int, req: Request):
     admin_id = await get_current_user_id(req)

--- a/backend/routes/admin_quest_routes.py
+++ b/backend/routes/admin_quest_routes.py
@@ -57,3 +57,14 @@ async def delete_quest(quest_id: int, req: Request):
     await require_role(["admin"], admin_id)
     svc.delete_quest(quest_id)
     return {"status": "deleted"}
+
+
+@router.post("/preview")
+async def preview_quest(data: dict, req: Request):
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    try:
+        svc._validate_branches(data.get("stages", []))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"valid": True}

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -8,8 +8,8 @@ from .admin_economy_routes import router as economy_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
 from .admin_npc_routes import router as npc_router
-codex/implement-crud-for-venues-and-businesses-3gvg83
-
+from .admin_quest_routes import router as quest_router
+from .admin_schema_routes import router as schema_router
 
 
 router = APIRouter()
@@ -21,6 +21,5 @@ router.include_router(economy_router)
 router.include_router(jobs_router)
 router.include_router(media_router)
 router.include_router(npc_router)
-codex/implement-crud-for-venues-and-businesses-3gvg83
-
-
+router.include_router(quest_router)
+router.include_router(schema_router)

--- a/backend/routes/admin_schema_routes.py
+++ b/backend/routes/admin_schema_routes.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+from typing import Dict, Any, List
+
+from auth.dependencies import get_current_user_id, require_role
+
+
+
+class NPCSchema(BaseModel):
+    identity: str
+    npc_type: str
+    dialogue_hooks: Dict[str, str] = {}
+    stats: Dict[str, Any] = {}
+
+
+class QuestStageSchema(BaseModel):
+    id: str
+    description: str
+    branches: Dict[str, str] = {}
+    reward: Dict[str, Any] | None = None
+
+
+class QuestSchema(BaseModel):
+    name: str
+    initial_stage: str
+    stages: List[QuestStageSchema]
+
+
+class EconomyConfigSchema(BaseModel):
+    tax_rate: float | None = None
+    inflation_rate: float | None = None
+    payout_rate: int | None = None
+
+
+router = APIRouter(prefix="/schema", tags=["AdminSchema"])
+
+
+async def _ensure_admin(req: Request) -> None:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+
+
+@router.get("/npc")
+async def npc_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return NPCSchema.model_json_schema()
+
+
+@router.get("/quest")
+async def quest_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return QuestSchema.model_json_schema()
+
+
+@router.get("/economy")
+async def economy_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return EconomyConfigSchema.model_json_schema()

--- a/backend/services/npc_service.py
+++ b/backend/services/npc_service.py
@@ -69,6 +69,19 @@ class NPCService:
         return self.db.delete(npc_id)
 
     # ---- Simulation ------------------------------------------------------
+    def preview_npc(self, identity: str, npc_type: str, dialogue_hooks=None, stats=None) -> Dict:
+        """Simulate NPC stats without persisting to the DB."""
+        npc = NPC(
+            id=None,
+            identity=identity,
+            npc_type=npc_type,
+            dialogue_hooks=dialogue_hooks or {},
+            stats=stats or {},
+        )
+        fame_gain = random.randint(0, npc.stats.get('activity', 5))
+        npc.stats['fame'] = npc.stats.get('fame', 0) + fame_gain
+        return {"fame_gain": fame_gain, "stats": npc.stats}
+
     def simulate_npc(self, npc_id: int) -> Optional[Dict]:
         npc = self.db.get(npc_id)
         if not npc:

--- a/backend/tests/admin/test_content_preview.py
+++ b/backend/tests/admin/test_content_preview.py
@@ -1,0 +1,56 @@
+import asyncio
+from copy import deepcopy
+
+import pytest
+from fastapi import Request
+
+from backend.routes.admin_npc_routes import preview_npc, svc as npc_svc
+from backend.routes.admin_quest_routes import preview_quest, svc as quest_svc
+from backend.routes.admin_economy_routes import (
+    preview_config,
+    svc as econ_svc,
+    ConfigUpdateIn,
+)
+
+
+async def _allow(req):
+    return 1
+
+
+async def _role(roles, user_id):
+    return True
+
+
+def test_preview_endpoints_do_not_persist(monkeypatch):
+    monkeypatch.setattr(
+        "backend.routes.admin_npc_routes.get_current_user_id", _allow
+    )
+    monkeypatch.setattr("backend.routes.admin_npc_routes.require_role", _role)
+    monkeypatch.setattr(
+        "backend.routes.admin_quest_routes.get_current_user_id", _allow
+    )
+    monkeypatch.setattr("backend.routes.admin_quest_routes.require_role", _role)
+    monkeypatch.setattr(
+        "backend.routes.admin_economy_routes.get_current_user_id", _allow
+    )
+    monkeypatch.setattr("backend.routes.admin_economy_routes.require_role", _role)
+
+    req = Request({})
+
+    asyncio.run(
+        preview_npc({"identity": "X", "npc_type": "merchant", "stats": {"activity": 1}}, req)
+    )
+    assert npc_svc.db._npcs == {}
+
+    payload = {
+        "name": "Quest",
+        "initial_stage": "start",
+        "stages": [{"id": "start", "description": "hi", "branches": {}}],
+    }
+    asyncio.run(preview_quest(payload, req))
+    assert quest_svc.get_quest(1) is None
+
+    before = deepcopy(econ_svc.get_config())
+    asyncio.run(preview_config(ConfigUpdateIn(tax_rate=0.5), req))
+    after = econ_svc.get_config()
+    assert before == after

--- a/frontend/src/admin/components/EconomyConfigForm.tsx
+++ b/frontend/src/admin/components/EconomyConfigForm.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import SchemaForm from './SchemaForm';
+
+const EconomyConfigForm: React.FC = () => (
+  <SchemaForm schemaUrl="/admin/schema/economy" submitUrl="/admin/economy/config" method="PUT" />
+);
+
+export default EconomyConfigForm;

--- a/frontend/src/admin/components/NPCForm.tsx
+++ b/frontend/src/admin/components/NPCForm.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import SchemaForm from './SchemaForm';
+
+const NPCForm: React.FC = () => (
+  <SchemaForm schemaUrl="/admin/schema/npc" submitUrl="/admin/npcs" />
+);
+
+export default NPCForm;

--- a/frontend/src/admin/components/QuestForm.tsx
+++ b/frontend/src/admin/components/QuestForm.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import SchemaForm from './SchemaForm';
+
+const QuestForm: React.FC = () => (
+  <SchemaForm schemaUrl="/admin/schema/quest" submitUrl="/admin/quests" />
+);
+
+export default QuestForm;

--- a/frontend/src/admin/components/SchemaForm.tsx
+++ b/frontend/src/admin/components/SchemaForm.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+
+interface SchemaFormProps {
+  schemaUrl: string;
+  submitUrl: string;
+  method?: string;
+}
+
+const SchemaForm: React.FC<SchemaFormProps> = ({ schemaUrl, submitUrl, method = 'POST' }) => {
+  const [schema, setSchema] = useState<any>(null);
+  const [formData, setFormData] = useState<Record<string, any>>({});
+
+  useEffect(() => {
+    fetch(schemaUrl)
+      .then(res => res.json())
+      .then(setSchema)
+      .catch(() => setSchema(null));
+  }, [schemaUrl]);
+
+  if (!schema) {
+    return <div>Loading...</div>;
+  }
+
+  const properties = schema.properties || {};
+
+  const handleChange = (name: string, value: any) => {
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch(submitUrl, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(formData),
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {Object.entries(properties).map(([name, prop]) => (
+        <div key={name}>
+          <label className="block text-sm font-medium mb-1">{name}</label>
+          <input
+            className="border p-1 w-full"
+            type={prop.type === 'number' ? 'number' : 'text'}
+            value={formData[name] ?? ''}
+            onChange={e => handleChange(name, e.target.value)}
+          />
+        </div>
+      ))}
+      <button type="submit" className="px-4 py-2 bg-blue-500 text-white">Submit</button>
+    </form>
+  );
+};
+
+export default SchemaForm;


### PR DESCRIPTION
## Summary
- expose /admin/schema endpoints for NPC, quest, and economy
- add preview routes for NPC, quest, and economy admin APIs
- create reusable admin schema form components in the frontend
- verify previews don't persist data

## Testing
- `pytest backend/tests/admin/test_content_preview.py`


------
https://chatgpt.com/codex/tasks/task_e_68af1dad44b4832593e34c5defe0b2ed