### PR TITLE
Add gear crafting system with bonuses

### DIFF
--- a/backend/models/gear.py
+++ b/backend/models/gear.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class StatModifier:
+    """Simple stat modifier applied by gear."""
+
+    stat: str
+    amount: float
+
+
+@dataclass
+class BaseItem:
+    """Base blueprint for craftable gear."""
+
+    name: str
+    durability: int
+    base_modifiers: List[StatModifier] = field(default_factory=list)
+
+
+@dataclass
+class GearComponent:
+    """Component that influences crafting success and stats."""
+
+    name: str
+    success_rate: float = 1.0
+    durability_bonus: int = 0
+    modifiers: List[StatModifier] = field(default_factory=list)
+
+
+@dataclass
+class GearItem:
+    """Crafted gear with durability and stat modifiers."""
+
+    id: int
+    name: str
+    durability: int
+    modifiers: List[StatModifier] = field(default_factory=list)
+
+
+__all__ = ["StatModifier", "BaseItem", "GearComponent", "GearItem"]

--- a/backend/routes/gear_routes.py
+++ b/backend/routes/gear_routes.py
@@ -1,0 +1,57 @@
+"""REST routes for gear crafting and management."""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import List
+
+from services.gear_service import gear_service
+
+
+router = APIRouter(prefix="/gear", tags=["Gear"])
+
+
+class CraftIn(BaseModel):
+    band_id: int
+    base: str
+    components: List[str]
+
+
+@router.post("/craft")
+def craft_item(payload: CraftIn):
+    try:
+        item = gear_service.craft(payload.base, payload.components)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if not item:
+        raise HTTPException(status_code=400, detail="Crafting failed")
+    gear_service.assign_to_band(payload.band_id, item)
+    return gear_service.asdict(item)
+
+
+class RepairIn(BaseModel):
+    amount: int
+
+
+@router.post("/{item_id}/repair")
+def repair_item(item_id: int, payload: RepairIn):
+    item = gear_service.repair(item_id, payload.amount)
+    return gear_service.asdict(item)
+
+
+class TradeIn(BaseModel):
+    item_id: int
+    from_band: int
+    to_band: int
+
+
+@router.post("/trade")
+def trade_item(payload: TradeIn):
+    try:
+        gear_service.trade(payload.item_id, payload.from_band, payload.to_band)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"status": "ok"}
+
+
+__all__ = ["router"]
+

--- a/backend/services/gear_service.py
+++ b/backend/services/gear_service.py
@@ -1,0 +1,97 @@
+"""Service managing gear crafting and bonuses."""
+from __future__ import annotations
+
+import random
+from dataclasses import asdict
+from itertools import chain
+from typing import Dict, List
+
+from backend.models.gear import BaseItem, GearComponent, GearItem, StatModifier
+
+
+class GearService:
+    """In-memory gear crafting and management."""
+
+    def __init__(self) -> None:
+        self.base_items: Dict[str, BaseItem] = {}
+        self.components: Dict[str, GearComponent] = {}
+        self.items: Dict[int, GearItem] = {}
+        self._ownership: Dict[int, int] = {}  # item_id -> band_id
+        self._band_items: Dict[int, List[int]] = {}
+        self._id_seq = 1
+
+    # ------------------------------------------------------------------
+    # crafting and upgrades
+    # ------------------------------------------------------------------
+    def craft(self, base_name: str, component_names: List[str]) -> GearItem | None:
+        base = self.base_items.get(base_name)
+        if not base:
+            raise ValueError("unknown base item")
+        comps: List[GearComponent] = []
+        chance = 1.0
+        for name in component_names:
+            comp = self.components.get(name)
+            if not comp:
+                raise ValueError(f"unknown component {name}")
+            comps.append(comp)
+            chance *= comp.success_rate
+        if random.random() > chance:
+            return None
+        durability = base.durability + sum(c.durability_bonus for c in comps)
+        modifiers = list(base.base_modifiers) + list(chain.from_iterable(c.modifiers for c in comps))
+        item = GearItem(id=self._id_seq, name=base.name, durability=durability, modifiers=modifiers)
+        self.items[item.id] = item
+        self._id_seq += 1
+        return item
+
+    def upgrade(self, item_id: int, component_name: str) -> GearItem | None:
+        item = self.items.get(item_id)
+        comp = self.components.get(component_name)
+        if not item or not comp:
+            raise ValueError("invalid item or component")
+        if random.random() > comp.success_rate:
+            item.durability = max(0, item.durability - 5)
+            return None
+        item.durability += comp.durability_bonus
+        item.modifiers.extend(comp.modifiers)
+        return item
+
+    def repair(self, item_id: int, amount: int) -> GearItem:
+        item = self.items[item_id]
+        item.durability += amount
+        return item
+
+    # ------------------------------------------------------------------
+    # ownership and bonuses
+    # ------------------------------------------------------------------
+    def assign_to_band(self, band_id: int, item: GearItem) -> None:
+        self._ownership[item.id] = band_id
+        self._band_items.setdefault(band_id, []).append(item.id)
+
+    def trade(self, item_id: int, from_band: int, to_band: int) -> None:
+        owner = self._ownership.get(item_id)
+        if owner != from_band:
+            raise ValueError("item not owned by source band")
+        self._ownership[item_id] = to_band
+        self._band_items[from_band].remove(item_id)
+        self._band_items.setdefault(to_band, []).append(item_id)
+
+    def get_band_bonus(self, band_id: int, stat: str) -> float:
+        total = 0.0
+        for iid in self._band_items.get(band_id, []):
+            item = self.items[iid]
+            for mod in item.modifiers:
+                if mod.stat == stat:
+                    total += mod.amount
+        return total
+
+    # helper for routes
+    def asdict(self, item: GearItem) -> Dict:
+        data = asdict(item)
+        data["modifiers"] = [asdict(m) for m in item.modifiers]
+        return data
+
+
+gear_service = GearService()
+
+__all__ = ["GearService", "gear_service"]

