### PR TITLE
feat: persist jam and social services

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -61,6 +61,57 @@ def init_db():
         )
         """)
 
+        # Admin audit log
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS admin_audit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            actor INTEGER,
+            action TEXT NOT NULL,
+            resource TEXT NOT NULL,
+            timestamp TEXT NOT NULL
+        )
+        """)
+
+        # Social features
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS friend_requests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            from_user_id INTEGER NOT NULL,
+            to_user_id INTEGER NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            created_at TEXT DEFAULT (datetime('now'))
+        )
+        """)
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS friendships (
+            user_a INTEGER NOT NULL,
+            user_b INTEGER NOT NULL,
+            created_at TEXT DEFAULT (datetime('now')),
+            UNIQUE(user_a, user_b)
+        )
+        """)
+
+        # Jam sessions
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS jam_sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            host_id INTEGER NOT NULL,
+            created_at TEXT DEFAULT (datetime('now'))
+        )
+        """)
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS jam_streams (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id INTEGER NOT NULL,
+            user_id INTEGER NOT NULL,
+            stream_id TEXT NOT NULL,
+            codec TEXT NOT NULL,
+            premium INTEGER NOT NULL DEFAULT 0,
+            started_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY(session_id) REFERENCES jam_sessions(id)
+        )
+        """)
+
         # -------------------------------
         # Sponsorship schema (new)
         # -------------------------------

