### PR TITLE
Add crowdfunding campaigns with pledge and payout management

### DIFF
--- a/backend/models/crowdfunding.py
+++ b/backend/models/crowdfunding.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class Campaign:
+    """Represents a crowdfunding campaign."""
+
+    id: int
+    creator_id: int
+    goal_cents: int
+    pledged_cents: int = 0
+    completed: bool = False
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+@dataclass
+class Pledge:
+    """Record of a pledge made toward a campaign."""
+
+    id: int
+    campaign_id: int
+    backer_id: int
+    amount_cents: int
+    pledged_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+@dataclass
+class PayoutSchedule:
+    """Defines how funds are shared once a campaign completes."""
+
+    campaign_id: int
+    creator_share: float = 0.8
+    backer_share: float = 0.2

--- a/backend/routes/crowdfunding_routes.py
+++ b/backend/routes/crowdfunding_routes.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.services.crowdfunding_service import CrowdfundingService, CrowdfundingError
+from backend.services.economy_service import EconomyService
+
+router = APIRouter(prefix="/crowdfunding", tags=["Crowdfunding"])
+svc = CrowdfundingService(economy=EconomyService())
+svc.ensure_schema()
+
+
+class CampaignCreateIn(BaseModel):
+    creator_id: int
+    goal_cents: int
+    creator_share: float = 0.8
+    backer_share: float = 0.2
+
+
+@router.post("/campaigns")
+def launch_campaign(payload: CampaignCreateIn):
+    cid = svc.create_campaign(
+        creator_id=payload.creator_id,
+        goal_cents=payload.goal_cents,
+        creator_share=payload.creator_share,
+        backer_share=payload.backer_share,
+    )
+    return {"campaign_id": cid}
+
+
+class PledgeIn(BaseModel):
+    campaign_id: int
+    backer_id: int
+    amount_cents: int
+
+
+@router.post("/pledge")
+def pledge(payload: PledgeIn):
+    try:
+        pid = svc.pledge(payload.campaign_id, payload.backer_id, payload.amount_cents)
+        return {"pledge_id": pid}
+    except CrowdfundingError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:  # Economy errors
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/campaigns/{campaign_id}/complete")
+def complete_campaign(campaign_id: int):
+    try:
+        svc.complete_campaign(campaign_id)
+        return {"ok": True}
+    except CrowdfundingError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/backend/services/crowdfunding_service.py
+++ b/backend/services/crowdfunding_service.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+from backend.services.economy_service import EconomyService
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class CrowdfundingError(Exception):
+    pass
+
+
+class CrowdfundingService:
+    """Service managing crowdfunding campaigns and pledges."""
+
+    def __init__(self, economy: Optional[EconomyService] = None, db_path: str | None = None):
+        self.db_path = str(db_path or DB_PATH)
+        self.economy = economy or EconomyService(db_path=self.db_path)
+        try:
+            self.economy.ensure_schema()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS campaigns (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    creator_id INTEGER NOT NULL,
+                    goal_cents INTEGER NOT NULL,
+                    pledged_cents INTEGER NOT NULL DEFAULT 0,
+                    completed INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT DEFAULT (datetime('now'))
+                )
+                """,
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS pledges (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    campaign_id INTEGER NOT NULL,
+                    backer_id INTEGER NOT NULL,
+                    amount_cents INTEGER NOT NULL,
+                    pledged_at TEXT DEFAULT (datetime('now')),
+                    FOREIGN KEY(campaign_id) REFERENCES campaigns(id)
+                )
+                """,
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS payout_schedules (
+                    campaign_id INTEGER PRIMARY KEY,
+                    creator_share REAL NOT NULL,
+                    backer_share REAL NOT NULL,
+                    FOREIGN KEY(campaign_id) REFERENCES campaigns(id)
+                )
+                """,
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def create_campaign(
+        self,
+        creator_id: int,
+        goal_cents: int,
+        creator_share: float = 0.8,
+        backer_share: float = 0.2,
+    ) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO campaigns(creator_id, goal_cents, created_at) VALUES (?, ?, datetime('now'))",
+                (creator_id, goal_cents),
+            )
+            cid = int(cur.lastrowid)
+            cur.execute(
+                "INSERT INTO payout_schedules(campaign_id, creator_share, backer_share) VALUES (?,?,?)",
+                (cid, creator_share, backer_share),
+            )
+            conn.commit()
+        return cid
+
+    # ------------------------------------------------------------------
+    def pledge(self, campaign_id: int, backer_id: int, amount_cents: int) -> int:
+        self.economy.withdraw(backer_id, amount_cents)
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO pledges(campaign_id, backer_id, amount_cents, pledged_at) VALUES (?, ?, ?, datetime('now'))",
+                (campaign_id, backer_id, amount_cents),
+            )
+            pid = int(cur.lastrowid)
+            cur.execute(
+                "UPDATE campaigns SET pledged_cents = pledged_cents + ? WHERE id = ?",
+                (amount_cents, campaign_id),
+            )
+            conn.commit()
+        return pid
+
+    # ------------------------------------------------------------------
+    def complete_campaign(self, campaign_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT creator_id, goal_cents, pledged_cents, completed FROM campaigns WHERE id = ?",
+                (campaign_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise CrowdfundingError("campaign_not_found")
+            creator_id, goal_cents, pledged_cents, completed = row
+            if completed:
+                raise CrowdfundingError("campaign_already_completed")
+            if pledged_cents < goal_cents:
+                raise CrowdfundingError("goal_not_met")
+            cur.execute("SELECT creator_share, backer_share FROM payout_schedules WHERE campaign_id=?", (campaign_id,))
+            ps_row = cur.fetchone()
+            creator_share, backer_share = ps_row if ps_row else (0.8, 0.2)
+            cur.execute("SELECT backer_id, amount_cents FROM pledges WHERE campaign_id=?", (campaign_id,))
+            pledges = cur.fetchall()
+            cur.execute("UPDATE campaigns SET completed = 1 WHERE id = ?", (campaign_id,))
+            conn.commit()
+
+        total = pledged_cents
+        creator_amount = int(total * creator_share)
+        self.economy.deposit(creator_id, creator_amount)
+        for backer_id, amt in pledges:
+            share = int(amt * backer_share)
+            if share:
+                self.economy.deposit(backer_id, share)

--- a/backend/tests/crowdfunding/test_crowdfunding_service.py
+++ b/backend/tests/crowdfunding/test_crowdfunding_service.py
@@ -1,0 +1,25 @@
+from backend.services.crowdfunding_service import CrowdfundingService
+from backend.services.economy_service import EconomyService
+
+
+def test_pledge_and_distribution(tmp_path):
+    db = tmp_path / "db.sqlite"
+    economy = EconomyService(db_path=str(db))
+    economy.ensure_schema()
+    svc = CrowdfundingService(db_path=str(db), economy=economy)
+    svc.ensure_schema()
+
+    # Seed backers with funds
+    economy.deposit(user_id=1, amount_cents=1000)
+    economy.deposit(user_id=2, amount_cents=1000)
+
+    campaign_id = svc.create_campaign(creator_id=3, goal_cents=1000, creator_share=0.5, backer_share=0.5)
+
+    svc.pledge(campaign_id=campaign_id, backer_id=1, amount_cents=600)
+    svc.pledge(campaign_id=campaign_id, backer_id=2, amount_cents=400)
+
+    svc.complete_campaign(campaign_id)
+
+    assert economy.get_balance(1) == 700  # 1000 - 600 + (600 * 0.5)
+    assert economy.get_balance(2) == 800  # 1000 - 400 + (400 * 0.5)
+    assert economy.get_balance(3) == 500  # creator share


### PR DESCRIPTION
## Summary
- Introduce crowdfunding datamodels for campaigns, pledges and payout schedules
- Implement CrowdfundingService for pledges and revenue distribution via EconomyService
- Add API routes to launch campaigns, pledge funds and trigger payouts
- Cover pledge and distribution logic with unit tests

## Testing
- `pytest backend/tests/crowdfunding/test_crowdfunding_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f1fd64b4832583bd1ad00069dc3f