### PR TITLE
Add merch models and economic integrations

### DIFF
--- a/backend/models/merch.py
+++ b/backend/models/merch.py
@@ -1,0 +1,53 @@
+"""Dataclasses representing merchandise products and stock keeping units.
+
+The project previously embedded simple dataclasses directly inside the
+merch service.  They are now promoted to a dedicated module so that the
+models can be reused by other parts of the application and in tests.
+
+The ``ProductIn`` dataclass captures high level details about a
+merchandise product such as its type and optional band association.  The
+``SKUIn`` dataclass represents a concrete design/variant of a product
+including its price and inventory level.  ``CartItem`` is used when
+building orders.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ProductIn:
+    """Input model for creating a merch product."""
+
+    name: str
+    category: str  # e.g. 'tshirt', 'poster', 'sticker'
+    band_id: Optional[int] = None
+    description: Optional[str] = None
+    image_url: Optional[str] = None
+    is_active: bool = True
+
+
+@dataclass
+class SKUIn:
+    """Input model for creating a product variant/SKU."""
+
+    product_id: int
+    price_cents: int
+    stock_qty: int
+    option_size: Optional[str] = None
+    option_color: Optional[str] = None
+    currency: str = "USD"
+    barcode: Optional[str] = None
+    is_active: bool = True
+
+
+@dataclass
+class CartItem:
+    """Represents an item placed in a user's cart for purchase."""
+
+    sku_id: int
+    qty: int
+
+
+__all__ = ["ProductIn", "SKUIn", "CartItem"]
+

--- a/backend/routes/merch_routes.py
+++ b/backend/routes/merch_routes.py
@@ -2,7 +2,8 @@ from typing import List
 
 from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
 from backend.services.economy_service import EconomyService
-from backend.services.merch_service import MerchError, MerchService, ProductIn, SKUIn
+from backend.services.merch_service import MerchError, MerchService
+from backend.models.merch import ProductIn, SKUIn
 from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 from pydantic import BaseModel
 

--- a/backend/tests/merch/test_merch_service.py
+++ b/backend/tests/merch/test_merch_service.py
@@ -1,0 +1,46 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys_path = Path(__file__).resolve().parents[3]
+import sys
+if str(sys_path) not in sys.path:
+    sys.path.append(str(sys_path))
+
+from backend.models.merch import ProductIn, SKUIn
+from backend.services.economy_service import EconomyService
+from backend.services.merch_service import MerchError, MerchService
+
+
+def setup_service():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    econ = EconomyService(db_path=path)
+    econ.ensure_schema()
+    svc = MerchService(db_path=path, economy=econ)
+    svc.ensure_schema()
+    return svc, econ
+
+
+def test_inventory_depletion_and_revenue_distribution():
+    svc, econ = setup_service()
+    # Create a product for band 42
+    pid = svc.create_product(ProductIn(name="Tour Hat", category="hat", band_id=42))
+    sid = svc.create_sku(SKUIn(product_id=pid, price_cents=500, stock_qty=3))
+
+    # Buyer funds and purchase two units
+    econ.deposit(1, 5000)
+    order_id = svc.purchase(1, items=[{"sku_id": sid, "qty": 2}])
+    assert order_id > 0
+
+    # Stock reduced and revenue paid to the band
+    skus = svc.list_skus(pid)
+    assert skus[0]["stock_qty"] == 1
+    assert econ.get_balance(42) == 1000
+
+    # Attempting to buy more than remaining inventory raises an error
+    with pytest.raises(MerchError):
+        svc.purchase(1, items=[{"sku_id": sid, "qty": 2}])
+


### PR DESCRIPTION
## Summary
- introduce `merch` dataclasses for products, SKUs and cart items
- expand merch service to handle revenue distribution and optional payments
- add withdraw/transfer support to economy service
- expose merch model imports in routes and add merch tests

## Testing
- `pytest -q backend/tests/property/test_property_service.py backend/tests/modding/test_marketplace.py backend/tests/merch/test_merch_service.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'WebSocket' from 'fastapi', ModuleNotFoundError: No module named 'starlette', ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68b2d937565c83258b1d2151b65a17c5