### PR TITLE
Add festival builder model, service, routes, and tests

### DIFF
--- a/backend/models/festival_builder.py
+++ b/backend/models/festival_builder.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class TicketTier:
+    """Simple ticket tier representation for a festival."""
+
+    name: str
+    price_cents: int
+    capacity: int
+    sold: int = 0
+
+
+@dataclass
+class Slot:
+    """Represents a stage timeslot that can host a band."""
+
+    stage: str
+    index: int
+    band_id: Optional[int] = None
+
+
+@dataclass
+class Stage:
+    """Collection of slots for a stage."""
+
+    name: str
+    slots: List[Slot] = field(default_factory=list)
+
+
+@dataclass
+class Sponsor:
+    """Festival sponsor contributing funds."""
+
+    name: str
+    contribution_cents: int
+
+
+@dataclass
+class FestivalBuilder:
+    """Aggregate object capturing a festival under construction."""
+
+    id: int
+    name: str
+    owner_id: int
+    stages: Dict[str, Stage] = field(default_factory=dict)
+    ticket_tiers: List[TicketTier] = field(default_factory=list)
+    sponsors: List[Sponsor] = field(default_factory=list)
+    finances: Dict[str, int] = field(default_factory=lambda: {"revenue": 0, "payouts": 0})
+    tickets: List[object] = field(default_factory=list)  # ticketing_models.Ticket instances

--- a/backend/routes/festival_builder_routes.py
+++ b/backend/routes/festival_builder_routes.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from auth.dependencies import get_current_user_id, require_role
+from backend.models.festival_builder import FestivalBuilder
+from backend.services.festival_builder_service import (
+    BookingConflictError,
+    FestivalBuilderService,
+    FestivalError,
+)
+
+router = APIRouter(prefix="/festival-builder", tags=["festival-builder"])
+_service = FestivalBuilderService()
+
+
+# Dependency to allow test overrides
+def get_service() -> FestivalBuilderService:
+    return _service
+
+
+# ----------- Admin endpoints -----------
+@router.post("/admin/festivals", dependencies=[Depends(require_role(["admin"]))])
+def create_festival(payload: dict, svc: FestivalBuilderService = Depends(get_service)) -> dict:
+    fid = svc.create_festival(
+        name=payload["name"],
+        owner_id=payload.get("owner_id", 0),
+        stages=payload.get("stages", {}),
+        ticket_tiers=payload.get("ticket_tiers", []),
+        sponsors=payload.get("sponsors"),
+    )
+    fest = svc.get_festival(fid)
+    return {"id": fest.id, "name": fest.name}
+
+
+@router.post(
+    "/admin/festivals/{festival_id}/book",
+    dependencies=[Depends(require_role(["admin"]))],
+)
+def book_act(
+    festival_id: int,
+    payload: dict,
+    svc: FestivalBuilderService = Depends(get_service),
+) -> dict:
+    try:
+        svc.book_act(
+            festival_id=festival_id,
+            stage_name=payload["stage"],
+            slot_index=int(payload["slot"]),
+            band_id=int(payload["band_id"]),
+            payout_cents=int(payload.get("payout_cents", 0)),
+        )
+        return {"status": "ok"}
+    except BookingConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except FestivalError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.get(
+    "/admin/festivals/{festival_id}/finances",
+    dependencies=[Depends(require_role(["admin"]))],
+)
+def get_finances(
+    festival_id: int, svc: FestivalBuilderService = Depends(get_service)
+) -> dict:
+    return svc.get_finances(festival_id)
+
+
+# ----------- Player endpoints -----------
+@router.get("/player/festivals/{festival_id}")
+def get_festival(
+    festival_id: int, svc: FestivalBuilderService = Depends(get_service)
+) -> FestivalBuilder:
+    try:
+        return svc.get_festival(festival_id)
+    except FestivalError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.post("/player/festivals/{festival_id}/tickets")
+def purchase_tickets(
+    festival_id: int,
+    payload: dict,
+    user_id: int = Depends(get_current_user_id),
+    svc: FestivalBuilderService = Depends(get_service),
+) -> dict:
+    try:
+        revenue = svc.sell_tickets(
+            festival_id, payload["tier"], int(payload.get("qty", 1)), user_id
+        )
+        return {"revenue": revenue}
+    except FestivalError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/backend/services/festival_builder_service.py
+++ b/backend/services/festival_builder_service.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from backend.models.festival_builder import (
+    FestivalBuilder,
+    Slot,
+    Stage,
+    Sponsor,
+    TicketTier,
+)
+from backend.models.ticketing_models import Ticket
+from backend.services.economy_service import EconomyService
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class FestivalError(Exception):
+    pass
+
+
+class BookingConflictError(FestivalError):
+    """Raised when attempting to double book a slot."""
+
+
+class FestivalBuilderService:
+    """Service handling festival creation and basic finance tracking."""
+
+    def __init__(self, db_path: Optional[str] = None, economy: EconomyService | None = None):
+        self.db_path = str(db_path or DB_PATH)
+        self.economy = economy or EconomyService(db_path=self.db_path)
+        self.economy.ensure_schema()
+        self._festivals: Dict[int, FestivalBuilder] = {}
+        self._id_seq = 1
+
+    # ---------------- Festival lifecycle ----------------
+    def create_festival(
+        self,
+        name: str,
+        owner_id: int,
+        stages: Dict[str, int],
+        ticket_tiers: List[Dict[str, int]],
+        sponsors: Optional[List[Dict[str, int]]] = None,
+    ) -> int:
+        stage_objs: Dict[str, Stage] = {}
+        for stage_name, slot_count in stages.items():
+            slots = [Slot(stage=stage_name, index=i) for i in range(int(slot_count))]
+            stage_objs[stage_name] = Stage(name=stage_name, slots=slots)
+
+        tier_objs = [
+            TicketTier(
+                name=t["name"],
+                price_cents=int(t["price_cents"]),
+                capacity=int(t["capacity"]),
+            )
+            for t in ticket_tiers
+        ]
+
+        sponsor_objs: List[Sponsor] = []
+        for s in sponsors or []:
+            sponsor_objs.append(
+                Sponsor(name=s["name"], contribution_cents=int(s["contribution_cents"]))
+            )
+
+        fest = FestivalBuilder(
+            id=self._id_seq,
+            name=name,
+            owner_id=owner_id,
+            stages=stage_objs,
+            ticket_tiers=tier_objs,
+            sponsors=sponsor_objs,
+        )
+        self._festivals[fest.id] = fest
+        self._id_seq += 1
+        return fest.id
+
+    def get_festival(self, festival_id: int) -> FestivalBuilder:
+        fest = self._festivals.get(int(festival_id))
+        if not fest:
+            raise FestivalError("Festival not found")
+        return fest
+
+    # ---------------- Lineup management ----------------
+    def book_act(
+        self,
+        festival_id: int,
+        stage_name: str,
+        slot_index: int,
+        band_id: int,
+        payout_cents: int,
+    ) -> None:
+        fest = self.get_festival(festival_id)
+        stage = fest.stages.get(stage_name)
+        if not stage:
+            raise FestivalError("Stage not found")
+        try:
+            slot = stage.slots[slot_index]
+        except IndexError:  # pragma: no cover - defensive
+            raise FestivalError("Invalid slot index") from None
+        if slot.band_id is not None:
+            raise BookingConflictError("Slot already booked")
+        slot.band_id = band_id
+        fest.finances["payouts"] += int(payout_cents)
+        self.economy.deposit(band_id, int(payout_cents))
+
+    # ---------------- Ticket sales ----------------
+    def sell_tickets(
+        self, festival_id: int, tier_name: str, qty: int, buyer_id: int
+    ) -> int:
+        fest = self.get_festival(festival_id)
+        tier = next((t for t in fest.ticket_tiers if t.name == tier_name), None)
+        if not tier:
+            raise FestivalError("Ticket tier not found")
+        qty = int(qty)
+        if tier.sold + qty > tier.capacity:
+            raise FestivalError("Not enough tickets available")
+        tier.sold += qty
+        revenue = tier.price_cents * qty
+        fest.finances["revenue"] += revenue
+        self.economy.deposit(fest.owner_id, revenue)
+        for _ in range(qty):
+            fest.tickets.append(
+                Ticket(
+                    band_id=None,
+                    venue_id=festival_id,
+                    price=tier.price_cents / 100.0,
+                    type=tier.name,
+                    fan_segment=None,
+                    sold=True,
+                )
+            )
+        return revenue
+
+    # ---------------- Finance reporting ----------------
+    def get_finances(self, festival_id: int) -> Dict[str, int]:
+        fest = self.get_festival(festival_id)
+        return dict(fest.finances)