--- a/backend/migrations/080_social_jam_admin.sql
+++ b/backend/migrations/080_social_jam_admin.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS admin_audit (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    actor INTEGER,
+    action TEXT NOT NULL,
+    resource TEXT NOT NULL,
+    timestamp TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS friend_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_user_id INTEGER NOT NULL,
+    to_user_id INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS friendships (
+    user_a INTEGER NOT NULL,
+    user_b INTEGER NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    UNIQUE(user_a, user_b)
+);
+
+CREATE TABLE IF NOT EXISTS jam_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    host_id INTEGER NOT NULL,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS jam_streams (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    stream_id TEXT NOT NULL,
+    codec TEXT NOT NULL,
+    premium INTEGER NOT NULL DEFAULT 0,
+    started_at TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY(session_id) REFERENCES jam_sessions(id)
+);

--- a/backend/models/jam_session.py
+++ b/backend/models/jam_session.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, Set
 
 
 @dataclass
@@ -17,25 +16,9 @@ class AudioStream:
 
 
 @dataclass
-class Participant:
-    user_id: int
-    joined_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
-
-
-@dataclass
 class JamSession:
-    """In-memory representation of a jam session."""
+    """Lightweight representation of a jam session."""
 
     id: str
     host_id: int
     created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
-    participants: Dict[int, Participant] = field(default_factory=dict)
-    streams: Dict[int, AudioStream] = field(default_factory=dict)
-    invites: Set[int] = field(default_factory=set)
-
-    def add_participant(self, user_id: int) -> None:
-        self.participants[user_id] = Participant(user_id=user_id)
-
-    def remove_participant(self, user_id: int) -> None:
-        self.participants.pop(user_id, None)
-        self.streams.pop(user_id, None)

--- a/backend/services/admin_audit_service.py
+++ b/backend/services/admin_audit_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import asdict
+import sqlite3
+from pathlib import Path
 from typing import List
 from fastapi import Depends, Request
 from datetime import datetime
@@ -9,22 +10,60 @@ from backend.auth.dependencies import get_current_user_id
 from backend.models.admin_audit import AdminAudit
 
 
-class AdminAuditService:
-    """Simple in-memory audit log service."""
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 
-    def __init__(self):
-        self._logs: List[AdminAudit] = []
+
+class AdminAuditService:
+    """Persistent audit log service backed by SQLite."""
+
+    def __init__(self, db_path: str | None = None):
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS admin_audit (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    actor INTEGER,
+                    action TEXT NOT NULL,
+                    resource TEXT NOT NULL,
+                    timestamp TEXT NOT NULL
+                )
+                """,
+            )
+            conn.commit()
 
     def log_action(self, actor: int | None, action: str, resource: str) -> AdminAudit:
-        entry = AdminAudit(actor=actor, action=action, resource=resource, timestamp=datetime.utcnow().isoformat())
-        self._logs.append(entry)
-        return entry
+        ts = datetime.utcnow().isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO admin_audit(actor, action, resource, timestamp) VALUES (?, ?, ?, ?)",
+                (actor, action, resource, ts),
+            )
+            conn.commit()
+        return AdminAudit(actor=actor, action=action, resource=resource, timestamp=ts)
 
     def query(self, skip: int = 0, limit: int = 100) -> List[dict]:
-        return [log.to_dict() for log in self._logs[skip : skip + limit]]
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT actor, action, resource, timestamp FROM admin_audit ORDER BY id LIMIT ? OFFSET ?",
+                (limit, skip),
+            )
+            rows = cur.fetchall()
+            return [
+                {"actor": r[0], "action": r[1], "resource": r[2], "timestamp": r[3]}
+                for r in rows
+            ]
 
     def clear(self) -> None:
-        self._logs.clear()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM admin_audit")
+            conn.commit()
 
 
 audit_service = AdminAuditService()

--- a/backend/services/jam_service.py
+++ b/backend/services/jam_service.py
@@ -1,7 +1,9 @@
 """Service layer for managing jam sessions and economy hooks."""
 from __future__ import annotations
 
-from typing import Dict, Optional
+import sqlite3
+from pathlib import Path
+from typing import Dict, Optional, Set
 
 from backend.models.jam_session import AudioStream, JamSession
 from backend.services.economy_service import EconomyService
@@ -9,70 +11,131 @@ from backend.services.economy_service import EconomyService
 STUDIO_RENTAL_CENTS = 100
 PREMIUM_STREAM_CENTS = 25
 
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
 
 class JamService:
-    """Simple in-memory jam session management."""
+    """Jam session management backed by SQLite for persistence."""
 
-    def __init__(self, economy: Optional[EconomyService] = None):
+    def __init__(self, economy: Optional[EconomyService] = None, db_path: str | None = None):
         self.economy = economy or EconomyService()
         try:
             self.economy.ensure_schema()
         except Exception:
             pass
-        self.sessions: Dict[str, JamSession] = {}
-        self._session_seq = 0
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+        self.invites: Dict[str, Set[int]] = {}
+        self.participants: Dict[str, Set[int]] = {}
+
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS jam_sessions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    host_id INTEGER NOT NULL,
+                    created_at TEXT DEFAULT (datetime('now'))
+                )
+                """,
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS jam_streams (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id INTEGER NOT NULL,
+                    user_id INTEGER NOT NULL,
+                    stream_id TEXT NOT NULL,
+                    codec TEXT NOT NULL,
+                    premium INTEGER NOT NULL DEFAULT 0,
+                    started_at TEXT DEFAULT (datetime('now')),
+                    FOREIGN KEY(session_id) REFERENCES jam_sessions(id)
+                )
+                """,
+            )
+            conn.commit()
 
     # ------------------------------------------------------------------
     def create_session(self, host_id: int) -> JamSession:
         """Create a new session and charge the host studio rental."""
         self.economy.withdraw(host_id, STUDIO_RENTAL_CENTS)
-        self._session_seq += 1
-        session_id = str(self._session_seq)
-        session = JamSession(id=session_id, host_id=host_id)
-        session.add_participant(host_id)
-        self.sessions[session_id] = session
-        return session
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO jam_sessions(host_id, created_at) VALUES (?, datetime('now'))",
+                (host_id,),
+            )
+            session_id = str(cur.lastrowid)
+            conn.commit()
+        self.participants[session_id] = {host_id}
+        self.invites[session_id] = set()
+        return JamSession(id=session_id, host_id=host_id)
 
     def invite(self, session_id: str, inviter_id: int, invitee_id: int) -> None:
-        session = self.sessions.get(session_id)
-        if not session:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT host_id FROM jam_sessions WHERE id = ?", (session_id,))
+            row = cur.fetchone()
+        if not row:
             raise KeyError("session_not_found")
-        if inviter_id != session.host_id and inviter_id not in session.participants:
+        host_id = row[0]
+        if inviter_id != host_id and inviter_id not in self.participants.get(session_id, set()):
             raise PermissionError("not_participant")
-        session.invites.add(invitee_id)
+        self.invites.setdefault(session_id, set()).add(invitee_id)
 
     def join_session(self, session_id: str, user_id: int) -> None:
-        session = self.sessions.get(session_id)
-        if not session:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT host_id FROM jam_sessions WHERE id = ?", (session_id,))
+            row = cur.fetchone()
+        if not row:
             raise KeyError("session_not_found")
-        if user_id != session.host_id and user_id not in session.invites:
+        host_id = row[0]
+        if user_id != host_id and user_id not in self.invites.get(session_id, set()):
             raise PermissionError("not_invited")
-        session.add_participant(user_id)
+        self.participants.setdefault(session_id, set()).add(user_id)
 
     def leave_session(self, session_id: str, user_id: int) -> None:
-        session = self.sessions.get(session_id)
-        if not session:
+        parts = self.participants.get(session_id)
+        if not parts:
             return
-        session.remove_participant(user_id)
-        if not session.participants:
-            self.sessions.pop(session_id, None)
+        parts.discard(user_id)
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "DELETE FROM jam_streams WHERE session_id = ? AND user_id = ?",
+                (session_id, user_id),
+            )
+            if not parts:
+                cur.execute("DELETE FROM jam_sessions WHERE id = ?", (session_id,))
+                cur.execute("DELETE FROM jam_streams WHERE session_id = ?", (session_id,))
+            conn.commit()
+        if not parts:
+            self.participants.pop(session_id, None)
+            self.invites.pop(session_id, None)
 
     def start_stream(
         self, session_id: str, user_id: int, stream_id: str, codec: str, premium: bool = False
     ) -> AudioStream:
-        session = self.sessions.get(session_id)
-        if not session:
-            raise KeyError("session_not_found")
-        if user_id not in session.participants:
+        if user_id not in self.participants.get(session_id, set()):
             raise PermissionError("not_participant")
         stream = AudioStream(user_id=user_id, stream_id=stream_id, codec=codec, premium=premium)
-        session.streams[user_id] = stream
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO jam_streams(session_id, user_id, stream_id, codec, premium, started_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (session_id, user_id, stream_id, codec, int(premium), stream.started_at),
+            )
+            conn.commit()
         if premium:
             self.economy.withdraw(user_id, PREMIUM_STREAM_CENTS)
         return stream
 
     def stop_stream(self, session_id: str, user_id: int) -> None:
-        session = self.sessions.get(session_id)
-        if not session:
-            return
-        session.streams.pop(user_id, None)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "DELETE FROM jam_streams WHERE session_id = ? AND user_id = ?",
+                (session_id, user_id),
+            )
+            conn.commit()

--- a/backend/tests/admin/test_audit_logging.py
+++ b/backend/tests/admin/test_audit_logging.py
@@ -9,8 +9,10 @@ from backend.routes import admin_media_moderation_routes as media_routes
 from backend.models.economy_config import set_config, save_config, EconomyConfig
 
 
-def test_log_action_and_query():
+def test_log_action_and_query(tmp_path):
     svc = get_admin_audit_service()
+    svc.db_path = str(tmp_path / "audit.db")
+    svc.ensure_schema()
     svc.clear()
     svc.log_action(1, "create", "/x")
     svc.log_action(2, "delete", "/y")
@@ -20,7 +22,7 @@ def test_log_action_and_query():
     assert svc.query(limit=1) == logs[:1]
 
 
-def test_admin_route_logs_action(monkeypatch):
+def test_admin_route_logs_action(monkeypatch, tmp_path):
     async def fake_current_user(req: Request):
         return 99
 
@@ -34,6 +36,8 @@ def test_admin_route_logs_action(monkeypatch):
     )
 
     svc = get_admin_audit_service()
+    svc.db_path = str(tmp_path / "audit.db")
+    svc.ensure_schema()
     svc.clear()
 
     req = type("Req", (), {"method": "POST", "url": type("U", (), {"path": "/admin/media/flag/1"})()})()

--- a/backend/tests/jam_sessions/test_jam_gateway.py
+++ b/backend/tests/jam_sessions/test_jam_gateway.py
@@ -27,9 +27,18 @@ class FakeWebSocket:
 
 def test_jam_session_flow(tmp_path):
     async def run() -> None:
-        jam_service.sessions.clear()
-        jam_service.economy.db_path = str(tmp_path / "jam.db")
+        jam_service.invites.clear()
+        jam_service.participants.clear()
+        jam_service.db_path = str(tmp_path / "jam.db")
+        jam_service.ensure_schema()
+        jam_service.economy.db_path = str(tmp_path / "jam_eco.db")
         jam_service.economy.ensure_schema()
+        # clear jam tables
+        import sqlite3
+        with sqlite3.connect(jam_service.db_path) as conn:
+            conn.execute("DELETE FROM jam_sessions")
+            conn.execute("DELETE FROM jam_streams")
+            conn.commit()
 
         host_id = 1
         user_id = 2

--- a/backend/tests/social/test_friendships.py
+++ b/backend/tests/social/test_friendships.py
@@ -1,0 +1,27 @@
+import asyncio
+import sqlite3
+
+from backend.services.social_service import social_service
+from backend.realtime import social_gateway
+
+
+def test_friend_request_flow(tmp_path, monkeypatch):
+    async def run():
+        social_service.db_path = str(tmp_path / "social.db")
+        social_service.ensure_schema()
+        with sqlite3.connect(social_service.db_path) as conn:
+            conn.execute("DELETE FROM friend_requests")
+            conn.execute("DELETE FROM friendships")
+            conn.commit()
+
+        async def fake_publish(target_user_id: int, from_user_id: int) -> int:
+            return 0
+
+        monkeypatch.setattr(social_gateway, "publish_friend_request", fake_publish)
+
+        req = await social_service.send_friend_request(1, 2)
+        await social_service.accept_friend_request(req.id, 2)
+        assert social_service.list_friends(1) == [2]
+        assert social_service.list_friends(2) == [1]
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- store admin audit logs, friend data, jam sessions and streams in SQLite
- refactor services to use persistent storage instead of in-memory dictionaries
- add migration and tests for persistent layers

## Testing
- `pytest backend/tests/admin/test_audit_logging.py backend/tests/jam_sessions/test_jam_gateway.py backend/tests/social/test_friendships.py -q`
- `pytest -q` *(fails: _field() missing 1 required positional argument: 'default'; ModuleNotFoundError: No module named 'fastapi.exceptions'; SyntaxError: invalid syntax; ModuleNotFoundError: No module named 'starlette'; SyntaxError in test_logging_json.py; ImportError: cannot import name 'MailService'; SyntaxError in test_metrics.py; SyntaxError in test_metrics_smoke.py; ModuleNotFoundError: No module named 'boto3'; SyntaxError in test_world_pulse_jobs.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ebfa66e0832594fdaa5e88b9972a