### PR TITLE
refactor: use explicit backend imports in analytics modules

### DIFF
--- a/backend/routes/admin_analytics_routes.py
+++ b/backend/routes/admin_analytics_routes.py
@@ -1,13 +1,14 @@
 # File: backend/routes/admin_analytics_routes.py
-from fastapi import APIRouter, HTTPException, Request, Depends
-from auth.dependencies import get_current_user_id, require_role
-from services.analytics_service import AnalyticsService
-from services.admin_service import AdminService
 from services.admin_audit_service import audit_dependency
+from services.admin_service import AdminService
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services.analytics_service import AnalyticsService
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 # Auth middleware / role dependency hook
 try:
-    from auth.dependencies import require_role
+    from backend.auth.dependencies import require_role
 except Exception:
     def require_role(roles):
         async def _noop():

--- a/backend/routes/analytics_routes.py
+++ b/backend/routes/analytics_routes.py
@@ -6,14 +6,14 @@ except Exception:  # pragma: no cover - fallback for stubs
     def Depends(dependency):  # type: ignore
         return dependency
 
-from auth.dependencies import require_role
-from services.analytics_service import AnalyticsService
-from services.fan_insight_service import FanInsightService
-from models.analytics import (
+from backend.auth.dependencies import require_role
+from backend.models.analytics import (
     AggregatedMetrics,
     FanSegmentSummary,
     FanTrends,
 )
+from backend.services.analytics_service import AnalyticsService
+from backend.services.fan_insight_service import FanInsightService
 
 router = APIRouter(prefix="/analytics", tags=["Analytics"])
 svc = AnalyticsService()

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -8,13 +8,14 @@ section is simply skipped so the API still returns useful data.
 """
 
 import sqlite3
-from pathlib import Path
-from typing import Optional, Dict, Any, List
 from datetime import datetime, timedelta
 from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from utils.db import get_conn
-from models.analytics import MetricPoint, AggregatedMetrics
+
+from backend.models.analytics import AggregatedMetrics, MetricPoint
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/backend/services/fan_insight_service.py
+++ b/backend/services/fan_insight_service.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 from utils.db import cached_query
-from models.analytics import (
+
+from backend.models.analytics import (
     AgeBucket,
-    RegionBucket,
-    SpendBucket,
     FanSegmentSummary,
     FanTrends,
     MetricPoint,
+    RegionBucket,
+    SpendBucket,
 )
 
 

--- a/backend/tests/analytics/test_analytics.py
+++ b/backend/tests/analytics/test_analytics.py
@@ -1,12 +1,13 @@
 import asyncio
 
 import pytest
-from auth.jwt import encode, now_ts
-from auth.dependencies import get_current_user_id, require_role
-from core.config import settings
-from services.analytics_service import AnalyticsService
-from utils.db import get_conn
 import utils.db as db_utils
+from auth.jwt import encode, now_ts
+from core.config import settings
+from utils.db import get_conn
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services.analytics_service import AnalyticsService
 from fastapi import HTTPException, Request
 
 DDL = """

--- a/backend/tests/analytics/test_fan_insights.py
+++ b/backend/tests/analytics/test_fan_insights.py
@@ -1,6 +1,7 @@
 import utils.db as db_utils
 from utils.db import get_conn
-from services.fan_insight_service import FanInsightService
+
+from backend.services.fan_insight_service import FanInsightService
 
 DDL = """
 CREATE TABLE users(id INTEGER PRIMARY KEY, age INTEGER, region TEXT);


### PR DESCRIPTION
## Summary
- use fully qualified backend paths for auth dependencies, analytics service, and analytics models across analytics routes, services, and tests
- organize imports and ensure linter clean

## Testing
- `ruff check backend/routes/admin_analytics_routes.py backend/routes/analytics_routes.py backend/tests/analytics/test_analytics.py backend/services/analytics_service.py backend/services/fan_insight_service.py backend/tests/analytics/test_fan_insights.py`


------
https://chatgpt.com/codex/tasks/task_e_68af87661c448325a33ad79476da07cb