### PR TITLE
Add skill model and switch services to skill IDs

### DIFF
--- a/backend/models/band.py
+++ b/backend/models/band.py
@@ -65,7 +65,7 @@ class BandSkill(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     band_id = Column(Integer, ForeignKey("bands.id"), nullable=False)
-    skill = Column(String, nullable=False)
+    skill_id = Column(Integer, nullable=False)
     level = Column(Integer, default=0)
 
 

--- a/backend/models/event_effect.py
+++ b/backend/models/event_effect.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -7,14 +8,21 @@ class EventEffect:
     """Represents a temporary effect applied to a user."""
 
     user_id: int
-    skill: str | None
+    skill_id: Optional[int]
     effect: str
     start: str
     duration: int
 
-    def __init__(self, user_id: int, effect: str, duration: int, skill: str | None = None, start: str | None = None):
+    def __init__(
+        self,
+        user_id: int,
+        effect: str,
+        duration: int,
+        skill_id: Optional[int] = None,
+        start: Optional[str] = None,
+    ):
         self.user_id = user_id
-        self.skill = skill
+        self.skill_id = skill_id
         self.effect = effect
         self.start = start or datetime.utcnow().isoformat()
         self.duration = duration
@@ -22,7 +30,7 @@ class EventEffect:
     def to_dict(self) -> dict:
         return {
             "user_id": self.user_id,
-            "skill": self.skill,
+            "skill_id": self.skill_id,
             "effect": self.effect,
             "start": self.start,
             "duration": self.duration,

--- a/backend/models/event_routes.py
+++ b/backend/models/event_routes.py
@@ -1,14 +1,16 @@
 # routes/event_routes.py
 
-from fastapi import APIRouter, Depends
-from services.event_service import roll_for_daily_event, apply_event_effect
+from seeds.skill_seed import SKILL_NAME_TO_ID
+from services.event_service import apply_event_effect, roll_for_daily_event
+
+from fastapi import APIRouter
 
 router = APIRouter()
 
 @router.post("/events/daily-roll")
 def trigger_daily_event(user_id: int):
     lifestyle = {"drinking": "high"}  # normally from DB
-    skills = ["vocals", "guitar"]
+    skills = [SKILL_NAME_TO_ID["vocals"], SKILL_NAME_TO_ID["guitar"]]
     event = roll_for_daily_event(user_id, lifestyle, skills)
     if event:
         apply_event_effect(user_id, event)

--- a/backend/models/skill.py
+++ b/backend/models/skill.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Skill:
+    """Represents a learnable skill."""
+
+    id: int
+    name: str
+    category: str
+    parent_id: Optional[int] = None
+
+
+__all__ = ["Skill"]

--- a/backend/routes/event_routes.py
+++ b/backend/routes/event_routes.py
@@ -1,15 +1,16 @@
-from auth.dependencies import get_current_user_id, require_role
 # routes/event_routes.py
 
-from fastapi import APIRouter, Depends
-from services.event_service import roll_for_daily_event, apply_event_effect
+from seeds.skill_seed import SKILL_NAME_TO_ID
+from services.event_service import apply_event_effect, roll_for_daily_event
+
+from fastapi import APIRouter
 
 router = APIRouter()
 
 @router.post("/events/daily-roll")
 def trigger_daily_event(user_id: int):
     lifestyle = {"drinking": "high"}  # normally from DB
-    skills = ["vocals", "guitar"]
+    skills = [SKILL_NAME_TO_ID["vocals"], SKILL_NAME_TO_ID["guitar"]]
     event = roll_for_daily_event(user_id, lifestyle, skills)
     if event:
         apply_event_effect(user_id, event)

--- a/backend/seeds/event_seed.py
+++ b/backend/seeds/event_seed.py
@@ -1,7 +1,7 @@
 """Seed data for random in-game events."""
 
 from seeds.quest_data import get_seed_quests
-
+from seeds.skill_seed import SKILL_NAME_TO_ID
 
 QUESTS = {quest.id: quest for quest in get_seed_quests()}
 
@@ -13,7 +13,7 @@ def get_seed_events():
             "name": "Sprained Wrist",
             "type": "injury",
             "effect_type": "block_skill",
-            "skill_affected": "guitar",
+            "skill_id": SKILL_NAME_TO_ID["guitar"],
             "duration_days": 5,
             "trigger_chance": 0.01,
             "related_quest": QUESTS["first_gig"].id,
@@ -22,7 +22,7 @@ def get_seed_events():
             "name": "Lost Love for Guitar",
             "type": "burnout",
             "effect_type": "freeze_progress",
-            "skill_affected": "guitar",
+            "skill_id": SKILL_NAME_TO_ID["guitar"],
             "duration_days": 3,
             "trigger_chance": 0.01,
         },
@@ -30,7 +30,7 @@ def get_seed_events():
             "name": "Throat Infection",
             "type": "illness",
             "effect_type": "block_skill",
-            "skill_affected": "vocals",
+            "skill_id": SKILL_NAME_TO_ID["vocals"],
             "duration_days": 4,
             "trigger_chance": 0.01,
         },
@@ -38,7 +38,7 @@ def get_seed_events():
             "name": "Emotional Slump",
             "type": "emotional",
             "effect_type": "decay_skill",
-            "skill_affected": "songwriting",
+            "skill_id": SKILL_NAME_TO_ID["songwriting"],
             "duration_days": 2,
             "trigger_chance": 0.01,
         },

