### PR TITLE
Refactor route imports for backend services

### DIFF
--- a/backend/routes/chat_routes.py
+++ b/backend/routes/chat_routes.py
@@ -1,17 +1,28 @@
-from auth.dependencies import get_current_user_id, require_role
-from fastapi import APIRouter
-from services.chat_service import *
-from schemas.chat_schemas import MessageSchema, GroupMessageSchema
+from schemas.chat_schemas import GroupMessageSchema, MessageSchema
+
+from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.services.chat_service import (
+    get_user_chat_history,
+    send_group_chat,
+    send_message,
+)
+from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 
 router = APIRouter()
 
-@router.post("/chat/send_direct", dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
+
+@router.post(
+    "/chat/send_direct",
+    dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))],
+)
 def send_direct_message(payload: MessageSchema):
     return send_message(payload.dict())
+
 
 @router.post("/chat/send_group")
 def send_group_message(payload: GroupMessageSchema):
     return send_group_chat(payload.dict())
+
 
 @router.get("/chat/history/")
 def get_chat_history(user_id: int):

--- a/backend/routes/dashboard_routes.py
+++ b/backend/routes/dashboard_routes.py
@@ -1,26 +1,19 @@
-from auth.dependencies import require_role
 # File: backend/routes/dashboard_routes.py
-from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import Optional
 
-from services.dashboard_service import DashboardService
-
-# Replace with your real auth; for now derive user_id from dependency
-try:
-    from auth.dependencies import get_current_user_id
-except Exception:
-    async def get_current_user_id():
-        # DEV fallback (user_id=1)
-        return 1
+from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.services.dashboard_service import DashboardService
+from fastapi import APIRouter, Depends, HTTPException, Query, Request  # noqa: F401
 
 router = APIRouter(prefix="/dashboard", tags=["Dashboard"])
 svc = DashboardService()
+
 
 @router.get("/summary")
 async def dashboard_summary(
     user_id: int = Depends(get_current_user_id),
     band_id: Optional[int] = Query(None),
-    top_n: int = Query(10, ge=1, le=50)
+    top_n: int = Query(10, ge=1, le=50),
 ):
     try:
         return svc.summary(user_id=user_id, band_id=band_id, top_n=top_n)

--- a/backend/routes/music_metrics_routes.py
+++ b/backend/routes/music_metrics_routes.py
@@ -1,11 +1,13 @@
-from auth.dependencies import get_current_user_id, require_role
 # File: backend/routes/music_metrics_routes.py
-from fastapi import APIRouter, Depends
 from typing import Optional
-from services.music_metrics import MusicMetricsService
+
+from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.services.music_metrics import MusicMetricsService
+from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 
 router = APIRouter(prefix="/music/metrics", tags=["Music Metrics"])
 svc = MusicMetricsService()
+
 
 @router.get("/totals")
 def get_totals(album_id: Optional[int] = None, song_id: Optional[int] = None):

--- a/backend/routes/sponsorship.py
+++ b/backend/routes/sponsorship.py
@@ -1,33 +1,33 @@
-from auth.dependencies import get_current_user_id, require_role
-# File: backend/routes/sponsorship.py
-from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel, Field
-from typing import Optional, List, Dict, Any
 import os
+from typing import Any, Dict, List, Optional
+
 from utils.i18n import _
 
-# Import style chosen to match many existing projects where routes/ and services/ are siblings
-from services.sponsorship_service import SponsorshipService
+from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.services.sponsorship_service import SponsorshipService
+from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
+from pydantic import BaseModel, Field
 
 router = APIRouter(prefix="/api/sponsorships", tags=["Sponsorships"])
+
 
 def get_service() -> SponsorshipService:
     # Use env var if present, else default SQLite in CWD
     db_path = os.environ.get("DEVMIND_DB_PATH") or "devmind_schema.db"
     return SponsorshipService(db_path)
 
+
 # ---------- Models ----------
 class SponsorIn(BaseModel):
-    
-name: str
+    name: str
     website_url: Optional[str] = None
     logo_url: Optional[str] = None
     contact_email: Optional[str] = None
     notes: Optional[str] = None
 
+
 class VenueSponsorshipIn(BaseModel):
-    
-venue_id: int
+    venue_id: int
     sponsor_id: int
     start_date: str = Field(..., description="YYYY-MM-DD")
     end_date: Optional[str] = Field(None, description="YYYY-MM-DD or null")
@@ -40,11 +40,12 @@ venue_id: int
     fixed_fee_cents: Optional[int] = None
     currency: str = "USD"
 
+
 class AdEventIn(BaseModel):
-    
-sponsorship_id: int
+    sponsorship_id: int
     event_type: str  # 'impression' | 'click'
     meta_json: Optional[str] = None
+
 
 # ---------- Sponsor admin ----------
 @router.post("/admin/sponsors", response_model=Dict[str, int])
