### PR TITLE
fix: standardize imports and auth dependency in social routes

### DIFF
--- a/backend/routes/social_routes.py
+++ b/backend/routes/social_routes.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from utils.i18n import _
 
-from auth.dependencies import get_current_user_id
+from backend.utils.i18n import _
+from backend.auth.dependencies import get_current_user_id
 from backend.services.social_service import social_service
 from backend.services.fan_club_service import fan_club_service
 from datetime import datetime


### PR DESCRIPTION
## Summary
- use backend package paths for i18n and auth dependencies
- ensure social routes import services via backend namespace

## Testing
- `pytest -q`
- `pytest backend/tests/test_i18n.py -q` *(fails: ModuleNotFoundError: No module named 'starlette')*


------
https://chatgpt.com/codex/tasks/task_e_68b2e2359a908325877126ab351e5151