### PR TITLE
Add production workflow models, service, routes and tests

### DIFF
--- a/backend/models/production.py
+++ b/backend/models/production.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+@dataclass
+class Track:
+    """Basic music track used during production."""
+
+    id: int
+    title: str
+    band_id: int
+    duration_sec: int
+    sessions: List[int] = field(default_factory=list)
+    mixing_id: Optional[int] = None
+    release: Optional["ReleaseMetadata"] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "band_id": self.band_id,
+            "duration_sec": self.duration_sec,
+            "sessions": list(self.sessions),
+            "mixing_id": self.mixing_id,
+            "release": self.release.to_dict() if self.release else None,
+        }
+
+
+@dataclass
+class StudioSession:
+    """Represents a recording session for a track."""
+
+    id: int
+    track_id: int
+    scheduled_date: str
+    engineer: str
+    cost_cents: int
+
+    def to_dict(self) -> dict:
+        return self.__dict__.copy()
+
+
+@dataclass
+class MixingSession:
+    """Represents a mixing/mastering session."""
+
+    id: int
+    track_id: int
+    engineer: str
+    cost_cents: int
+    mastered: bool = False
+
+    def to_dict(self) -> dict:
+        return self.__dict__.copy()
+
+
+@dataclass
+class ReleaseMetadata:
+    """Metadata about a released track."""
+
+    track_id: int
+    release_date: str
+    channels: List[str]
+    sales: int = 0
+    chart_position: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        return self.__dict__.copy()

--- a/backend/routes/production_routes.py
+++ b/backend/routes/production_routes.py
@@ -1,0 +1,62 @@
+from flask import Blueprint, jsonify, request
+
+from services.analytics_service import AnalyticsService
+from services.economy_service import EconomyService
+from services.production_service import ProductionService
+
+
+production_routes = Blueprint("production_routes", __name__)
+service = ProductionService(EconomyService(), AnalyticsService())
+
+
+@production_routes.route("/tracks", methods=["POST"])
+def create_track():
+    data = request.json
+    track = service.create_track(
+        data["title"], data["band_id"], data["duration_sec"]
+    )
+    return jsonify(track.to_dict()), 201
+
+
+@production_routes.route("/tracks/<int:track_id>/sessions", methods=["POST"])
+def schedule_session(track_id: int):
+    data = request.json
+    session = service.schedule_session(
+        track_id,
+        data["scheduled_date"],
+        data["engineer"],
+        data["hours"],
+        data["hourly_rate_cents"],
+    )
+    return jsonify(session.to_dict()), 201
+
+
+@production_routes.route("/tracks/<int:track_id>/mix", methods=["POST"])
+def mix_track(track_id: int):
+    data = request.json
+    mix = service.mix_track(
+        track_id, data["engineer"], data["cost_cents"], data.get("mastered", True)
+    )
+    return jsonify(mix.to_dict()), 201
+
+
+@production_routes.route("/tracks/<int:track_id>/release", methods=["POST"])
+def release_track(track_id: int):
+    data = request.json
+    release = service.release_track(
+        track_id,
+        data["release_date"],
+        data.get("channels", []),
+        data["price_cents"],
+        data["sales"],
+    )
+    return jsonify(release.to_dict()), 201
+
+
+@production_routes.route("/tracks/<int:track_id>", methods=["GET"])
+def get_track(track_id: int):
+    track = service.get_track(track_id)
+    if not track:
+        return jsonify({"error": "not found"}), 404
+    return jsonify(track.to_dict())
+