@@ -52,39 +53,61 @@ async def create_sponsor(payload: SponsorIn, svc: SponsorshipService = Depends(g
     sponsor_id = await svc.create_sponsor(payload.dict())
     return {"id": sponsor_id}
 
+
 @router.get("/admin/sponsors", response_model=List[Dict[str, Any]])
 async def list_sponsors(svc: SponsorshipService = Depends(get_service)):
     return await svc.list_sponsors()
 
+
 @router.patch("/admin/sponsors/{sponsor_id}")
-async def update_sponsor(sponsor_id: int, payload: Dict[str, Any], svc: SponsorshipService = Depends(get_service)):
+async def update_sponsor(
+    sponsor_id: int, payload: Dict[str, Any], svc: SponsorshipService = Depends(get_service)
+):
     await svc.update_sponsor(sponsor_id, payload)
     return {"ok": True}
+
 
 @router.delete("/admin/sponsors/{sponsor_id}")
 async def delete_sponsor(sponsor_id: int, svc: SponsorshipService = Depends(get_service)):
     await svc.delete_sponsor(sponsor_id)
     return {"ok": True}
 
+
 # ---------- Venue sponsorship admin ----------
 @router.post("/admin/venue", response_model=Dict[str, int])
-async def create_venue_sponsorship(payload: VenueSponsorshipIn, svc: SponsorshipService = Depends(get_service)):
+async def create_venue_sponsorship(
+    payload: VenueSponsorshipIn, svc: SponsorshipService = Depends(get_service)
+):
     sponsorship_id = await svc.create_venue_sponsorship(payload.dict())
     return {"id": sponsorship_id}
 
+
 @router.get("/admin/venue", response_model=List[Dict[str, Any]])
-async def list_venue_sponsorships(venue_id: Optional[int] = None, active_only: bool = False, svc: SponsorshipService = Depends(get_service)):
+async def list_venue_sponsorships(
+    venue_id: Optional[int] = None,
+    active_only: bool = False,
+    svc: SponsorshipService = Depends(get_service),
+):
     return await svc.list_venue_sponsorships(venue_id=venue_id, active_only=active_only)
 
+
 @router.patch("/admin/venue/{sponsorship_id}")
-async def update_venue_sponsorship(sponsorship_id: int, payload: Dict[str, Any], svc: SponsorshipService = Depends(get_service)):
+async def update_venue_sponsorship(
+    sponsorship_id: int, payload: Dict[str, Any], svc: SponsorshipService = Depends(get_service)
+):
     await svc.update_venue_sponsorship(sponsorship_id, payload)
     return {"ok": True}
 
+
 @router.post("/admin/venue/{sponsorship_id}/end")
-async def end_venue_sponsorship(sponsorship_id: int, end_date: Optional[str] = None, svc: SponsorshipService = Depends(get_service)):
+async def end_venue_sponsorship(
+    sponsorship_id: int,
+    end_date: Optional[str] = None,
+    svc: SponsorshipService = Depends(get_service),
+):
     await svc.end_venue_sponsorship(sponsorship_id, end_date)
     return {"ok": True}
+
 
 # ---------- Public helpers ----------
 @router.get("/venue/{venue_id}")
@@ -94,11 +117,13 @@ async def get_venue_with_sponsorship(venue_id: int, svc: SponsorshipService = De
     except ValueError:
         raise HTTPException(status_code=404, detail=_("Venue not found"))
 
+
 # ---------- Tracking ----------
 @router.post("/events")
 async def record_ad_event(payload: AdEventIn, svc: SponsorshipService = Depends(get_service)):
     await svc.record_ad_event(payload.sponsorship_id, payload.event_type, payload.meta_json)
     return {"ok": True}
+
 
 @router.get("/events/{sponsorship_id}/rollup")
 async def ad_rollup(sponsorship_id: int, svc: SponsorshipService = Depends(get_service)):

--- a/backend/routes/video_routes.py
+++ b/backend/routes/video_routes.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter, HTTPException
-
-from services.video_service import VideoService
-from services.economy_service import EconomyService
+from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.services.economy_service import EconomyService
+from backend.services.video_service import VideoService
+from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 
 router = APIRouter()
 


### PR DESCRIPTION
## Summary
- Standardize FastAPI and auth imports across router modules
- Update service imports to use the `backend.services` package
- Keep router prefixes, tags, and dependencies consistent

## Testing
- `ruff check backend/routes/video_routes.py backend/routes/sponsorship.py backend/routes/music_metrics_routes.py backend/routes/dashboard_routes.py backend/routes/chat_routes.py backend/routes/merch_routes.py`
- `pytest` *(fails: ImportError: cannot import name 'WebSocket' from 'fastapi', ModuleNotFoundError: No module named 'fastapi.exceptions', ModuleNotFoundError: No module named 'starlette', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68af833d13408325bef273692d8c22d5