### PR TITLE
Add construction system with land parcels and build queues

### DIFF
--- a/backend/models/construction.py
+++ b/backend/models/construction.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class BuildPhase:
+    """Represents one stage in a construction project."""
+
+    name: str
+    duration: int  # generic time units
+
+
+@dataclass
+class Blueprint:
+    """A blueprint describing what to build on a parcel.
+
+    ``target_type`` indicates which service should be updated when the build is
+    completed.  Supported values are ``"property"`` and ``"venue"``.
+    ``upgrade_effect`` is a simple mapping of field to value that will be passed
+    to the corresponding service.  The interpretation of those fields is left to
+    the service itself.
+    """
+
+    name: str
+    cost: int
+    phases: List[BuildPhase]
+    target_type: str
+    upgrade_effect: Dict[str, int]
+
+
+@dataclass
+class LandParcel:
+    """Piece of land owned by a player on which buildings can be erected."""
+
+    id: int
+    owner_id: int
+    location: str
+    size: int
+
+
+@dataclass
+class ConstructionTask:
+    """An entry in the build queue."""
+
+    parcel_id: int
+    blueprint: Blueprint
+    owner_id: int
+    target_id: int
+    phase_index: int = 0
+    remaining: int = field(init=False)
+    prepaid_cost: int = 0
+
+    def __post_init__(self) -> None:
+        self.remaining = self.blueprint.phases[0].duration

