### PR TITLE
Add city economic trends system and integrate with gameplay metrics

### DIFF
--- a/backend/models/city.py
+++ b/backend/models/city.py
@@ -1,0 +1,25 @@
+"""Dataclass representing a game city with economic trends."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class City:
+    """Represents a city's economic and cultural data."""
+
+    name: str
+    population: int
+    style_preferences: Dict[str, float]
+    market_index: float = 1.0
+    event_modifier: float = 1.0
+
+    def popular_style(self) -> str:
+        """Return the style with highest preference."""
+        if not self.style_preferences:
+            return "unknown"
+        return max(self.style_preferences, key=self.style_preferences.get)
+
+
+__all__ = ["City"]

--- a/backend/routes/city_routes.py
+++ b/backend/routes/city_routes.py
@@ -1,0 +1,19 @@
+"""API routes exposing city analytics."""
+from fastapi import APIRouter, HTTPException
+
+from backend.services.city_service import city_service
+
+router = APIRouter(prefix="/cities", tags=["Cities"])
+
+
+@router.get("/{name}")
+def city_stats(name: str) -> dict:
+    city = city_service.get_city(name)
+    if not city:
+        raise HTTPException(status_code=404, detail="City not found")
+    return city_service.stats(name)
+
+
+@router.get("/popular")
+def popular_cities(limit: int = 5) -> list[dict]:
+    return city_service.popular_cities(limit)

--- a/backend/services/city_service.py
+++ b/backend/services/city_service.py
@@ -1,0 +1,64 @@
+"""Service for managing city economic trends and analytics."""
+from __future__ import annotations
+
+import random
+from typing import Dict, List
+
+from backend.models.city import City
+
+
+class CityService:
+    """Maintain cities and update their market trends daily."""
+
+    def __init__(self) -> None:
+        self.cities: Dict[str, City] = {}
+        self.day: int = 0
+
+    # ------------ city management ------------
+    def add_city(self, city: City) -> None:
+        self.cities[city.name] = city
+
+    def get_city(self, name: str) -> City | None:
+        return self.cities.get(name)
+
+    # ------------ economics ------------
+    def update_daily(self) -> None:
+        """Advance the simulation by one day updating trends."""
+        self.day += 1
+        for city in self.cities.values():
+            delta = random.uniform(-0.05, 0.05)
+            city.market_index = max(0.1, city.market_index * (1 + delta))
+            # adjust style preferences slightly
+            for style, pref in list(city.style_preferences.items()):
+                city.style_preferences[style] = max(0.0, pref + random.uniform(-0.1, 0.1))
+            # event modifier derived from market index
+            city.event_modifier = 1 + (city.market_index - 1) * 0.2
+
+    def get_event_modifier(self, name: str) -> float:
+        city = self.cities.get(name)
+        return city.event_modifier if city else 1.0
+
+    def get_market_demand(self, name: str) -> float:
+        city = self.cities.get(name)
+        return city.market_index if city else 1.0
+
+    # ------------ analytics ------------
+    def stats(self, name: str) -> Dict[str, object]:
+        city = self.cities.get(name)
+        if not city:
+            raise KeyError(name)
+        return {
+            "name": city.name,
+            "population": city.population,
+            "market_index": city.market_index,
+            "popular_style": city.popular_style(),
+        }
+
+    def popular_cities(self, limit: int = 5) -> List[Dict[str, object]]:
+        """Return top cities sorted by market index."""
+        data = [self.stats(n) for n in self.cities]
+        data.sort(key=lambda d: d["market_index"], reverse=True)
+        return data[:limit]
+
+
+city_service = CityService()

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -3,6 +3,7 @@
 import random
 
 from .weather_service import weather_service
+from .city_service import city_service
 
 
 def roll_for_daily_event(user_id, lifestyle_data, active_skills):
@@ -30,10 +31,13 @@ def is_skill_blocked(user_id, skill):
 
 
 def adjust_event_attendance(base_attendance: int, region: str) -> int:
-    """Modify event attendance based on current weather."""
+    """Modify event attendance based on weather and city trends."""
     forecast = weather_service.get_forecast(region)
+    attendance = base_attendance
     if forecast.event and forecast.event.type == "storm":
-        return int(base_attendance * 0.7)
-    if forecast.event and forecast.event.type == "festival":
-        return int(base_attendance * 1.3)
-    return base_attendance
+        attendance = int(attendance * 0.7)
+    elif forecast.event and forecast.event.type == "festival":
+        attendance = int(attendance * 1.3)
+    # apply city economic modifier
+    attendance = int(attendance * city_service.get_event_modifier(region))
+    return attendance

--- a/backend/services/live_performance_service.py
+++ b/backend/services/live_performance_service.py
@@ -2,6 +2,7 @@ import sqlite3
 import random
 from datetime import datetime
 from backend.database import DB_PATH
+from backend.services.city_service import city_service
 
 
 def simulate_gig(band_id: int, city: str, venue: str, setlist: list) -> dict:
@@ -19,11 +20,12 @@ def simulate_gig(band_id: int, city: str, venue: str, setlist: list) -> dict:
     # Simulate crowd size based on fame and randomness
     base_crowd = fame * 2
     crowd_size = min(random.randint(base_crowd, base_crowd + 300), 2000)
+    crowd_size = int(crowd_size * city_service.get_event_modifier(city))
 
     fame_earned = crowd_size // 10
     revenue_earned = crowd_size * 5
     skill_gain = len(setlist) * 0.3
-    merch_sold = int(crowd_size * 0.15)
+    merch_sold = int(crowd_size * 0.15 * city_service.get_market_demand(city))
 
     # Record performance
     cur.execute("""

--- a/backend/services/quest_service.py
+++ b/backend/services/quest_service.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Dict
 
-from models.quest import Quest, QuestReward
+from models.quest import Quest, QuestReward, QuestStage
+from backend.services.city_service import city_service
 
 
 class QuestService:
@@ -47,3 +48,14 @@ class QuestService:
         """Return the reward for the current stage without claiming it."""
         stage = self.get_current_stage(user_id, quest)
         return stage.reward if stage else None
+
+    # --------- city influenced quests ---------
+    def generate_city_quest(self, city_name: str) -> Quest:
+        """Create a simple quest themed around the city's popular style."""
+        city = city_service.get_city(city_name)
+        if not city:
+            raise ValueError("Unknown city")
+        style = city.popular_style()
+        reward = QuestReward(type="fame", amount=max(1, city.population // 100_000))
+        stage = QuestStage(id="start", description=f"Perform a {style} show in {city_name}", branches={}, reward=reward)
+        return Quest(id=f"{city_name}_{style}", name=f"{city_name} {style} Craze", stages={"start": stage}, initial_stage="start")

--- a/backend/tests/city/test_city_trends.py
+++ b/backend/tests/city/test_city_trends.py
@@ -1,0 +1,60 @@
+import sqlite3
+from datetime import datetime
+
+import sqlite3
+from datetime import datetime
+
+from backend.services.city_service import city_service
+from backend.services import event_service, live_performance_service
+from backend.services.quest_service import QuestService
+from backend.models.weather import Forecast
+from backend.models.city import City
+
+
+def setup_function(_):
+    city_service.cities.clear()
+
+
+def test_daily_update_changes_market_index(monkeypatch):
+    city_service.add_city(City(name="Metro", population=1_000_000, style_preferences={"rock": 1.0}))
+    monkeypatch.setattr("backend.services.city_service.random.uniform", lambda a, b: 0.05)
+    city_service.update_daily()
+    city = city_service.get_city("Metro")
+    assert city and city.market_index > 1.0
+
+
+def test_city_adjusts_event_attendance(monkeypatch):
+    city_service.add_city(City(name="Metro", population=1_000_000, style_preferences={}, event_modifier=1.2))
+
+    def fake_forecast(region: str) -> Forecast:
+        return Forecast(region=region, date=datetime.utcnow(), condition="sunny", high=20, low=10, event=None)
+
+    monkeypatch.setattr(event_service.weather_service, "get_forecast", fake_forecast)
+    attendance = event_service.adjust_event_attendance(100, "Metro")
+    assert attendance == 120
+
+
+def test_city_trends_affect_merch_sales(monkeypatch):
+    city_service.add_city(City(name="Metro", population=1_000_000, style_preferences={}, event_modifier=1.5, market_index=2.0))
+
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE bands (id INTEGER PRIMARY KEY, fame INTEGER, skill REAL, revenue INTEGER)")
+    cur.execute("CREATE TABLE live_performances (band_id INTEGER, city TEXT, venue TEXT, date TEXT, setlist TEXT, crowd_size INTEGER, fame_earned INTEGER, revenue_earned INTEGER, skill_gain REAL, merch_sold INTEGER)")
+    cur.execute("INSERT INTO bands (id, fame, skill, revenue) VALUES (1, 100, 0, 0)")
+
+    monkeypatch.setattr(live_performance_service, "DB_PATH", ":memory:")
+    monkeypatch.setattr(live_performance_service.sqlite3, "connect", lambda _: conn)
+    monkeypatch.setattr(live_performance_service.random, "randint", lambda a, b: a)
+
+    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", ["song"])
+    assert result["crowd_size"] == 300  # 200 base * 1.5 modifier
+    assert result["merch_sold"] == 90   # 300 * 0.15 * 2.0
+
+
+def test_city_influences_quest_generation():
+    city_service.add_city(City(name="Metro", population=500_000, style_preferences={"rock": 2.0, "pop": 0.5}))
+    svc = QuestService()
+    quest = svc.generate_city_quest("Metro")
+    assert "rock" in quest.name.lower()
+    assert "rock" in quest.stages["start"].description.lower()


### PR DESCRIPTION
## Summary
- Introduce `City` model and `CityService` tracking population, market indices, and style trends
- Add city analytics API routes and daily trend updates
- Influence event attendance, merch sales, and quest generation with city modifiers

## Testing
- `pytest backend/tests/city -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2dca65a6c8325995ba0013d75b846