### PR TITLE
Add radio streaming models, service, routes and tests

### DIFF
--- a/backend/models/radio.py
+++ b/backend/models/radio.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class RadioStation:
+    """Simple representation of a radio station."""
+
+    id: int
+    name: str
+    owner_id: int
+
+
+@dataclass
+class RadioEpisode:
+    """Episode or show belonging to a radio station."""
+
+    id: int
+    station_id: int
+    title: str
+    recorded_at: datetime | None = None
+
+
+@dataclass
+class RadioSchedule:
+    """Scheduled slot for broadcasting an episode."""
+
+    id: int
+    station_id: int
+    episode_id: int
+    start_time: datetime
+    end_time: datetime | None = None
+    status: str = "scheduled"

--- a/backend/routes/radio_routes.py
+++ b/backend/routes/radio_routes.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""API routes for radio stations and streaming."""
+
+from flask import Blueprint, jsonify, request
+
+from backend.services.radio_service import RadioService
+
+radio_routes = Blueprint("radio_routes", __name__)
+_service = RadioService()
+_service.ensure_schema()
+
+
+@radio_routes.route("/radio/stations", methods=["POST"])
+def create_station():
+    data = request.get_json() or {}
+    owner_id = int(data["owner_id"])
+    name = data["name"]
+    return jsonify(_service.create_station(owner_id, name)), 201
+
+
+@radio_routes.route("/radio/stations/<int:station_id>/schedule", methods=["POST"])
+def schedule_show(station_id: int):
+    data = request.get_json() or {}
+    title = data["title"]
+    start_time = data["start_time"]
+    return jsonify(_service.schedule_show(station_id, title, start_time)), 201
+
+
+@radio_routes.route("/radio/stations/<int:station_id>/subscribe", methods=["POST"])
+def subscribe(station_id: int):
+    data = request.get_json() or {}
+    user_id = int(data["user_id"])
+    _service.subscribe(station_id, user_id)
+    return jsonify({"status": "subscribed"})
+
+
+@radio_routes.route("/radio/stations/<int:station_id>/listen", methods=["POST"])
+def listen(station_id: int):
+    data = request.get_json() or {}
+    user_id = int(data["user_id"])
+    try:
+        count = _service.listen(station_id, user_id)
+        return jsonify({"listeners": count})
+    except PermissionError:
+        return jsonify({"error": "not subscribed"}), 403

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -42,6 +42,7 @@ class AnalyticsService:
 
             res = {
                 "streams": {"plays": 0},
+                "radio": {"plays": 0},
                 "digital": {"revenue_cents": 0, "count": 0},
                 "vinyl": {"revenue_cents": 0, "units": 0},
                 "tickets": {"revenue_cents": 0, "orders": 0},
@@ -55,6 +56,18 @@ class AnalyticsService:
                     WHERE datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
                 """, (f"{period_start} 00:00:00", f"{period_end} 23:59:59"))
                 res["streams"]["plays"] = int(cur.fetchone()[0])
