### PR TITLE
feat: add songwriting service and routes

### DIFF
--- a/backend/models/songwriting.py
+++ b/backend/models/songwriting.py
@@ -1,0 +1,37 @@
+"""Models for AI-assisted songwriting drafts and metadata."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class GenerationMetadata:
+    """Metadata about an LLM generation."""
+
+    model: str = "unknown"
+    latency_ms: Optional[int] = None
+
+
+@dataclass
+class StylePrompt:
+    """Describes the desired musical style for generation."""
+
+    genre: str
+    mood: Optional[str] = None
+    tempo: Optional[str] = None
+
+
+@dataclass
+class LyricDraft:
+    """A single AI generated lyric draft with optional chords."""
+
+    id: int
+    creator_id: int
+    prompt: str
+    style: str
+    lyrics: str
+    chords: Optional[str] = None
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    metadata: GenerationMetadata = field(default_factory=GenerationMetadata)

--- a/backend/routes/songwriting_routes.py
+++ b/backend/routes/songwriting_routes.py
@@ -1,0 +1,63 @@
+"""Routes for AI-assisted songwriting features."""
+from __future__ import annotations
+
+from typing import Dict, Set
+
+from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id
+from backend.services.songwriting_service import songwriting_service
+
+router = APIRouter(prefix="/songwriting", tags=["songwriting"])
+
+
+class PromptPayload(BaseModel):
+    prompt: str
+    style: str
+
+
+class DraftUpdate(BaseModel):
+    lyrics: str | None = None
+    chords: str | None = None
+
+
+@router.post("/prompt")
+async def submit_prompt(payload: PromptPayload, user_id: int = Depends(get_current_user_id)):
+    draft = await songwriting_service.generate_draft(user_id, payload.prompt, payload.style)
+    return draft
+
+
+@router.get("/drafts/{draft_id}")
+def get_draft(draft_id: int, user_id: int = Depends(get_current_user_id)):
+    draft = songwriting_service.get_draft(draft_id)
+    if not draft or draft.creator_id != user_id:
+        raise HTTPException(status_code=404, detail="draft_not_found")
+    return draft
+
+
+@router.put("/drafts/{draft_id}")
+def edit_draft(draft_id: int, updates: DraftUpdate, user_id: int = Depends(get_current_user_id)):
+    draft = songwriting_service.update_draft(draft_id, user_id, lyrics=updates.lyrics, chords=updates.chords)
+    return draft
+
+
+# --- WebSocket for collaborative editing --------------------------------------
+_subscribers: Dict[int, Set[WebSocket]] = {}
+
+
+@router.websocket("/ws/{draft_id}")
+async def songwriting_ws(ws: WebSocket, draft_id: int) -> None:
+    await ws.accept()
+    subs = _subscribers.setdefault(draft_id, set())
+    subs.add(ws)
+    try:
+        while True:
+            msg = await ws.receive_text()
+            for peer in list(subs):
+                if peer is not ws:
+                    await peer.send_text(msg)
+    except WebSocketDisconnect:  # pragma: no cover - network event
+        subs.discard(ws)
+        if not subs:
+            _subscribers.pop(draft_id, None)

--- a/backend/services/songwriting_service.py
+++ b/backend/services/songwriting_service.py
@@ -1,0 +1,93 @@
+"""Service for AI-assisted songwriting generation and storage."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from typing import Protocol, List
+
+from backend.models.song import Song
+from backend.models.songwriting import LyricDraft
+
+
+class _Message:
+    """Lightweight message object passed to the LLM."""
+
+    def __init__(self, role: str, content: str) -> None:
+        self.role = role
+        self.content = content
+
+
+class LLMProvider(Protocol):
+    async def complete(self, history: List[_Message]) -> str: ...
+
+
+class EchoLLM:
+    async def complete(self, history: List[_Message]) -> str:  # pragma: no cover - trivial
+        if history:
+            return f"Echo: {history[-1].content}"
+        return "..."
+
+
+class SongwritingService:
+    """Generate lyric drafts using an LLM and manage them."""
+
+    def __init__(self, llm_client: Optional[LLMProvider] = None) -> None:
+        self.llm = llm_client or EchoLLM()
+        self._drafts: Dict[int, LyricDraft] = {}
+        self._songs: Dict[int, Song] = {}
+        self._counter = 1
+
+    async def generate_draft(self, creator_id: int, prompt: str, style: str) -> LyricDraft:
+        """Generate lyrics and chord suggestions for a prompt."""
+        lyric_prompt = f"Write song lyrics in {style} style about: {prompt}"
+        lyrics = await self.llm.complete([_Message(role="user", content=lyric_prompt)])
+        chord_prompt = f"Suggest a chord progression for the following lyrics: {lyrics}"
+        chords = await self.llm.complete([_Message(role="user", content=chord_prompt)])
+
+        draft = LyricDraft(
+            id=self._counter,
+            creator_id=creator_id,
+            prompt=prompt,
+            style=style,
+            lyrics=lyrics,
+            chords=chords,
+        )
+        self._drafts[draft.id] = draft
+        song = Song(
+            id=draft.id,
+            title=prompt[:30],
+            duration_sec=0,
+            genre=style,
+            lyrics=lyrics,
+            owner_band_id=creator_id,
+        )
+        self._songs[draft.id] = song
+        self._counter += 1
+        return draft
+
+    def get_draft(self, draft_id: int) -> Optional[LyricDraft]:
+        return self._drafts.get(draft_id)
+
+    def list_drafts(self, creator_id: int) -> List[LyricDraft]:
+        return [d for d in self._drafts.values() if d.creator_id == creator_id]
+
+    def update_draft(
+        self, draft_id: int, user_id: int, *, lyrics: Optional[str] = None, chords: Optional[str] = None
+    ) -> LyricDraft:
+        draft = self._drafts.get(draft_id)
+        if not draft:
+            raise KeyError("draft_not_found")
+        if draft.creator_id != user_id:
+            raise PermissionError("forbidden")
+        if lyrics is not None:
+            draft.lyrics = lyrics
+            self._songs[draft_id].lyrics = lyrics
+        if chords is not None:
+            draft.chords = chords
+        return draft
+
+    def get_song(self, draft_id: int) -> Optional[Song]:
+        return self._songs.get(draft_id)
+
+
+songwriting_service = SongwritingService()

