### PR TITLE
Add weather forecasting service and integration

### DIFF
--- a/backend/models/weather.py
+++ b/backend/models/weather.py
@@ -1,0 +1,32 @@
+from datetime import date
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ClimateZone(BaseModel):
+    """Represents a region and its overall climate pattern."""
+
+    name: str
+    pattern: str
+    avg_high: float
+    avg_low: float
+
+
+class WeatherEvent(BaseModel):
+    """Weather driven world events such as storms or festivals."""
+
+    type: str
+    severity: int
+    description: Optional[str] = None
+
+
+class Forecast(BaseModel):
+    """Daily forecast for a region including optional events."""
+
+    region: str
+    date: date
+    condition: str
+    high: float
+    low: float
+    event: Optional[WeatherEvent] = None

--- a/backend/routes/weather_routes.py
+++ b/backend/routes/weather_routes.py
@@ -1,0 +1,22 @@
+from backend.models.weather import Forecast
+from backend.services.weather_service import weather_service
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+@router.get("/weather/{region}", response_model=Forecast)
+def get_forecast(region: str) -> Forecast:
+    return weather_service.get_forecast(region)
+
+
+class SubscribeRequest(BaseModel):
+    region: str
+    user_id: int
+
+
+@router.post("/weather/subscribe")
+def subscribe(req: SubscribeRequest) -> dict:
+    weather_service.subscribe(req.region, req.user_id)
+    return {"message": "subscribed"}

--- a/backend/seeds/weather_seed.py
+++ b/backend/seeds/weather_seed.py
@@ -1,0 +1,11 @@
+"""Seed initial climate zones."""
+
+from backend.models.weather import ClimateZone
+
+
+def get_seed_climate_zones():
+    return [
+        ClimateZone(name="north", pattern="temperate", avg_high=20, avg_low=10),
+        ClimateZone(name="south", pattern="tropical", avg_high=30, avg_low=20),
+        ClimateZone(name="desert", pattern="arid", avg_high=35, avg_low=25),
+    ]

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -1,7 +1,9 @@
 # services/event_service.py
 
-from datetime import datetime, timedelta
 import random
+
+from .weather_service import weather_service
+
 
 def roll_for_daily_event(user_id, lifestyle_data, active_skills):
     # Sample logic: if drinking high and vocals practiced 5 days in a row
@@ -25,3 +27,13 @@ def clear_expired_events():
 def is_skill_blocked(user_id, skill):
     # Check if user has an active event blocking this skill
     return False
+
+
+def adjust_event_attendance(base_attendance: int, region: str) -> int:
+    """Modify event attendance based on current weather."""
+    forecast = weather_service.get_forecast(region)
+    if forecast.event and forecast.event.type == "storm":
+        return int(base_attendance * 0.7)
+    if forecast.event and forecast.event.type == "festival":
+        return int(base_attendance * 1.3)
+    return base_attendance

--- a/backend/services/weather_service.py
+++ b/backend/services/weather_service.py
@@ -1,0 +1,41 @@
+"""Service for generating weather forecasts and world events."""
+from __future__ import annotations
+
+import random
+from datetime import date
+from typing import Dict, List, Optional
+
+from backend.models.weather import ClimateZone, Forecast, WeatherEvent
+
+
+class WeatherService:
+    def __init__(self, zones: Optional[Dict[str, ClimateZone]] = None) -> None:
+        self.zones: Dict[str, ClimateZone] = zones or {}
+        self.subscribers: Dict[str, List[int]] = {}
+
+    # --------- zone management ---------
+    def add_zone(self, zone: ClimateZone) -> None:
+        self.zones[zone.name] = zone
+
+    # --------- forecasting ---------
+    def get_forecast(self, region: str, for_date: Optional[date] = None) -> Forecast:
+        zone = self.zones.get(region)
+        if not zone:
+            zone = ClimateZone(name=region, pattern="temperate", avg_high=25, avg_low=15)
+        high = random.randint(int(zone.avg_high - 5), int(zone.avg_high + 5))
+        low = random.randint(int(zone.avg_low - 5), int(zone.avg_low + 5))
+        condition = random.choice(["sunny", "cloudy", "rain"])
+        event: Optional[WeatherEvent] = None
+        roll = random.random()
+        if roll < 0.1:
+            event = WeatherEvent(type="storm", severity=random.randint(1, 10))
+        elif roll < 0.15:
+            event = WeatherEvent(type="festival", severity=random.randint(1, 10))
+        return Forecast(region=region, date=for_date or date.today(), condition=condition, high=high, low=low, event=event)
+
+    # --------- subscriptions ---------
+    def subscribe(self, region: str, user_id: int) -> None:
+        self.subscribers.setdefault(region, []).append(user_id)
+
+
+weather_service = WeatherService()

--- a/backend/tests/weather/test_weather_service.py
+++ b/backend/tests/weather/test_weather_service.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.models.weather import ClimateZone, Forecast, WeatherEvent
+from backend.services import event_service
+from backend.services.economy_service import EconomyService
+from backend.services.property_service import PropertyService
+from backend.services.weather_service import WeatherService, weather_service
+
+
+def test_forecast_generates_event(monkeypatch):
+    svc = WeatherService()
+    svc.add_zone(ClimateZone(name="north", pattern="temperate", avg_high=20, avg_low=10))
+    monkeypatch.setattr("backend.services.weather_service.random.random", lambda: 0.05)
+    monkeypatch.setattr("backend.services.weather_service.random.randint", lambda a, b: a)
+    forecast = svc.get_forecast("north")
+    assert forecast.event and forecast.event.type == "storm"
+
+
+def test_adjust_event_attendance(monkeypatch):
+    def fake_forecast(region: str) -> Forecast:
+        return Forecast(region=region, date=date.today(), condition="sunny", high=20, low=10,
+                        event=WeatherEvent(type="storm", severity=5))
+
+    monkeypatch.setattr(event_service.weather_service, "get_forecast", fake_forecast)
+    assert event_service.adjust_event_attendance(100, "north") == 70
+
+
+def test_rent_adjusted_by_weather(monkeypatch):
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    econ = EconomyService(db_path=path)
+    econ.ensure_schema()
+    svc = PropertyService(db_path=path, economy=econ, weather=weather_service)
+    svc.ensure_schema()
+    econ.deposit(1, 100000)
+    svc.buy_property(1, "Flat", "apt", "north", 50000, 1000)
+
+    def fake_forecast(region: str) -> Forecast:
+        return Forecast(region=region, date=date.today(), condition="sunny", high=20, low=10,
+                        event=WeatherEvent(type="storm", severity=7))
+
+    monkeypatch.setattr(weather_service, "get_forecast", fake_forecast)
+    total = svc.collect_rent(1)
+    assert total == 500  # 50% due to storm
+    assert econ.get_balance(1) == 100000 - 50000 + 500


### PR DESCRIPTION
## Summary
- add weather models and forecasting service
- adjust event attendance and rent based on weather
- expose weather endpoints and seed climate zones

## Testing
- `ruff check backend/models/weather.py backend/services/weather_service.py backend/services/event_service.py backend/services/property_service.py backend/routes/weather_routes.py backend/seeds/weather_seed.py backend/tests/weather/test_weather_service.py`
- `pytest backend/tests/weather -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7b4d83248325b8bd8090afafe085