### PR TITLE
Add event effect tracking and scheduled cleanup

### DIFF
--- a/backend/core/scheduler.py
+++ b/backend/core/scheduler.py
@@ -35,7 +35,12 @@ except Exception:
         return conn
 
 # Import job modules
-from backend.jobs import cleanup_idempotency, cleanup_rate_limits, backup_db  # type: ignore
+from backend.jobs import (
+    cleanup_idempotency,
+    cleanup_rate_limits,
+    backup_db,
+    cleanup_event_effects,
+)  # type: ignore
 
 
 JobFunc = Callable[[], tuple[int, str]]
@@ -53,6 +58,7 @@ def register_jobs() -> None:
     _registry["cleanup_idempotency"] = cleanup_idempotency.run
     _registry["cleanup_rate_limits"] = cleanup_rate_limits.run
     _registry["backup_db"] = backup_db.run
+    _registry["cleanup_event_effects"] = cleanup_event_effects.run
 
 
 def list_jobs() -> dict:

--- a/backend/jobs/cleanup_event_effects.py
+++ b/backend/jobs/cleanup_event_effects.py
@@ -1,0 +1,8 @@
+"""Clear expired event effects from the database."""
+
+from backend.services.event_service import clear_expired_events
+
+
+def run() -> tuple[int, str]:
+    deleted = clear_expired_events()
+    return deleted, "expired_cleared"

--- a/backend/models/event_effect.py
+++ b/backend/models/event_effect.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from dataclasses import dataclass
+
+
+@dataclass
+class EventEffect:
+    """Represents a temporary effect applied to a user."""
+
+    user_id: int
+    skill: str | None
+    effect: str
+    start: str
+    duration: int
+
+    def __init__(self, user_id: int, effect: str, duration: int, skill: str | None = None, start: str | None = None):
+        self.user_id = user_id
+        self.skill = skill
+        self.effect = effect
+        self.start = start or datetime.utcnow().isoformat()
+        self.duration = duration
+
+    def to_dict(self) -> dict:
+        return {
+            "user_id": self.user_id,
+            "skill": self.skill,
+            "effect": self.effect,
+            "start": self.start,
+            "duration": self.duration,
+        }

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -1,33 +1,105 @@
 # services/event_service.py
-
 import random
+import sqlite3
+import logging
 
+from backend.database import DB_PATH
+from backend.models.event_effect import EventEffect
 from .weather_service import weather_service
 from .city_service import city_service
+
+logger = logging.getLogger(__name__)
+
+
+def _conn() -> sqlite3.Connection:
+    return sqlite3.connect(str(DB_PATH))
+
+
+def _ensure_schema() -> None:
+    with _conn() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS event_effects (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                effect TEXT NOT NULL,
+                skill TEXT,
+                start_date TEXT NOT NULL,
+                duration_days INTEGER NOT NULL
+            )
+            """
+        )
+        conn.commit()
 
 
 def roll_for_daily_event(user_id, lifestyle_data, active_skills):
     # Sample logic: if drinking high and vocals practiced 5 days in a row
     if lifestyle_data.get("drinking") == "high" and "vocals" in active_skills:
         if random.random() < 0.15:
-            return {"event": "vocal fatigue", "effect": "freeze_progress", "skill": "vocals", "duration": 3}
+            return {
+                "event": "vocal fatigue",
+                "effect": "freeze_progress",
+                "skill": "vocals",
+                "duration": 3,
+            }
 
     if random.random() < 0.01:
-        return {"event": "sprained wrist", "effect": "block_skill", "skill": "guitar", "duration": 5}
+        return {
+            "event": "sprained wrist",
+            "effect": "block_skill",
+            "skill": "guitar",
+            "duration": 5,
+        }
 
     return None
 
-def apply_event_effect(user_id, event_data):
-    # Store in database as active event
-    print(f"Applied {event_data} to user {user_id}")
 
-def clear_expired_events():
-    # Clear events whose start_date + duration_days < today
-    pass
+def apply_event_effect(user_id, event_data):
+    _ensure_schema()
+    effect = EventEffect(
+        user_id=user_id,
+        effect=event_data.get("effect"),
+        duration=event_data.get("duration", 0),
+        skill=event_data.get("skill"),
+    )
+    with _conn() as conn:
+        conn.execute(
+            """
+            INSERT INTO event_effects (user_id, effect, skill, start_date, duration_days)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (effect.user_id, effect.effect, effect.skill, effect.start, effect.duration),
+        )
+        conn.commit()
+    logger.info("Applied %s to user %s", event_data, user_id)
+
+
+def clear_expired_events() -> int:
+    _ensure_schema()
+    with _conn() as conn:
+        cur = conn.execute(
+            """
+            DELETE FROM event_effects
+            WHERE datetime(start_date, '+' || duration_days || ' days') <= datetime('now')
+            """
+        )
+        conn.commit()
+        return cur.rowcount if cur.rowcount is not None else 0
+
 
 def is_skill_blocked(user_id, skill):