--- a/backend/services/production_service.py
+++ b/backend/services/production_service.py
@@ -1,0 +1,93 @@
+"""Service layer for music production workflows."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from backend.models.production import (
+    MixingSession,
+    ReleaseMetadata,
+    StudioSession,
+    Track,
+)
+
+
+class ProductionService:
+    """Orchestrates recording, mixing and release of tracks."""
+
+    def __init__(self, economy_service=None, analytics_service=None):
+        self.economy = economy_service
+        self.analytics = analytics_service
+        self.tracks: Dict[int, Track] = {}
+        self.sessions: Dict[int, StudioSession] = {}
+        self.mixes: Dict[int, MixingSession] = {}
+        self._next_track_id = 1
+        self._next_session_id = 1
+        self._next_mix_id = 1
+
+    # ------------------ track lifecycle ------------------
+    def create_track(self, title: str, band_id: int, duration_sec: int) -> Track:
+        track = Track(self._next_track_id, title, band_id, duration_sec)
+        self.tracks[track.id] = track
+        self._next_track_id += 1
+        return track
+
+    def schedule_session(
+        self,
+        track_id: int,
+        scheduled_date: str,
+        engineer: str,
+        hours: int,
+        hourly_rate_cents: int,
+    ) -> StudioSession:
+        cost = hours * hourly_rate_cents
+        session = StudioSession(
+            self._next_session_id, track_id, scheduled_date, engineer, cost
+        )
+        self.sessions[session.id] = session
+        self.tracks[track_id].sessions.append(session.id)
+        self._next_session_id += 1
+        return session
+
+    def mix_track(
+        self, track_id: int, engineer: str, cost_cents: int, mastered: bool = True
+    ) -> MixingSession:
+        mix = MixingSession(self._next_mix_id, track_id, engineer, cost_cents, mastered)
+        self.mixes[mix.id] = mix
+        self.tracks[track_id].mixing_id = mix.id
+        self._next_mix_id += 1
+        return mix
+
+    def production_cost(self, track_id: int) -> int:
+        track = self.tracks[track_id]
+        total = sum(self.sessions[sid].cost_cents for sid in track.sessions)
+        if track.mixing_id:
+            total += self.mixes[track.mixing_id].cost_cents
+        return total
+
+    def release_track(
+        self,
+        track_id: int,
+        release_date: str,
+        channels: List[str],
+        price_cents: int,
+        sales: int,
+    ) -> ReleaseMetadata:
+        track = self.tracks[track_id]
+        release = ReleaseMetadata(track_id, release_date, channels, sales)
+        track.release = release
+
+        revenue = price_cents * sales
+        if self.economy is not None:
+            # deposit revenue into band's account
+            self.economy.deposit(track.band_id, revenue)
+        if self.analytics is not None:
+            if hasattr(self.analytics, "record_sale"):
+                self.analytics.record_sale(track_id, sales)
+            if hasattr(self.analytics, "update_charts"):
+                self.analytics.update_charts(track_id, sales)
+        return release
+
+    def get_track(self, track_id: int) -> Optional[Track]:
+        return self.tracks.get(track_id)
+

--- a/backend/tests/production/test_release_flow.py
+++ b/backend/tests/production/test_release_flow.py
@@ -1,0 +1,48 @@
+from backend.services.production_service import ProductionService
+
+
+class FakeEconomy:
+    def __init__(self):
+        self.deposits = []
+
+    def deposit(self, user_id: int, amount_cents: int) -> None:
+        self.deposits.append((user_id, amount_cents))
+
+
+class FakeAnalytics:
+    def __init__(self):
+        self.sales = []
+        self.charts = []
+
+    def record_sale(self, track_id: int, sales: int) -> None:
+        self.sales.append((track_id, sales))
+
+    def update_charts(self, track_id: int, sales: int) -> None:
+        self.charts.append(track_id)
+
+
+def test_end_to_end_release_flow():
+    economy = FakeEconomy()
+    analytics = FakeAnalytics()
+    svc = ProductionService(economy, analytics)
+
+    track = svc.create_track("My Song", band_id=1, duration_sec=180)
+    svc.schedule_session(track.id, "2024-01-01", "Jane", hours=5, hourly_rate_cents=1000)
+    svc.mix_track(track.id, "Bob", cost_cents=2000)
+
+    # Verify cost calculation
+    assert svc.production_cost(track.id) == 5 * 1000 + 2000
+
+    release = svc.release_track(
+        track.id,
+        "2024-02-01",
+        ["digital"],
+        price_cents=150,
+        sales=10,
+    )
+
+    assert release.sales == 10
+    assert economy.deposits == [(1, 1500)]
+    assert analytics.sales == [(track.id, 10)]
+    assert analytics.charts == [track.id]
+    assert svc.get_track(track.id).release == release


### PR DESCRIPTION
## Summary
- add models for tracks, studio sessions, mixing, and release metadata
- implement production service handling sessions, costs, mastering, and release with economy and analytics integrations
- expose production routes for session management and releases
- test end-to-end release flow

## Testing
- `pytest backend/tests/production/test_release_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2d5f6d5a8832587c6bba97f51b5ed