+
+            # Radio listeners
+            if self._table_exists(cur, "radio_listeners"):
+                cur.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM radio_listeners
+                    WHERE datetime(listened_at) >= datetime(?) AND datetime(listened_at) <= datetime(?)
+                    """,
+                    (f"{period_start} 00:00:00", f"{period_end} 23:59:59"),
+                )
+                res["radio"]["plays"] = int(cur.fetchone()[0])
 
             # Digital sales
             if self._table_exists(cur, "digital_sales"):

--- a/backend/services/radio_service.py
+++ b/backend/services/radio_service.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+"""Service layer for handling radio streaming, scheduling and stats."""
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+from backend.services.economy_service import EconomyService
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+AD_REVENUE_CENTS = 1  # revenue per listener
+
+
+class RadioService:
+    def __init__(self, db_path: Optional[str] = None, economy: Optional[EconomyService] = None):
+        self.db_path = str(db_path or DB_PATH)
+        self.economy = economy or EconomyService(self.db_path)
+        self.economy.ensure_schema()
+
+    # ---------------- schema ----------------
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS radio_stations (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    owner_id INTEGER NOT NULL
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS radio_episodes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    station_id INTEGER NOT NULL,
+                    title TEXT NOT NULL,
+                    recorded_at TEXT DEFAULT (datetime('now'))
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS radio_schedule (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    station_id INTEGER NOT NULL,
+                    episode_id INTEGER NOT NULL,
+                    start_time TEXT NOT NULL,
+                    end_time TEXT,
+                    status TEXT NOT NULL DEFAULT 'scheduled'
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS radio_subscriptions (
+                    station_id INTEGER NOT NULL,
+                    user_id INTEGER NOT NULL,
+                    PRIMARY KEY (station_id, user_id)
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS radio_listeners (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    station_id INTEGER NOT NULL,
+                    user_id INTEGER NOT NULL,
+                    listened_at TEXT DEFAULT (datetime('now'))
+                )
+                """
+            )
+            conn.commit()
+
+    # ---------------- stations & scheduling ----------------
+    def create_station(self, owner_id: int, name: str) -> dict:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("INSERT INTO radio_stations(name, owner_id) VALUES (?, ?)", (name, owner_id))
+            station_id = cur.lastrowid
+            conn.commit()
+        return {"id": station_id, "name": name, "owner_id": owner_id}
+
+    def schedule_show(self, station_id: int, title: str, start_time: str) -> dict:
+        """Create an episode and schedule it for broadcast."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("INSERT INTO radio_episodes(station_id, title) VALUES (?, ?)", (station_id, title))
+            episode_id = cur.lastrowid
+            cur.execute(
+                "INSERT INTO radio_schedule(station_id, episode_id, start_time) VALUES (?, ?, ?)",
+                (station_id, episode_id, start_time),
+            )
+            schedule_id = cur.lastrowid
+            conn.commit()
+        return {
+            "id": schedule_id,
+            "station_id": station_id,
+            "episode_id": episode_id,
+            "start_time": start_time,
+        }
+
+    def subscribe(self, station_id: int, user_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO radio_subscriptions(station_id, user_id) VALUES (?, ?)",
+                (station_id, user_id),
+            )
+            conn.commit()
+
+    # ---------------- streaming ----------------
+    def listen(self, station_id: int, user_id: int) -> int:
+        """Record a listener if subscribed and pay out ad revenue."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT 1 FROM radio_subscriptions WHERE station_id=? AND user_id=?",
+                (station_id, user_id),
+            )
+            if cur.fetchone() is None:
+                raise PermissionError("User not subscribed to station")
+            cur.execute(
+                "INSERT INTO radio_listeners(station_id, user_id) VALUES (?, ?)",
+                (station_id, user_id),
+            )
+            conn.commit()
+
+        # deposit ad revenue to station owner
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT owner_id FROM radio_stations WHERE id=?", (station_id,))
+            row = cur.fetchone()
+        if row:
+            self.economy.deposit(int(row[0]), AD_REVENUE_CENTS)
+        return self.get_listener_count(station_id)
+
+    def get_listener_count(self, station_id: int) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT COUNT(*) FROM radio_listeners WHERE station_id=?",
+                (station_id,),
+            )
+            return int(cur.fetchone()[0])
+
+    # For completeness: archive completed schedules
+    def publish(self, schedule_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE radio_schedule SET status='completed' WHERE id=?",
+                (schedule_id,),
+            )
+            conn.commit()

--- a/backend/tests/radio/test_radio_service.py
+++ b/backend/tests/radio/test_radio_service.py
@@ -1,0 +1,39 @@
+import tempfile
+
+import pytest
+
+from backend.services.radio_service import RadioService
+from backend.services.economy_service import EconomyService
+from backend.services.analytics_service import AnalyticsService
+
+
+def setup_services(tmp_path):
+    db = tmp_path / "radio.db"
+    eco = tmp_path / "eco.db"
+    economy = EconomyService(str(eco))
+    economy.ensure_schema()
+    svc = RadioService(db_path=str(db), economy=economy)
+    svc.ensure_schema()
+    return svc, economy, AnalyticsService(db_path=str(db))
+
+
+def test_schedule_and_access_control(tmp_path):
+    svc, economy, analytics = setup_services(tmp_path)
+
+    station = svc.create_station(owner_id=1, name="Rock FM")
+    sched = svc.schedule_show(station_id=station["id"], title="Morning", start_time="2024-01-01T08:00:00")
+    assert sched["station_id"] == station["id"]
+
+    # Subscribe and listen
+    svc.subscribe(station["id"], user_id=2)
+    count = svc.listen(station["id"], user_id=2)
+    assert count == 1
+    assert economy.get_balance(1) == 1
+
+    # Analytics should see the listener
+    metrics = analytics.kpis("2000-01-01", "2030-12-31")
+    assert metrics["radio"]["plays"] == 1
+
+    # Unauthorized listener
+    with pytest.raises(PermissionError):
+        svc.listen(station["id"], user_id=3)


### PR DESCRIPTION
## Summary
- introduce dataclasses for radio stations, episodes and schedules
- add RadioService managing station creation, scheduling, subscriptions and listener revenue
- expose radio HTTP routes for station creation, scheduling, subscribing and listening
- integrate radio listener metrics into analytics KPIs
- cover radio scheduling and access control with tests

## Testing
- `pytest` *(fails: TypeError _field missing required positional argument)*
- `pytest backend/tests/radio/test_radio_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2f39d8cc483258eef3f9103877b71