### PR TITLE
Implement rehearsal scheduling with skill bonuses

### DIFF
--- a/backend/models/band.py
+++ b/backend/models/band.py
@@ -1,6 +1,11 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, Boolean, DateTime, func
 from sqlalchemy.ext.declarative import declarative_base
 
+# additional imports for extended band modelling
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
 Base = declarative_base()
 
 class Band(Base):
@@ -11,6 +16,9 @@ class Band(Base):
     founder_id = Column(Integer, ForeignKey("characters.id"))
     genre = Column(String)
     formed_at = Column(DateTime(timezone=True), server_default=func.now())
+    # aggregate skill metric and upcoming performance quality modifier
+    skill = Column(Integer, default=0)
+    performance_quality = Column(Integer, default=0)
 
 class BandMember(Base):
     __tablename__ = "band_members"
@@ -31,3 +39,67 @@ class BandCollaboration(Base):
     project_type = Column(String)  # "song" or "album"
     title = Column(String)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+# ---------------------------------------------------------------------------
+# Extended models for band lineup, skills and availability
+# ---------------------------------------------------------------------------
+
+
+class BandLineupSlot(Base):
+    """Represents a required role in the band's lineup."""
+
+    __tablename__ = "band_lineup_slots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    band_id = Column(Integer, ForeignKey("bands.id"), nullable=False)
+    role = Column(String, nullable=False)
+    required_skill = Column(String, nullable=True)
+    min_level = Column(Integer, default=0)
+
+
+class BandSkill(Base):
+    """Tracks a band's proficiency for a given skill."""
+
+    __tablename__ = "band_skills"
+
+    id = Column(Integer, primary_key=True, index=True)
+    band_id = Column(Integer, ForeignKey("bands.id"), nullable=False)
+    skill = Column(String, nullable=False)
+    level = Column(Integer, default=0)
+
+
+class BandAvailability(Base):
+    """Availability window for rehearsal or events."""
+
+    __tablename__ = "band_availability"
+
+    id = Column(Integer, primary_key=True, index=True)
+    band_id = Column(Integer, ForeignKey("bands.id"), nullable=False)
+    start = Column(DateTime(timezone=True), nullable=False)
+    end = Column(DateTime(timezone=True), nullable=False)
+
+
+# Convenience dataclasses for service layer consumption
+
+
+@dataclass
+class AvailabilityWindow:
+    band_id: int
+    start: datetime
+    end: datetime
+
+
+@dataclass
+class LineupSlot:
+    band_id: int
+    role: str
+    required_skill: Optional[str] = None
+    min_level: int = 0
+
+
+@dataclass
+class SkillProgress:
+    band_id: int
+    skill: str
+    level: int

