### PR TITLE
refactor: use explicit backend imports for routes

### DIFF
--- a/backend/routes/karma_admin_routes.py
+++ b/backend/routes/karma_admin_routes.py
@@ -1,18 +1,33 @@
-from auth.dependencies import get_current_user_id, require_role
-from fastapi import APIRouter
-from karma_extras import get_karma_score, get_karma_leaderboard, add_karma_vote
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.karma_extras import add_karma_vote, get_karma_leaderboard, get_karma_score
+from fastapi import APIRouter, Depends, HTTPException, Request
 
-router = APIRouter()
+router = APIRouter(prefix="/karma", tags=["Karma"])
 
-@router.get("/karma/score/{user_id}", dependencies=[Depends(require_role(["admin"]))])
-def read_karma_score(user_id: int):
+
+@router.get("/score/{user_id}", dependencies=[Depends(require_role(["admin"]))])
+def read_karma_score(
+    user_id: int, _req: Request, _: int = Depends(get_current_user_id)
+):
     return {"user_id": user_id, "karma": get_karma_score(user_id)}
 
-@router.post("/karma/vote")
-def cast_vote(voter_id: int, target_id: int, vote: int):
+
+@router.post("/vote")
+def cast_vote(
+    voter_id: int,
+    target_id: int,
+    vote: int,
+    _req: Request,
+    _: int = Depends(get_current_user_id),
+):
+    if vote not in (-1, 1):
+        raise HTTPException(status_code=400, detail="vote must be -1 or 1")
+    if voter_id == target_id:
+        raise HTTPException(status_code=400, detail="self-vote not allowed")
     score = add_karma_vote(voter_id, target_id, vote)
     return {"target_id": target_id, "updated_karma": score}
 
-@router.get("/karma/leaderboard")
-def karma_top():
+
+@router.get("/leaderboard")
+def karma_top(_req: Request, _: int = Depends(get_current_user_id)):
     return {"leaderboard": get_karma_leaderboard()}


### PR DESCRIPTION
## Summary
- switch chart routes to FastAPI APIRouter and backend imports
- namespace karma admin routes and add auth dependencies

## Testing
- `ruff check backend/routes/chart_routes.py backend/routes/karma_admin_routes.py`
- `pytest` *(fails: TypeError: _field() missing 1 required positional argument: 'default', ModuleNotFoundError: No module named 'fastapi.exceptions', SyntaxError: invalid syntax, ModuleNotFoundError: No module named 'starlette', ImportError: cannot import name 'MailService', ModuleNotFoundError: No module named 'boto3', SyntaxError: unexpected character after line continuation character)*

------
https://chatgpt.com/codex/tasks/task_e_68b2df24d1e48325a18baf2b3040054e