--- a/backend/services/live_performance_service.py
+++ b/backend/services/live_performance_service.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from backend.database import DB_PATH
 from backend.services.city_service import city_service
 from backend.services.event_service import is_skill_blocked
+from backend.services.gear_service import gear_service
 
 
 def simulate_gig(band_id: int, city: str, venue: str, setlist: list) -> dict:
@@ -26,6 +27,7 @@ def simulate_gig(band_id: int, city: str, venue: str, setlist: list) -> dict:
     fame_earned = crowd_size // 10
     revenue_earned = crowd_size * 5
     skill_gain = len(setlist) * 0.3
+    skill_gain += gear_service.get_band_bonus(band_id, "performance")
     applied_skill = 0 if is_skill_blocked(band_id, "performance") else skill_gain
     merch_sold = int(crowd_size * 0.15 * city_service.get_market_demand(city))
 

--- a/backend/services/rehearsal_service.py
+++ b/backend/services/rehearsal_service.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 from backend.services.event_service import is_skill_blocked
+from backend.services.gear_service import gear_service
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 
@@ -103,6 +104,7 @@ class RehearsalService:
 
             attendee_list: List[int] = list(attendees)
             bonus = float(len(attendee_list)) * 0.5
+            bonus += gear_service.get_band_bonus(band_id, "rehearsal")
             c.execute(
                 """
                 INSERT INTO rehearsals(band_id, start, end, attendees, bonus)

--- a/backend/tests/gear/test_crafting.py
+++ b/backend/tests/gear/test_crafting.py
@@ -1,0 +1,29 @@
+from backend.services.gear_service import GearService
+from backend.models.gear import BaseItem, GearComponent, StatModifier
+
+
+def test_crafting_success(monkeypatch):
+    svc = GearService()
+    svc.base_items["amp"] = BaseItem(name="amp", durability=50)
+    svc.components["tube"] = GearComponent(
+        name="tube",
+        success_rate=0.8,
+        durability_bonus=5,
+        modifiers=[StatModifier("performance", 1.0)],
+    )
+
+    monkeypatch.setattr("backend.services.gear_service.random.random", lambda: 0.1)
+    item = svc.craft("amp", ["tube"])
+    assert item is not None
+    assert item.durability == 55
+    assert item.modifiers[0].stat == "performance"
+
+
+def test_crafting_failure(monkeypatch):
+    svc = GearService()
+    svc.base_items["amp"] = BaseItem(name="amp", durability=50)
+    svc.components["tube"] = GearComponent(name="tube", success_rate=0.2)
+
+    monkeypatch.setattr("backend.services.gear_service.random.random", lambda: 0.9)
+    item = svc.craft("amp", ["tube"])
+    assert item is None


### PR DESCRIPTION
## Summary
- add dataclasses for gear items, components, and stat modifiers
- implement in-memory GearService for crafting, upgrades, durability, and bonuses
- expose gear crafting, repair, and trade routes
- apply gear bonuses in performance and rehearsal services
- add unit tests for crafting success and failure

## Testing
- `pytest backend/tests/gear/test_crafting.py backend/tests/rehearsal/test_rehearsal_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2f0e94df88325a1fc4a1c20c160a5