--- a/backend/routes/rehearsal_routes.py
+++ b/backend/routes/rehearsal_routes.py
@@ -1,0 +1,50 @@
+"""API routes for rehearsal scheduling and attendance."""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import List
+
+from services.rehearsal_service import RehearsalService
+
+
+router = APIRouter(prefix="/rehearsals", tags=["Rehearsals"])
+svc = RehearsalService()
+
+
+class RehearsalIn(BaseModel):
+    band_id: int
+    start: str
+    end: str
+    attendees: List[int] = []
+
+
+@router.post("/")
+def schedule_rehearsal(payload: RehearsalIn):
+    try:
+        return svc.book_session(
+            band_id=payload.band_id,
+            start=payload.start,
+            end=payload.end,
+            attendees=payload.attendees,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+class AttendanceIn(BaseModel):
+    member_id: int
+
+
+@router.post("/{rehearsal_id}/attendance")
+def mark_attendance(rehearsal_id: int, payload: AttendanceIn):
+    svc.record_attendance(rehearsal_id, payload.member_id)
+    return {"rehearsal_id": rehearsal_id, "member_id": payload.member_id}
+
+
+@router.get("/{rehearsal_id}/attendance")
+def get_attendance(rehearsal_id: int):
+    return svc.attendance(rehearsal_id)
+
+
+__all__ = ["router"]
+

--- a/backend/services/rehearsal_service.py
+++ b/backend/services/rehearsal_service.py
@@ -1,0 +1,151 @@
+"""Service for managing band rehearsal sessions.
+
+This module provides minimal scheduling with conflict detection and
+practice bonuses that feed back into a band's skill progression and
+upcoming performance quality.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class RehearsalService:
+    """Simple SQLite backed rehearsal scheduler."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+
+    def _conn(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        return conn
+
+    def _ensure_schema(self) -> None:
+        """Create required tables if they do not yet exist."""
+
+        with self._conn() as conn:
+            c = conn.cursor()
+            c.execute(
+                """
+                CREATE TABLE IF NOT EXISTS bands (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT,
+                    skill REAL DEFAULT 0,
+                    performance_quality REAL DEFAULT 0
+                )
+                """
+            )
+            c.execute(
+                """
+                CREATE TABLE IF NOT EXISTS rehearsals (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    band_id INTEGER NOT NULL,
+                    start TEXT NOT NULL,
+                    end TEXT NOT NULL,
+                    attendees TEXT,
+                    bonus REAL DEFAULT 0,
+                    FOREIGN KEY(band_id) REFERENCES bands(id)
+                )
+                """
+            )
+            c.execute(
+                """
+                CREATE TABLE IF NOT EXISTS rehearsal_attendance (
+                    rehearsal_id INTEGER,
+                    member_id INTEGER,
+                    UNIQUE(rehearsal_id, member_id)
+                )
+                """
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+
+    def book_session(
+        self, band_id: int, start: str, end: str, attendees: Iterable[int]
+    ) -> dict:
+        """Book a rehearsal session.
+
+        Raises:
+            ValueError: if the booking conflicts with an existing session.
+        """
+
+        start_dt = datetime.fromisoformat(start)
+        end_dt = datetime.fromisoformat(end)
+        if end_dt <= start_dt:
+            raise ValueError("End must be after start")
+
+        with self._conn() as conn:
+            c = conn.cursor()
+            c.execute(
+                "SELECT start, end FROM rehearsals WHERE band_id = ?",
+                (band_id,),
+            )
+            for row in c.fetchall():
+                exist_start = datetime.fromisoformat(row[0])
+                exist_end = datetime.fromisoformat(row[1])
+                if not (end_dt <= exist_start or start_dt >= exist_end):
+                    raise ValueError("Booking conflict")
+
+            attendee_list: List[int] = list(attendees)
+            bonus = float(len(attendee_list)) * 0.5
+            c.execute(
+                """
+                INSERT INTO rehearsals(band_id, start, end, attendees, bonus)
+                VALUES (?,?,?,?,?)
+                """,
+                (
+                    band_id,
+                    start_dt.isoformat(),
+                    end_dt.isoformat(),
+                    ",".join(str(a) for a in attendee_list),
+                    bonus,
+                ),
+            )
+            rehearsal_id = c.lastrowid
+            # update band skills and performance
+            c.execute(
+                "UPDATE bands SET skill = skill + ?, performance_quality = performance_quality + ? WHERE id = ?",
+                (bonus, bonus * 0.5, band_id),
+            )
+            conn.commit()
+        return {"rehearsal_id": rehearsal_id, "bonus": bonus}
+
+    def record_attendance(self, rehearsal_id: int, member_id: int) -> None:
+        """Mark a band member as present for a rehearsal."""
+
+        with self._conn() as conn:
+            c = conn.cursor()
+            c.execute(
+                "INSERT OR IGNORE INTO rehearsal_attendance(rehearsal_id, member_id) VALUES (?, ?)",
+                (rehearsal_id, member_id),
+            )
+            conn.commit()
+
+    def attendance(self, rehearsal_id: int) -> List[int]:
+        """Return a list of member ids that attended a rehearsal."""
+
+        with self._conn() as conn:
+            c = conn.cursor()
+            c.execute(
+                "SELECT member_id FROM rehearsal_attendance WHERE rehearsal_id = ?",
+                (rehearsal_id,),
+            )
+            return [row[0] for row in c.fetchall()]
+
+
+__all__ = ["RehearsalService"]
+

--- a/backend/tests/rehearsal/test_rehearsal_service.py
+++ b/backend/tests/rehearsal/test_rehearsal_service.py
@@ -1,0 +1,37 @@
+import sqlite3
+from backend.services.rehearsal_service import RehearsalService
+
+
+def _setup(tmp_path):
+    db = tmp_path / "test.db"
+    svc = RehearsalService(db)
+    with sqlite3.connect(db) as conn:
+        conn.execute("INSERT INTO bands (id, name) VALUES (1, 'Test')")
+    return svc, db
+
+
+def test_booking_collision(tmp_path):
+    svc, _ = _setup(tmp_path)
+    svc.book_session(1, "2024-01-01T10:00:00", "2024-01-01T12:00:00", [])
+    try:
+        svc.book_session(1, "2024-01-01T11:00:00", "2024-01-01T13:00:00", [])
+    except ValueError:
+        collision = True
+    else:
+        collision = False
+    assert collision, "expected booking conflict"
+
+
+def test_practice_bonus(tmp_path):
+    svc, db = _setup(tmp_path)
+    result = svc.book_session(
+        1, "2024-01-02T10:00:00", "2024-01-02T11:00:00", [1, 2, 3]
+    )
+    assert result["bonus"] == 1.5
+    with sqlite3.connect(db) as conn:
+        skill, quality = conn.execute(
+            "SELECT skill, performance_quality FROM bands WHERE id=1"
+        ).fetchone()
+    assert skill == 1.5
+    assert quality == 0.75
+


### PR DESCRIPTION
## Summary
- expand band models with lineup slots, skills, and availability tracking
- add rehearsal service and routes for booking sessions with practice bonuses
- include tests for booking conflicts and rehearsal bonus calculations

## Testing
- `pytest backend/tests/rehearsal/test_rehearsal_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8d2a8e2c8325ab68ee7b542e69c5