### PR TITLE
Refactor admin router aggregation

### DIFF
--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -3,22 +3,28 @@
 from fastapi import APIRouter
 
 from .admin_analytics_routes import router as analytics_router
+from .admin_audit_routes import router as audit_router
 from .admin_business_routes import router as business_router
 from .admin_economy_routes import router as economy_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
-from .admin_npc_routes import router as npc_router
-codex/expose-monitoring-metrics-in-backend
 from .admin_monitoring_routes import router as monitoring_router
-
-
-
-=======
+from .admin_npc_routes import router as npc_router
 from .admin_quest_routes import router as quest_router
-codex/create-schema-and-preview-endpoints
 from .admin_schema_routes import router as schema_router
+from .admin_venue_routes import router as venue_router
 
-codex/expose-monitoring-metrics-in-backend
+router = APIRouter()
+
+router.include_router(analytics_router)
+router.include_router(audit_router)
+router.include_router(business_router)
+router.include_router(economy_router)
+router.include_router(jobs_router)
+router.include_router(media_router)
 router.include_router(monitoring_router)
-
+router.include_router(npc_router)
+router.include_router(quest_router)
+router.include_router(schema_router)
+router.include_router(venue_router)
 


### PR DESCRIPTION
## Summary
- rewrite admin router to aggregate all admin sub-routers in one APIRouter

## Testing
- `ruff check backend/routes/admin_routes.py`
- `pytest backend/tests/admin -q` *(fails: assert 1000 == 900 in test_admin_economy_config_updates; AttributeError 'EconomyService' has no attribute 'withdraw' in test_admin_venue_business_flow)*

------
https://chatgpt.com/codex/tasks/task_e_68af824f766083259406ffe9965c8c4c