### PR TITLE
Add basic banking features with loans and interest

### DIFF
--- a/backend/models/banking.py
+++ b/backend/models/banking.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Loan:
+    """Represents a loan issued to a user."""
+
+    id: Optional[int]
+    user_id: int
+    principal_cents: int
+    balance_cents: int
+    interest_rate: float
+    term_days: int
+    created_at: Optional[datetime] = None
+
+
+@dataclass
+class InterestAccount:
+    """An interest bearing account linked to a user."""
+
+    id: Optional[int]
+    user_id: int
+    balance_cents: int
+    interest_rate: float
+    currency: str = "USD"
+    created_at: Optional[datetime] = None
+
+
+@dataclass
+class ExchangeRate:
+    """Exchange rate between two currencies."""
+
+    base_currency: str
+    target_currency: str
+    rate: float
+    updated_at: Optional[datetime] = None

--- a/backend/routes/banking_routes.py
+++ b/backend/routes/banking_routes.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.services.economy_service import EconomyError, EconomyService
+
+router = APIRouter(prefix="/banking", tags=["Banking"])
+svc = EconomyService()
+svc.ensure_schema()
+
+
+class LoanIn(BaseModel):
+    user_id: int
+    amount_cents: int
+    interest_rate: float
+    term_days: int
+
+
+class ConversionIn(BaseModel):
+    amount_cents: int
+    from_currency: str
+    to_currency: str
+
+
+@router.post("/loans")
+def create_loan(payload: LoanIn):
+    try:
+        loan_id = svc.create_loan(
+            payload.user_id,
+            payload.amount_cents,
+            payload.interest_rate,
+            payload.term_days,
+        )
+        return {"loan_id": loan_id}
+    except EconomyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/convert")
+def convert(payload: ConversionIn):
+    try:
+        amount = svc.convert_currency(
+            payload.amount_cents, payload.from_currency, payload.to_currency
+        )
+        return {"amount_cents": amount}
+    except EconomyError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/backend/services/business_service.py
+++ b/backend/services/business_service.py
@@ -137,3 +137,13 @@ class BusinessService:
 
     def get_business(self, business_id: int) -> Optional[Dict[str, Any]]:
         return self._fetch(business_id)
+
+    # investment features
+    def invest(self, owner_id: int, amount_cents: int, interest_rate: float) -> int:
+        if amount_cents <= 0:
+            raise ValueError("amount_cents must be positive")
+        self.economy.withdraw(owner_id, amount_cents)
+        return self.economy.open_interest_account(owner_id, amount_cents, interest_rate)
+
+    def collect_investment_returns(self, account_id: int) -> int:
+        return self.economy.calculate_daily_interest(account_id)

--- a/backend/services/property_service.py
+++ b/backend/services/property_service.py
@@ -75,9 +75,12 @@ class PropertyService:
         location: str,
         price_cents: int,
         base_rent: int,
+        mortgage_rate: float | None = None,
     ) -> int:
         if price_cents <= 0:
             raise PropertyError("Price must be positive")
+        if mortgage_rate is not None:
+            self.economy.create_loan(owner_id, price_cents, mortgage_rate, term_days=365)
         try:
             self.economy.withdraw(owner_id, price_cents)
         except EconomyError as e:

--- a/backend/tests/economy/test_banking.py
+++ b/backend/tests/economy/test_banking.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.services.economy_service import EconomyError, EconomyService
+from backend.services.property_service import PropertyService
+from backend.services.business_service import BusinessService
+
+
+def setup_env():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    econ = EconomyService(db_path=path)
+    econ.ensure_schema()
+    prop = PropertyService(db_path=path, economy=econ)
+    prop.ensure_schema()
+    biz = BusinessService(db_path=path, economy=econ)
+    biz.ensure_schema()
+    return econ, prop, biz
+
+
+def test_mortgage_property_creates_loan():
+    econ, prop, _ = setup_env()
+    pid = prop.buy_property(
+        owner_id=1,
+        name="House",
+        property_type="home",
+        location="LA",
+        price_cents=1000,
+        base_rent=100,
+        mortgage_rate=0.05,
+    )
+    assert pid > 0
+    loans = econ.list_loans(1)
+    assert loans and loans[0].balance_cents == 1000
+    assert econ.get_balance(1) == 0
+
+
+def test_investment_interest_returns():
+    econ, _, biz = setup_env()
+    econ.deposit(1, 1000)
+    acct = biz.invest(1, 500, 0.1)
+    interest = biz.collect_investment_returns(acct)
+    assert interest == 50
+    assert econ.get_balance(1) == 550
+
+
+def test_currency_conversion_and_missing_rate():
+    econ, _, _ = setup_env()
+    econ.set_exchange_rate("USD", "EUR", 0.5)
+    assert econ.convert_currency(200, "USD", "EUR") == 100
+    with pytest.raises(EconomyError):
+        econ.convert_currency(100, "EUR", "JPY")
+
+
+def test_create_loan_invalid_amount():
+    econ, _, _ = setup_env()
+    with pytest.raises(EconomyError):
+        econ.create_loan(1, 0, 0.05, 10)


### PR DESCRIPTION
## Summary
- add Loan, InterestAccount and ExchangeRate models
- extend EconomyService with loans, interest calculation and currency conversion
- enable mortgages and investment returns via property and business services
- expose banking endpoints and add banking tests

## Testing
- `pytest backend/tests/economy/test_banking.py -q`
- `pytest backend/tests/property/test_property_service.py -q`
- `pytest backend/tests/economy/test_economy_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ed2028708325bcebdc07981f6498