### PR TITLE
Add social realtime gateway for friend and forum notifications

### DIFF
--- a/backend/realtime/publish.py
+++ b/backend/realtime/publish.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
-from .gateway import hub, topic_for_user, PULSE_TOPIC, ADMIN_JOBS_TOPIC
+from .gateway import ADMIN_JOBS_TOPIC, PULSE_TOPIC, hub, topic_for_user
 
 logger = logging.getLogger(__name__)
 
@@ -39,20 +39,6 @@ async def publish_admin_job_status(event: Dict[str, Any]) -> int:
     """
     payload: Dict[str, Any] = {"type": "admin_job", **event}
     return await hub.publish(ADMIN_JOBS_TOPIC, payload)
-
-async def publish_friend_request(target_user_id: int, from_user_id: int) -> int:
-    """Notify a user of a new friend request."""
-    payload: Dict[str, Any] = {"type": "friend_request", "from_user_id": int(from_user_id)}
-    topic = topic_for_user(int(target_user_id))
-    return await hub.publish(topic, payload)
-
-
-async def publish_forum_reply(target_user_id: int, thread_id: int, post_id: int) -> int:
-    """Notify a user that someone replied to their forum post."""
-    payload: Dict[str, Any] = {"type": "forum_reply", "thread_id": int(thread_id), "post_id": int(post_id)}
-    topic = topic_for_user(int(target_user_id))
-    return await hub.publish(topic, payload)
-
 
 async def publish_fan_club_post(fan_club_id: int, thread_id: int, post_id: int) -> int:
     """Broadcast a new fan club post to all club subscribers."""

--- a/backend/realtime/social_gateway.py
+++ b/backend/realtime/social_gateway.py
@@ -1,0 +1,46 @@
+"""Realtime helpers for social notifications."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set, Tuple  # noqa: F401
+
+from .gateway import hub, topic_for_user
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FriendRequestEvent:
+    """Payload sent when a user receives a friend request."""
+
+    type: str = "friend_request"
+    from_user_id: int = 0
+
+
+@dataclass
+class ForumReplyEvent:
+    """Payload sent when a user's forum post receives a reply."""
+
+    type: str = "forum_reply"
+    thread_id: int = 0
+    post_id: int = 0
+
+
+async def publish_friend_request(target_user_id: int, from_user_id: int) -> int:
+    """Notify a user of a new friend request."""
+
+    payload: Dict[str, int] = FriendRequestEvent(from_user_id=int(from_user_id)).__dict__
+    topic = topic_for_user(int(target_user_id))
+    return await hub.publish(topic, payload)
+
+
+async def publish_forum_reply(target_user_id: int, thread_id: int, post_id: int) -> int:
+    """Notify a user that someone replied to their forum post."""
+
+    payload: Dict[str, int] = ForumReplyEvent(
+        thread_id=int(thread_id), post_id=int(post_id)
+    ).__dict__
+    topic = topic_for_user(int(target_user_id))
+    return await hub.publish(topic, payload)
+

--- a/backend/services/social_service.py
+++ b/backend/services/social_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Set, Tuple
 
-from backend.realtime.publish import publish_friend_request, publish_forum_reply
+from backend.realtime.social_gateway import publish_forum_reply, publish_friend_request
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add new realtime `social_gateway` module with helpers for friend requests and forum replies
- update `SocialService` to use new gateway
- clean up legacy helpers from `realtime.publish`

## Testing
- `ruff check backend/realtime/social_gateway.py backend/realtime/publish.py backend/services/social_service.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_68b2e02bb85883258e10ad2173b9c41f