### PR TITLE
Add tournament bracket service with performance-based scoring

### DIFF
--- a/backend/models/tournament.py
+++ b/backend/models/tournament.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class Score:
+    """Represents performance metrics for a band within a match."""
+
+    band_id: int
+    fame_earned: int = 0
+    revenue_earned: int = 0
+    crowd_size: int = 0
+
+    @property
+    def value(self) -> int:
+        """Total points used to determine winners.
+
+        Currently this simply uses fame earned from a performance but can be
+        extended with other metrics.
+        """
+
+        return self.fame_earned
+
+
+@dataclass
+class Match:
+    """A single contest between two bands."""
+
+    band1_id: int
+    band2_id: int
+    band1_score: Optional[int] = None
+    band2_score: Optional[int] = None
+    winner_id: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "band1_id": self.band1_id,
+            "band2_id": self.band2_id,
+            "band1_score": self.band1_score,
+            "band2_score": self.band2_score,
+            "winner_id": self.winner_id,
+        }
+
+
+@dataclass
+class Bracket:
+    """A collection of rounds, each round containing matches."""
+
+    rounds: List[List[Match]] = field(default_factory=list)
+
+    def add_round(self, matches: List[Match]) -> None:
+        self.rounds.append(matches)
+
+    def current_round(self) -> List[Match]:
+        return self.rounds[-1] if self.rounds else []
+
+    def to_dict(self) -> dict:
+        return {"rounds": [[m.to_dict() for m in rnd] for rnd in self.rounds]}

--- a/backend/routes/tournament_routes.py
+++ b/backend/routes/tournament_routes.py
@@ -1,0 +1,37 @@
+from flask import Blueprint, jsonify, request
+
+from services.tournament_service import TournamentService
+
+
+tournament_routes = Blueprint("tournament_routes", __name__)
+service = TournamentService()
+
+
+@tournament_routes.route("/tournaments", methods=["POST"])
+def register_bands():
+    data = request.get_json() or {}
+    band_ids = data.get("band_ids", [])
+    if not band_ids:
+        return jsonify({"error": "band_ids required"}), 400
+    tid = service.create_tournament(band_ids)
+    return jsonify({"tournament_id": tid}), 201
+
+
+@tournament_routes.route("/tournaments/<int:tid>/bracket", methods=["GET"])
+def view_bracket(tid: int):
+    bracket = service.get_bracket(tid)
+    if not bracket:
+        return jsonify({"error": "tournament not found"}), 404
+    return jsonify(bracket.to_dict())
+
+
+@tournament_routes.route("/tournaments/<int:tid>/results", methods=["POST"])
+def report_results(tid: int):
+    bracket = service.get_bracket(tid)
+    if not bracket:
+        return jsonify({"error": "tournament not found"}), 404
+    champion = service.play_round(bracket)
+    response = {"bracket": bracket.to_dict()}
+    if champion is not None:
+        response["champion"] = champion
+    return jsonify(response)

--- a/backend/services/tournament_service.py
+++ b/backend/services/tournament_service.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+import sqlite3
+
+from backend.models.tournament import Bracket, Match, Score
+from backend.services import live_performance_service
+from backend.database import DB_PATH
+
+
+class TournamentService:
+    """Service for managing simple elimination tournaments."""
+
+    def __init__(
+        self,
+        performance_service: Optional[object] = None,
+        db_path: str = DB_PATH,
+        prize_amount: int = 1000,
+    ):
+        # ``performance_service`` is expected to provide a ``simulate_gig``
+        # function.  By default we use the module-level implementation from
+        # :mod:`live_performance_service`.
+        self.performance = performance_service or live_performance_service
+        self.db_path = db_path
+        self.prize_amount = prize_amount
+        self.brackets: Dict[int, Bracket] = {}
+        self._next_id = 1
+
+    # Tournament management -------------------------------------------------
+    def create_tournament(self, band_ids: List[int]) -> int:
+        bracket = self._create_bracket(band_ids)
+        tid = self._next_id
+        self.brackets[tid] = bracket
+        self._next_id += 1
+        return tid
+
+    def get_bracket(self, tournament_id: int) -> Optional[Bracket]:
+        return self.brackets.get(tournament_id)
+
+    # Core logic ------------------------------------------------------------
+    def _create_bracket(self, band_ids: List[int]) -> Bracket:
+        matches: List[Match] = []
+        it = iter(band_ids)
+        for b1, b2 in zip(it, it):
+            matches.append(Match(b1, b2))
+        bracket = Bracket()
+        bracket.add_round(matches)
+        return bracket
+
+    def play_round(self, bracket: Bracket) -> Optional[int]:
+        """Play the current round, returning champion id if concluded."""
+
+        current = bracket.current_round()
+        if not current:
+            return None
+
+        winners: List[int] = []
+        for match in current:
+            score1 = self._calculate_score(match.band1_id)
+            score2 = self._calculate_score(match.band2_id)
+            match.band1_score = score1.value
+            match.band2_score = score2.value
+            match.winner_id = match.band1_id if score1.value >= score2.value else match.band2_id
+            winners.append(match.winner_id)
+            self._award_prize(match.winner_id)
+
+        if len(winners) == 1:
+            # Champion determined
+            return winners[0]
+
+        next_round: List[Match] = []
+        it = iter(winners)
+        for b1, b2 in zip(it, it):
+            next_round.append(Match(b1, b2))
+        bracket.add_round(next_round)
+        return None
+
+    # Helpers ---------------------------------------------------------------
+    def _calculate_score(self, band_id: int) -> Score:
+        result = self.performance.simulate_gig(
+            band_id=band_id, city="Arena City", venue="Grand Arena", setlist=["song"]
+        )
+        return Score(
+            band_id=band_id,
+            fame_earned=result.get("fame_earned", 0),
+            revenue_earned=result.get("revenue_earned", 0),
+            crowd_size=result.get("crowd_size", 0),
+        )
+
+    def _award_prize(self, band_id: int) -> None:
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE bands SET revenue = COALESCE(revenue, 0) + ? WHERE id = ?",
+            (self.prize_amount, band_id),
+        )
+        conn.commit()
+        conn.close()

