### PR TITLE
Add genre hierarchy and integrate across models

### DIFF
--- a/backend/models/album.py
+++ b/backend/models/album.py
@@ -2,12 +2,12 @@
 from datetime import datetime
 
 class Album:
-    def __init__(self, id, title, album_type, genre, band_id, release_date=None,
+    def __init__(self, id, title, album_type, genre_id, band_id, release_date=None,
                  song_ids=None, distribution_channels=None, cover_art=None):
         self.id = id
         self.title = title
         self.album_type = album_type
-        self.genre = genre
+        self.genre_id = genre_id
         self.band_id = band_id
         self.release_date = release_date or datetime.utcnow().isoformat()
         self.song_ids = song_ids or []

--- a/backend/models/analytics.py
+++ b/backend/models/analytics.py
@@ -73,3 +73,11 @@ class EngagementTrends(BaseModel):
     likes: List[MetricPoint]
     comments: List[MetricPoint]
     shares: List[MetricPoint]
+
+
+class GenreAggregate(BaseModel):
+    """Aggregated counts for genres and subgenres."""
+
+    genre_id: int
+    subgenre_id: int | None = None
+    count: int

--- a/backend/models/band.py
+++ b/backend/models/band.py
@@ -14,7 +14,7 @@ class Band(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, index=True)
     founder_id = Column(Integer, ForeignKey("characters.id"))
-    genre = Column(String)
+    genre_id = Column(Integer, ForeignKey("genres.id"))
     formed_at = Column(DateTime(timezone=True), server_default=func.now())
     # aggregate skill metric and upcoming performance quality modifier
     skill = Column(Integer, default=0)

--- a/backend/models/festival.py
+++ b/backend/models/festival.py
@@ -20,5 +20,5 @@ class Festival(BaseModel):
     ticket_price: float
     attendance: int
     revenue: float
-    genre_focus: Optional[str]
+    genre_id: Optional[int]
     success_score: Optional[float]

--- a/backend/models/genre.py
+++ b/backend/models/genre.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+class Genre(Base):
+    __tablename__ = "genres"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+    parent_id = Column(Integer, ForeignKey("genres.id"), nullable=True)
+
+    parent = relationship("Genre", remote_side=[id], backref="subgenres")

--- a/backend/models/song.py
+++ b/backend/models/song.py
@@ -2,12 +2,12 @@
 from datetime import datetime
 
 class Song:
-    def __init__(self, id, title, duration_sec, genre, lyrics, owner_band_id,
+    def __init__(self, id, title, duration_sec, genre_id, lyrics, owner_band_id,
                  release_date=None, format='digital', royalties_split=None):
         self.id = id
         self.title = title
         self.duration_sec = duration_sec
-        self.genre = genre
+        self.genre_id = genre_id
         self.lyrics = lyrics
         self.owner_band_id = owner_band_id
         self.release_date = release_date or datetime.utcnow().isoformat()

--- a/backend/models/world_pulse.py
+++ b/backend/models/world_pulse.py
@@ -4,7 +4,8 @@ from datetime import datetime
 class WorldPulse:
     def __init__(self, id, trending_genres, karma_level, active_events, top_players, updated_at=None):
         self.id = id
-        self.trending_genres = trending_genres  # list of genre strings
+        # list of dicts: {"genre_id": int, "subgenre_id": Optional[int], "count": int}
+        self.trending_genres = trending_genres
         self.karma_level = karma_level  # e.g., 'Peaceful', 'Chaotic'
         self.active_events = active_events  # list of event titles
         self.top_players = top_players  # list of usernames or ids

--- a/backend/models/world_pulse_models.py
+++ b/backend/models/world_pulse_models.py
@@ -2,7 +2,8 @@ from pydantic import BaseModel
 from typing import List, Dict
 
 class GenreTrend(BaseModel):
-    genre: str
+    genre_id: int
+    subgenre_id: int | None = None
     trend_score: float
 
 class CityKarma(BaseModel):

--- a/backend/schemas/world_pulse_schemas.py
+++ b/backend/schemas/world_pulse_schemas.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 class TrendingGenresResponse(BaseModel):
-    genres: list
+    genres: list  # each item: {"genre_id": int, "subgenre_id": int | None, "count": int}
 
 class KarmaHeatmapResponse(BaseModel):
     heatmap: dict

--- a/backend/seeds/genre_seed.py
+++ b/backend/seeds/genre_seed.py
@@ -1,0 +1,24 @@
+"""Seed data for music genres and subgenres."""
+
+from typing import List, Dict, Optional
+
+
+def get_seed_genres() -> List[Dict[str, Optional[int]]]:
+    """Return a list of genres with optional parent genre IDs."""
+    return [
+        {"id": 1, "name": "Rock", "parent_id": None},
+        {"id": 2, "name": "Pop", "parent_id": None},
+        {"id": 3, "name": "Jazz", "parent_id": None},
+        {"id": 4, "name": "Hip Hop", "parent_id": None},
+        {"id": 5, "name": "Electronic", "parent_id": None},
+        {"id": 6, "name": "Hard Rock", "parent_id": 1},
+        {"id": 7, "name": "Alternative Rock", "parent_id": 1},
+        {"id": 8, "name": "Synth Pop", "parent_id": 2},
+        {"id": 9, "name": "K-Pop", "parent_id": 2},
+        {"id": 10, "name": "Smooth Jazz", "parent_id": 3},
+        {"id": 11, "name": "Bebop", "parent_id": 3},
+        {"id": 12, "name": "Trap", "parent_id": 4},
+        {"id": 13, "name": "Boom Bap", "parent_id": 4},
+        {"id": 14, "name": "House", "parent_id": 5},
+        {"id": 15, "name": "Techno", "parent_id": 5},
+    ]

--- a/backend/services/world_pulse_service.py
+++ b/backend/services/world_pulse_service.py
@@ -7,7 +7,7 @@ class WorldPulseService:
         self.db = db
 
     def generate_world_pulse(self):
-        genres = self.db.get_trending_genres()
+        genres = self.db.get_trending_genres_by_id()
         karma = self.db.get_average_karma()
         events = self.db.get_current_events()
         top_players = self.db.get_top_players()


### PR DESCRIPTION
## Summary
- add self-referential `Genre` model for genres and subgenres
- seed genres and subgenres
- migrate music models and services to reference genre IDs and expose genre analytics

## Testing
- `pytest` *(fails: _field() missing 1 required positional argument: 'default')*

------
https://chatgpt.com/codex/tasks/task_e_68b2fbd33fa083258ebae57fb1ffa8c0