--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -1,0 +1,21 @@
+"""Seed data for default skills."""
+
+from backend.models.skill import Skill
+
+SEED_SKILLS = [
+    Skill(id=1, name="guitar", category="instrument"),
+    Skill(id=2, name="bass", category="instrument"),
+    Skill(id=3, name="vocals", category="performance"),
+    Skill(id=4, name="songwriting", category="creative"),
+    Skill(id=5, name="performance", category="stage"),
+]
+
+SKILL_NAME_TO_ID = {skill.name: skill.id for skill in SEED_SKILLS}
+
+
+def get_seed_skills() -> list[Skill]:
+    """Return the list of default skills."""
+    return SEED_SKILLS
+
+
+__all__ = ["get_seed_skills", "SEED_SKILLS", "SKILL_NAME_TO_ID"]

--- a/backend/services/live_performance_service.py
+++ b/backend/services/live_performance_service.py
@@ -1,6 +1,9 @@
-import sqlite3
 import random
+import sqlite3
 from datetime import datetime
+
+from seeds.skill_seed import SKILL_NAME_TO_ID
+
 from backend.database import DB_PATH
 from backend.services.city_service import city_service
 from backend.services.event_service import is_skill_blocked
@@ -28,7 +31,8 @@ def simulate_gig(band_id: int, city: str, venue: str, setlist: list) -> dict:
     revenue_earned = crowd_size * 5
     skill_gain = len(setlist) * 0.3
     skill_gain += gear_service.get_band_bonus(band_id, "performance")
-    applied_skill = 0 if is_skill_blocked(band_id, "performance") else skill_gain
+    performance_id = SKILL_NAME_TO_ID["performance"]
+    applied_skill = 0 if is_skill_blocked(band_id, performance_id) else skill_gain
     merch_sold = int(crowd_size * 0.15 * city_service.get_market_demand(city))
 
     # Record performance

--- a/backend/services/rehearsal_service.py
+++ b/backend/services/rehearsal_service.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List, Optional
 
+from seeds.skill_seed import SKILL_NAME_TO_ID
+
 from backend.services.event_service import is_skill_blocked
 from backend.services.gear_service import gear_service
 
@@ -120,7 +122,8 @@ class RehearsalService:
             )
             rehearsal_id = c.lastrowid
             # update band skills and performance
-            skill_gain = 0 if is_skill_blocked(band_id, "rehearsal") else bonus
+            performance_id = SKILL_NAME_TO_ID["performance"]
+            skill_gain = 0 if is_skill_blocked(band_id, performance_id) else bonus
             c.execute(
                 "UPDATE bands SET skill = skill + ?, performance_quality = performance_quality + ? WHERE id = ?",
                 (skill_gain, bonus * 0.5, band_id),

--- a/backend/tests/services/test_event_service.py
+++ b/backend/tests/services/test_event_service.py
@@ -1,10 +1,14 @@
 import sqlite3
 
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from services import event_service
+
 
 def test_roll_for_daily_event_trigger(monkeypatch):
     monkeypatch.setattr(event_service.random, "random", lambda: 0.0)
-    event = event_service.roll_for_daily_event(1, {"drinking": "high"}, ["vocals"])
+    event = event_service.roll_for_daily_event(
+        1, {"drinking": "high"}, [SKILL_NAME_TO_ID["vocals"]]
+    )
     assert event is not None
     assert event["event"] == "vocal fatigue"
 
@@ -19,16 +23,16 @@ def test_apply_and_block(tmp_path, monkeypatch):
     db = tmp_path / "test.db"
     monkeypatch.setattr(event_service, "DB_PATH", db)
     event_service.apply_event_effect(
-        1, {"effect": "block_skill", "skill": "guitar", "duration": 1}
+        1, {"effect": "block_skill", "skill_id": SKILL_NAME_TO_ID["guitar"], "duration": 1}
     )
-    assert event_service.is_skill_blocked(1, "guitar")
+    assert event_service.is_skill_blocked(1, SKILL_NAME_TO_ID["guitar"])
 
 
 def test_clear_expired(tmp_path, monkeypatch):
     db = tmp_path / "test.db"
     monkeypatch.setattr(event_service, "DB_PATH", db)
     event_service.apply_event_effect(
-        1, {"effect": "block_skill", "skill": "guitar", "duration": 1}
+        1, {"effect": "block_skill", "skill_id": SKILL_NAME_TO_ID["guitar"], "duration": 1}
     )
     with sqlite3.connect(db) as conn:
         conn.execute(
@@ -36,4 +40,4 @@ def test_clear_expired(tmp_path, monkeypatch):
         )
     deleted = event_service.clear_expired_events()
     assert deleted == 1
-    assert not event_service.is_skill_blocked(1, "guitar")
+    assert not event_service.is_skill_blocked(1, SKILL_NAME_TO_ID["guitar"])


### PR DESCRIPTION
## Summary
- add `Skill` model and seed data for core music skills
- update event handling and rehearsal services to use skill IDs
- refactor band skill tracking and related routes to reference skill IDs

## Testing
- `ruff check backend/models/skill.py backend/seeds/skill_seed.py backend/seeds/event_seed.py backend/services/event_service.py backend/services/rehearsal_service.py backend/services/live_performance_service.py backend/routes/event_routes.py backend/models/event_routes.py backend/tests/services/test_event_service.py`
- `pytest backend/tests/services/test_event_service.py backend/tests/rehearsal/test_rehearsal_service.py backend/tests/city/test_city_trends.py backend/tests/weather/test_weather_service.py -q`
- `pytest backend/tests/integration/test_user_flows.py -q` *(fails: ScopeMismatch: tried to access function scoped fixture monkeypatch with a session scoped request object)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f9e4a7708325abacf854d04801c7