--- a/backend/tests/tournament/test_tournament_service.py
+++ b/backend/tests/tournament/test_tournament_service.py
@@ -1,0 +1,73 @@
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys_path = Path(__file__).resolve().parents[3]
+import sys
+if str(sys_path) not in sys.path:
+    sys.path.append(str(sys_path))
+
+from backend.services.tournament_service import TournamentService
+
+
+class DummyPerformance:
+    def __init__(self, scores):
+        self.scores = scores
+
+    def simulate_gig(self, band_id, city, venue, setlist):
+        value = self.scores[band_id]
+        return {
+            "status": "ok",
+            "city": city,
+            "venue": venue,
+            "crowd_size": value * 10,
+            "fame_earned": value,
+            "revenue_earned": 0,
+            "skill_gain": 0,
+            "merch_sold": 0,
+        }
+
+
+def setup_service(scores):
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE bands (id INTEGER PRIMARY KEY, revenue INTEGER)")
+    for i in range(1, 5):
+        cur.execute("INSERT INTO bands (id, revenue) VALUES (?, 0)", (i,))
+    conn.commit()
+    conn.close()
+    perf = DummyPerformance(scores)
+    svc = TournamentService(performance_service=perf, db_path=path, prize_amount=1000)
+    return svc, path
+
+
+def test_bracket_progression_and_prize():
+    scores = {1: 10, 2: 20, 3: 5, 4: 15}
+    svc, db_path = setup_service(scores)
+    tid = svc.create_tournament([1, 2, 3, 4])
+    bracket = svc.get_bracket(tid)
+    assert len(bracket.rounds[0]) == 2
+
+    champion = svc.play_round(bracket)
+    assert champion is None
+    assert len(bracket.rounds) == 2
+    assert [m.winner_id for m in bracket.rounds[0]] == [2, 4]
+
+    champion = svc.play_round(bracket)
+    assert champion == 2
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT revenue FROM bands WHERE id = 2")
+    winner_revenue = cur.fetchone()[0]
+    cur.execute("SELECT revenue FROM bands WHERE id = 1")
+    loser_revenue = cur.fetchone()[0]
+    conn.close()
+
+    assert winner_revenue == 2000
+    assert loser_revenue == 0


### PR DESCRIPTION
## Summary
- introduce models for tournament brackets, matches and scores
- add service that schedules matches, uses live performance metrics for scoring and awards prizes
- expose routes for tournament creation, viewing brackets and progressing results
- include tests for bracket progression and prize payouts

## Testing
- `pytest backend/tests/tournament/test_tournament_service.py -q`
- `pytest -q` *(fails: _field() missing 1 required positional argument: 'default'; ModuleNotFoundError: No module named 'fastapi.exceptions'; ModuleNotFoundError: No module named 'starlette'; SyntaxError: invalid syntax; ImportError: cannot import name 'MailService'; SyntaxError: unexpected character after line continuation character; ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68b2f2c0943083258c80ee97d620f7c7