-    # Check if user has an active event blocking this skill
-    return False
+    _ensure_schema()
+    with _conn() as conn:
+        cur = conn.execute(
+            """
+            SELECT 1 FROM event_effects
+             WHERE user_id = ? AND skill = ? AND effect = 'block_skill'
+               AND datetime(start_date, '+' || duration_days || ' days') > datetime('now')
+            """,
+            (user_id, skill),
+        )
+        return cur.fetchone() is not None
+
 
 
 def adjust_event_attendance(base_attendance: int, region: str) -> int:

--- a/backend/services/rehearsal_service.py
+++ b/backend/services/rehearsal_service.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List, Optional
 
+from backend.services.event_service import is_skill_blocked
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 
@@ -117,9 +118,10 @@ class RehearsalService:
             )
             rehearsal_id = c.lastrowid
             # update band skills and performance
+            skill_gain = 0 if is_skill_blocked(band_id, "rehearsal") else bonus
             c.execute(
                 "UPDATE bands SET skill = skill + ?, performance_quality = performance_quality + ? WHERE id = ?",
-                (bonus, bonus * 0.5, band_id),
+                (skill_gain, bonus * 0.5, band_id),
             )
             conn.commit()
         return {"rehearsal_id": rehearsal_id, "bonus": bonus}

--- a/backend/tests/city/test_city_trends.py
+++ b/backend/tests/city/test_city_trends.py
@@ -46,6 +46,8 @@ def test_city_trends_affect_merch_sales(monkeypatch):
     monkeypatch.setattr(live_performance_service, "DB_PATH", ":memory:")
     monkeypatch.setattr(live_performance_service.sqlite3, "connect", lambda _: conn)
     monkeypatch.setattr(live_performance_service.random, "randint", lambda a, b: a)
+    monkeypatch.setattr(event_service, "DB_PATH", ":memory:")
+    monkeypatch.setattr(event_service.sqlite3, "connect", lambda _: conn)
 
     result = live_performance_service.simulate_gig(1, "Metro", "The Spot", ["song"])
     assert result["crowd_size"] == 300  # 200 base * 1.5 modifier

--- a/backend/tests/rehearsal/test_rehearsal_service.py
+++ b/backend/tests/rehearsal/test_rehearsal_service.py
@@ -1,5 +1,6 @@
 import sqlite3
 from backend.services.rehearsal_service import RehearsalService
+from backend.services import event_service
 
 
 def _setup(tmp_path):
@@ -34,4 +35,18 @@ def test_practice_bonus(tmp_path):
         ).fetchone()
     assert skill == 1.5
     assert quality == 0.75
+
+
+def test_blocked_skill(tmp_path, monkeypatch):
+    svc, db = _setup(tmp_path)
+    monkeypatch.setattr(
+        "backend.services.rehearsal_service.is_skill_blocked", lambda *_: True
+    )
+    svc.book_session(1, "2024-01-03T10:00:00", "2024-01-03T11:00:00", [1, 2])
+    with sqlite3.connect(db) as conn:
+        skill, quality = conn.execute(
+            "SELECT skill, performance_quality FROM bands WHERE id=1"
+        ).fetchone()
+    assert skill == 0
+    assert quality == 0.5
 

--- a/backend/tests/services/test_event_service.py
+++ b/backend/tests/services/test_event_service.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 from services import event_service
 
 def test_roll_for_daily_event_trigger(monkeypatch):
@@ -11,3 +13,27 @@ def test_roll_for_daily_event_none(monkeypatch):
     monkeypatch.setattr(event_service.random, "random", lambda: 1.0)
     event = event_service.roll_for_daily_event(1, {"drinking": "low"}, [])
     assert event is None
+
+
+def test_apply_and_block(tmp_path, monkeypatch):
+    db = tmp_path / "test.db"
+    monkeypatch.setattr(event_service, "DB_PATH", db)
+    event_service.apply_event_effect(
+        1, {"effect": "block_skill", "skill": "guitar", "duration": 1}
+    )
+    assert event_service.is_skill_blocked(1, "guitar")
+
+
+def test_clear_expired(tmp_path, monkeypatch):
+    db = tmp_path / "test.db"
+    monkeypatch.setattr(event_service, "DB_PATH", db)
+    event_service.apply_event_effect(
+        1, {"effect": "block_skill", "skill": "guitar", "duration": 1}
+    )
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "UPDATE event_effects SET start_date = datetime('now', '-10 days')"
+        )
+    deleted = event_service.clear_expired_events()
+    assert deleted == 1
+    assert not event_service.is_skill_blocked(1, "guitar")


### PR DESCRIPTION
## Summary
- Introduce `EventEffect` model and database helpers for storing temporary gameplay effects
- Schedule cleanup job and use logging for applied effects
- Block skill progression during rehearsals and gigs when events require it

## Testing
- `pytest backend/tests/services/test_event_service.py backend/tests/rehearsal/test_rehearsal_service.py backend/tests/city/test_city_trends.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2e437d6f8832594fea0fb0a2a8e1b