### PR TITLE
Add marketing AI campaign planning service and analytics engagement metrics

### DIFF
--- a/backend/models/analytics.py
+++ b/backend/models/analytics.py
@@ -46,6 +46,7 @@ class FanSegmentSummary(BaseModel):
     age: List[AgeBucket]
     region: List[RegionBucket]
     spend: List[SpendBucket]
+    engagement: List["EngagementBucket"]
 
 
 class FanTrends(BaseModel):
@@ -54,3 +55,21 @@ class FanTrends(BaseModel):
     events: List[MetricPoint]
     purchases: List[MetricPoint]
     streams: List[MetricPoint]
+    likes: List[MetricPoint]
+    comments: List[MetricPoint]
+    shares: List[MetricPoint]
+
+
+class EngagementBucket(BaseModel):
+    """Number of fans grouped by engagement level."""
+
+    bucket: str
+    fans: int
+
+
+class EngagementTrends(BaseModel):
+    """Time-series metrics for engagement signals."""
+
+    likes: List[MetricPoint]
+    comments: List[MetricPoint]
+    shares: List[MetricPoint]

--- a/backend/routes/marketing_ai_routes.py
+++ b/backend/routes/marketing_ai_routes.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter
+
+from services.marketing_ai_service import (
+    accept_promotion_plan,
+    generate_promotion_plan,
+)
+
+router = APIRouter()
+
+
+@router.post("/marketing_ai/plan")
+def recommend_plan(data: dict):
+    """Generate a marketing campaign plan for the band."""
+    band_id = int(data.get("band_id"))
+    return generate_promotion_plan(band_id)
+
+
+@router.post("/marketing_ai/plan/accept")
+def accept_plan(plan: dict):
+    """Accept a proposed plan and persist it as promotions."""
+    return accept_promotion_plan(plan)

--- a/backend/services/marketing_ai_service.py
+++ b/backend/services/marketing_ai_service.py
@@ -1,0 +1,51 @@
+from datetime import date, timedelta
+from typing import Dict, List
+
+from backend.models.promotion import Promotion
+
+# In-memory storage for accepted promotions
+_promotions_db: List[Promotion] = []
+_promo_id: int = 1
+
+
+def generate_promotion_plan(band_id: int) -> Dict[str, object]:
+    """Recommend a simple campaign plan for the band."""
+    today = date.today()
+    plan = [
+        {"type": "tiktok", "date": today.isoformat(), "media_channel": "TikkaTok"},
+        {
+            "type": "radio",
+            "date": (today + timedelta(days=7)).isoformat(),
+            "media_channel": "Local Radio",
+        },
+    ]
+    return {"band_id": band_id, "plan": plan}
+
+
+def accept_promotion_plan(plan: Dict[str, object]) -> Dict[str, object]:
+    """Persist accepted plan elements into Promotion models for tracking."""
+    global _promo_id
+    accepted: List[Promotion] = []
+    band_id = int(plan.get("band_id", 0))
+    for item in plan.get("plan", []):
+        promo = Promotion(
+            id=_promo_id,
+            band_id=band_id,
+            type=item.get("type", "unknown"),
+            date=date.fromisoformat(item.get("date")),
+            outcome="pending",
+            fame_change=0.0,
+            fan_gain=0,
+            press_score_change=0.0,
+            controversy_level=0.0,
+            media_channel=item.get("media_channel"),
+        )
+        _promotions_db.append(promo)
+        accepted.append(promo)
+        _promo_id += 1
+    return {"accepted": len(accepted), "promotions": [p.dict() for p in accepted]}
+
+
+def list_accepted_promotions() -> List[Promotion]:
+    """Return all accepted promotions for inspection/testing."""
+    return _promotions_db

--- a/backend/tests/marketing_ai/test_marketing_ai_routes.py
+++ b/backend/tests/marketing_ai/test_marketing_ai_routes.py
@@ -1,0 +1,37 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routes import marketing_ai_routes
+
+
+def test_generate_and_accept_plan(monkeypatch):
+    fake_plan = {
+        "band_id": 1,
+        "plan": [
+            {
+                "type": "radio",
+                "date": "2030-01-01",
+                "media_channel": "KEXP",
+            }
+        ],
+    }
+
+    def fake_generate(band_id: int):
+        assert band_id == 1
+        return fake_plan
+
+    monkeypatch.setattr(marketing_ai_routes, "generate_promotion_plan", fake_generate)
+
+    app = FastAPI()
+    app.include_router(marketing_ai_routes.router)
+    client = TestClient(app)
+
+    r = client.post("/marketing_ai/plan", json={"band_id": 1})
+    assert r.status_code == 200
+    assert r.json() == fake_plan
+
+    r2 = client.post("/marketing_ai/plan/accept", json=fake_plan)
+    assert r2.status_code == 200
+    promotions = r2.json()["promotions"]
+    assert promotions[0]["type"] == "radio"
+    assert promotions[0]["media_channel"] == "KEXP"


### PR DESCRIPTION
## Summary
- extend analytics models with engagement buckets and trends
- implement marketing AI service for campaign recommendations and acceptance
- expose marketing AI routes and persist accepted plans as promotions
- test marketing AI workflow with mocked recommendations

## Testing
- `pytest backend/tests/marketing_ai/test_marketing_ai_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f63a45488325a50241d0f0805ba6