--- a/backend/routes/construction_routes.py
+++ b/backend/routes/construction_routes.py
@@ -1,0 +1,76 @@
+from typing import Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from models.construction import Blueprint, BuildPhase
+from services.construction_service import ConstructionService
+from services.economy_service import EconomyService
+from services.property_service import PropertyService
+from services.venue_service import VenueService
+
+router = APIRouter(prefix="/construction", tags=["Construction"])
+
+econ = EconomyService()
+prop_service = PropertyService(economy=econ)
+venue_service = VenueService(economy=econ)
+svc = ConstructionService(economy=econ, properties=prop_service, venues=venue_service)
+
+
+class LandPurchaseIn(BaseModel):
+    location: str
+    size: int
+    price: int
+
+
+@router.post("/land", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+def purchase_land(payload: LandPurchaseIn, owner_id: int = Depends(get_current_user_id)):
+    try:
+        parcel_id = svc.purchase_land(owner_id, payload.location, payload.size, payload.price)
+        return {"parcel_id": parcel_id}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+class PhaseIn(BaseModel):
+    name: str
+    duration: int
+
+
+class DesignIn(BaseModel):
+    parcel_id: int
+    target_id: int
+    target_type: str
+    name: str
+    cost: int
+    phases: List[PhaseIn]
+    upgrade_effect: Dict[str, int]
+
+
+@router.post("/design", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+def submit_design(payload: DesignIn, owner_id: int = Depends(get_current_user_id)):
+    blueprint = Blueprint(
+        name=payload.name,
+        cost=payload.cost,
+        phases=[BuildPhase(p.name, p.duration) for p in payload.phases],
+        target_type=payload.target_type,
+        upgrade_effect=payload.upgrade_effect,
+    )
+    try:
+        task = svc.submit_design(payload.parcel_id, blueprint, owner_id, payload.target_id)
+        return {
+            "parcel_id": task.parcel_id,
+            "blueprint": task.blueprint.name,
+            "phase_index": task.phase_index,
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get(
+    "/progress",
+    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+)
+def progress() -> List[Dict[str, int]]:
+    return svc.get_queue()

--- a/backend/services/construction_service.py
+++ b/backend/services/construction_service.py
@@ -1,0 +1,119 @@
+"""Service for managing building construction queues and upgrades."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from models.construction import Blueprint, ConstructionTask, LandParcel
+from .economy_service import EconomyService, EconomyError
+from .property_service import PropertyService
+from .venue_service import VenueService
+
+
+class ConstructionService:
+    def __init__(
+        self,
+        economy: Optional[EconomyService] = None,
+        properties: Optional[PropertyService] = None,
+        venues: Optional[VenueService] = None,
+    ) -> None:
+        self.economy = economy or EconomyService()
+        self.property_service = properties or PropertyService(economy=self.economy)
+        self.venue_service = venues or VenueService(economy=self.economy)
+        # ensure dependent schemas
+        try:
+            self.property_service.ensure_schema()
+        except Exception:
+            pass
+        try:
+            self.venue_service.ensure_schema()
+        except Exception:
+            pass
+        self.parcels: Dict[int, LandParcel] = {}
+        self.queue: List[ConstructionTask] = []
+        self._next_parcel_id = 1
+
+    # ---------------- land management ----------------
+    def purchase_land(self, owner_id: int, location: str, size: int, price: int) -> int:
+        """Purchase a new land parcel."""
+        try:
+            self.economy.withdraw(owner_id, price)
+        except EconomyError as e:
+            raise ValueError(str(e)) from e
+        parcel_id = self._next_parcel_id
+        self._next_parcel_id += 1
+        self.parcels[parcel_id] = LandParcel(parcel_id, owner_id, location, size)
+        return parcel_id
+
+    # ---------------- building ----------------
+    def submit_design(
+        self,
+        parcel_id: int,
+        blueprint: Blueprint,
+        owner_id: int,
+        target_id: int,
+    ) -> ConstructionTask:
+        """Add a blueprint to the build queue for a parcel."""
+        if parcel_id not in self.parcels:
+            raise ValueError("Parcel not found")
+        try:
+            self.economy.withdraw(owner_id, blueprint.cost)
+        except EconomyError as e:
+            raise ValueError(str(e)) from e
+        task = ConstructionTask(parcel_id, blueprint, owner_id, target_id, prepaid_cost=blueprint.cost)
+        self.queue.append(task)
+        return task
+
+    def advance_time(self, units: int = 1) -> List[ConstructionTask]:
+        """Advance construction by ``units`` time steps."""
+        completed: List[ConstructionTask] = []
+        for task in list(self.queue):
+            task.remaining -= units
+            while task.remaining <= 0:
+                task.phase_index += 1
+                if task.phase_index >= len(task.blueprint.phases):
+                    self._complete_task(task)
+                    self.queue.remove(task)
+                    completed.append(task)
+                    break
+                task.remaining += task.blueprint.phases[task.phase_index].duration
+        return completed
+
+    def _complete_task(self, task: ConstructionTask) -> None:
+        """Apply upgrade effects when a construction task finishes."""
+        if task.blueprint.target_type == "property":
+            # Re‑deposit prepaid cost so upgrade_property can charge the owner
+            self.economy.deposit(task.owner_id, task.prepaid_cost)
+            try:
+                self.property_service.upgrade_property(task.target_id, task.owner_id)
+            except Exception:
+                pass
+            effect = task.blueprint.upgrade_effect
+            if effect:
+                import sqlite3
+
+                with sqlite3.connect(self.property_service.db_path) as conn:
+                    cur = conn.cursor()
+                    set_clause = ", ".join(f"{k} = {k} + ?" for k in effect)
+                    vals = list(effect.values()) + [task.target_id]
+                    cur.execute(f"UPDATE properties SET {set_clause} WHERE id = ?", vals)
+                    conn.commit()
+        elif task.blueprint.target_type == "venue":
+            base = self.venue_service.get_venue(task.target_id) or {}
+            updates = {k: base.get(k, 0) + v for k, v in task.blueprint.upgrade_effect.items()}
+            try:
+                self.venue_service.update_venue(task.target_id, updates)
+            except Exception:
+                pass
+
+    # ---------------- helpers ----------------
+    def get_queue(self) -> List[Dict[str, int]]:
+        """Return a serialisable view of the build queue."""
+        return [
+            {
+                "parcel_id": t.parcel_id,
+                "blueprint": t.blueprint.name,
+                "phase_index": t.phase_index,
+                "remaining": t.remaining,
+            }
+            for t in self.queue
+        ]

--- a/backend/tests/construction/test_construction_service.py
+++ b/backend/tests/construction/test_construction_service.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.services.construction_service import ConstructionService
+from backend.services.economy_service import EconomyService
+from backend.services.property_service import PropertyService
+from backend.services.venue_service import VenueService
+from backend.models.construction import Blueprint, BuildPhase
+
+
+@pytest.fixture
+def setup_services():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    econ = EconomyService(db_path=path)
+    econ.ensure_schema()
+    prop = PropertyService(db_path=path, economy=econ)
+    prop.ensure_schema()
+    venue = VenueService(db_path=path, economy=econ)
+    venue.ensure_schema()
+    svc = ConstructionService(economy=econ, properties=prop, venues=venue)
+    return svc, prop, venue, econ
+
+
+def test_build_queue_and_property_upgrade(setup_services):
+    svc, prop_service, _, econ = setup_services
+    owner = 1
+    econ.deposit(owner, 50000)
+    # purchase land and property
+    parcel_id = svc.purchase_land(owner, "NYC", 100, 1000)
+    pid = prop_service.buy_property(owner, "Studio", "studio", "NYC", 10000, 1000)
+    # blueprint to upgrade property
+    blueprint = Blueprint(
+        name="Studio Upgrade",
+        cost=10000,
+        phases=[BuildPhase("foundation", 2), BuildPhase("finishing", 1)],
+        target_type="property",
+        upgrade_effect={"base_rent": 100},
+    )
+    svc.submit_design(parcel_id, blueprint, owner, pid)
+    assert len(svc.get_queue()) == 1
+    svc.advance_time(3)
+    assert svc.get_queue() == []
+    prop = prop_service.list_properties(owner)[0]
+    assert prop["level"] == 2
+    assert prop["base_rent"] == int(1000 * 1.2) + 100
+    assert econ.get_balance(owner) == 50000 - 1000 - 10000 - 10000
+
+
+def test_venue_upgrade(setup_services):
+    svc, _, venue_service, econ = setup_services
+    owner = 2
+    econ.deposit(owner, 5000)
+    venue = venue_service.create_venue(owner, "Hall", "City", "Country", 500, 1000)
+    parcel_id = svc.purchase_land(owner, "City", 50, 0)
+    blueprint = Blueprint(
+        name="Expand Hall",
+        cost=500,
+        phases=[BuildPhase("work", 1)],
+        target_type="venue",
+        upgrade_effect={"capacity": 100},
+    )
+    svc.submit_design(parcel_id, blueprint, owner, venue["id"])
+    svc.advance_time(1)
+    updated = venue_service.get_venue(venue["id"])
+    assert updated["capacity"] == 600
+    assert econ.get_balance(owner) == 5000 - 1000 - 500


### PR DESCRIPTION
## Summary
- add dataclasses for land parcels, blueprints and build phases
- implement ConstructionService to manage build queues, costs and upgrades
- expose routes for land purchase, design submission and progress tracking
- cover property and venue upgrades with unit tests

## Testing
- `pytest backend/tests/construction/test_construction_service.py -q`
- `pytest backend/tests/property/test_property_service.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi.exceptions', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b2f723dc408325bacb1674adfea735