### PR TITLE
Implement core logging and metrics utilities

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,1 +1,9 @@
-<contents of backend/api.py here>
+"""Expose the FastAPI application instance.
+
+This tiny module allows tools like ``uvicorn`` to load the pre-configured
+application by importing :mod:`backend.api`.
+"""
+
+from .main import app
+
+__all__ = ["app"]

--- a/backend/core/logging.py
+++ b/backend/core/logging.py
@@ -1,1 +1,46 @@
-<contents of backend/core/logging.py here>
+"""Minimal logging helpers for the backend.
+
+These utilities provide a JSON based log formatter and convenience
+functions to configure and retrieve loggers.  They are intentionally
+light‑weight but fully functional so that other modules can rely on
+``core.logging`` without pulling in heavy dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as a JSON object."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+        log_record: Dict[str, Any] = {
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure the root logger to emit structured JSON logs."""
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger with *name*."""
+
+    return logging.getLogger(name)
+
+
+__all__ = ["JsonFormatter", "setup_logging", "get_logger"]

--- a/backend/core/metrics.py
+++ b/backend/core/metrics.py
@@ -1,1 +1,67 @@
-<contents of backend/core/metrics.py here>
+"""Tiny in-memory metrics helpers.
+
+This module provides a very small subset of the Prometheus client API.  It is
+used to track metrics without requiring an additional dependency.  Only what
+is needed by the application is implemented.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Dict, Iterable, Tuple
+
+_REGISTRY: Dict[str, "Counter"] = {}
+
+
+class Counter:
+    """A minimal counter implementation."""
+
+    def __init__(self, name: str, description: str, labelnames: Iterable[str] = ()):  # pragma: no cover - simple container
+        self.name = name
+        self.description = description
+        self.labelnames = tuple(labelnames)
+        self._values: Dict[Tuple[str, ...], int] = {}
+        self._lock = threading.Lock()
+        _REGISTRY[self.name] = self
+
+    class _LabelCounter:
+        def __init__(self, parent: "Counter", key: Tuple[str, ...]):
+            self._parent = parent
+            self._key = key
+
+        def inc(self, amount: int = 1) -> None:
+            with self._parent._lock:
+                self._parent._values[self._key] = self._parent._values.get(self._key, 0) + amount
+
+    def labels(self, *labelvalues: str) -> "Counter._LabelCounter":
+        if len(labelvalues) != len(self.labelnames):
+            raise ValueError("Incorrect label count")
+        key = tuple(labelvalues)
+        with self._lock:
+            self._values.setdefault(key, 0)
+        return Counter._LabelCounter(self, key)
+
+    def collect(self):  # pragma: no cover - trivial iteration
+        for labels, value in self._values.items():
+            yield labels, value
+
+
+def generate_latest() -> bytes:
+    """Render the current metrics in Prometheus text format."""
+
+    lines = []
+    for counter in _REGISTRY.values():
+        lines.append(f"# HELP {counter.name} {counter.description}")
+        lines.append(f"# TYPE {counter.name} counter")
+        for labels, value in counter.collect():
+            if counter.labelnames:
+                label_str = ",".join(f'{n}="{v}"' for n, v in zip(counter.labelnames, labels))
+                lines.append(f"{counter.name}{{{label_str}}} {value}")
+            else:
+                lines.append(f"{counter.name} {value}")
+    return "\n".join(lines).encode("utf-8")
+
+
+CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+
+__all__ = ["Counter", "generate_latest", "CONTENT_TYPE_LATEST"]


### PR DESCRIPTION
## Summary
- expose `backend.api` as the configured FastAPI application
- add functional JSON logging helpers in `core.logging`
- implement lightweight Prometheus-style metrics in `core.metrics`

## Testing
- `pytest` *(fails: ImportError for fastapi WebSocket and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68af811d64308325a8dbe5f6720230d3