--- a/backend/tests/festival_builder/test_service.py
+++ b/backend/tests/festival_builder/test_service.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.services.festival_builder_service import (
+    BookingConflictError,
+    FestivalBuilderService,
+)
+
+
+def setup_service():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    svc = FestivalBuilderService(db_path=path)
+    return svc
+
+
+def test_creation():
+    svc = setup_service()
+    fid = svc.create_festival(
+        name="TestFest",
+        owner_id=1,
+        stages={"Main": 2},
+        ticket_tiers=[{"name": "GA", "price_cents": 1000, "capacity": 100}],
+        sponsors=[{"name": "Acme", "contribution_cents": 50000}],
+    )
+    fest = svc.get_festival(fid)
+    assert fest.name == "TestFest"
+    assert "Main" in fest.stages
+    assert fest.ticket_tiers[0].name == "GA"
+
+
+def test_booking_conflict():
+    svc = setup_service()
+    fid = svc.create_festival(
+        "Fest",
+        owner_id=1,
+        stages={"Stage": 1},
+        ticket_tiers=[{"name": "GA", "price_cents": 1000, "capacity": 10}],
+    )
+    svc.book_act(fid, "Stage", 0, band_id=2, payout_cents=500)
+    with pytest.raises(BookingConflictError):
+        svc.book_act(fid, "Stage", 0, band_id=3, payout_cents=500)
+
+
+def test_financial_reconciliation():
+    svc = setup_service()
+    fid = svc.create_festival(
+        "Fest",
+        owner_id=1,
+        stages={"Stage": 1},
+        ticket_tiers=[{"name": "GA", "price_cents": 1500, "capacity": 10}],
+    )
+    svc.sell_tickets(fid, "GA", 2, buyer_id=5)
+    svc.book_act(fid, "Stage", 0, band_id=2, payout_cents=500)
+    finances = svc.get_finances(fid)
+    assert finances["revenue"] == 3000
+    assert finances["payouts"] == 500
+    assert svc.economy.get_balance(1) == 3000
+    assert svc.economy.get_balance(2) == 500


### PR DESCRIPTION
## Summary
- add FestivalBuilder dataclasses to capture stages, slots, sponsors, ticket tiers
- implement FestivalBuilderService for festival creation, lineup booking with payouts, and ticket sales
- expose admin and player endpoints for managing festivals and buying tickets
- test creation, booking conflicts, and financial reconciliation

## Testing
- `pytest backend/tests/festival_builder/test_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7f710f508325abfc17c36a1c62ad