--- a/backend/tests/songwriting/test_songwriting_service.py
+++ b/backend/tests/songwriting/test_songwriting_service.py
@@ -1,0 +1,40 @@
+import pytest
+
+import asyncio
+import pytest
+
+from backend.services.songwriting_service import SongwritingService
+
+
+class FakeLLM:
+    async def complete(self, history):
+        last = history[-1].content
+        if "chord" in last.lower():
+            return "C G Am F"
+        return "la la la"
+
+
+def test_generate_and_store_draft():
+    async def run():
+        svc = SongwritingService(llm_client=FakeLLM())
+        draft = await svc.generate_draft(creator_id=1, prompt="love story", style="rock")
+        assert draft.lyrics == "la la la"
+        assert draft.chords == "C G Am F"
+        song = svc.get_song(draft.id)
+        assert song is not None
+        assert song.lyrics == draft.lyrics
+        assert song.owner_band_id == 1
+
+    asyncio.run(run())
+
+
+def test_permission_on_update():
+    async def run():
+        svc = SongwritingService(llm_client=FakeLLM())
+        draft = await svc.generate_draft(creator_id=1, prompt="sad", style="blues")
+        svc.update_draft(draft.id, user_id=1, lyrics="updated")
+        assert svc.get_draft(draft.id).lyrics == "updated"
+        with pytest.raises(PermissionError):
+            svc.update_draft(draft.id, user_id=2, lyrics="hack")
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- define models for lyric drafts and metadata
- add songwriting service for LLM-generated lyric and chord drafts
- expose REST and WebSocket endpoints for songwriting drafts
- test songwriting service generation and permissions

## Testing
- `python -m pytest backend/tests/songwriting/test_songwriting_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af7c842ed08325b5bd8af8be9e47fc