### PR TITLE
Expand music skills and genres with admin editing

### DIFF
--- a/backend/models/genre.py
+++ b/backend/models/genre.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class Genre:
+    """Represents a music genre with subgenres and demographic popularity."""
+
+    id: int
+    name: str
+    subgenres: List[str] = field(default_factory=list)
+    popularity: Dict[str, Dict[str, float]] = field(default_factory=dict)
+
+
+__all__ = ["Genre"]

--- a/backend/routes/admin_music_routes.py
+++ b/backend/routes/admin_music_routes.py
@@ -1,0 +1,47 @@
+from typing import List
+
+import backend.seeds.genre_seed as genre_seed
+import backend.seeds.skill_seed as skill_seed
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.models.genre import Genre
+from backend.models.skill import Skill
+from backend.schemas.admin_music_schema import GenreSchema, SkillSchema
+from backend.services.admin_audit_service import audit_dependency
+from fastapi import APIRouter, Depends, Request
+
+router = APIRouter(
+    prefix="/music", tags=["AdminMusic"], dependencies=[Depends(audit_dependency)]
+)
+
+
+async def _ensure_admin(req: Request) -> None:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+
+
+@router.get("/skills")
+async def list_skills(req: Request) -> List[dict]:
+    await _ensure_admin(req)
+    return [s.__dict__ for s in skill_seed.SEED_SKILLS]
+
+
+@router.put("/skills")
+async def replace_skills(skills: List[SkillSchema], req: Request) -> dict:
+    await _ensure_admin(req)
+    skill_seed.SEED_SKILLS = [Skill(**s.dict()) for s in skills]
+    skill_seed.SKILL_NAME_TO_ID = {s.name: s.id for s in skill_seed.SEED_SKILLS}
+    return {"status": "updated", "count": len(skill_seed.SEED_SKILLS)}
+
+
+@router.get("/genres")
+async def list_genres(req: Request) -> List[dict]:
+    await _ensure_admin(req)
+    return [g.__dict__ for g in genre_seed.SEED_GENRES]
+
+
+@router.put("/genres")
+async def replace_genres(genres: List[GenreSchema], req: Request) -> dict:
+    await _ensure_admin(req)
+    genre_seed.SEED_GENRES = [Genre(**g.dict()) for g in genres]
+    genre_seed.GENRE_NAME_TO_ID = {g.name: g.id for g in genre_seed.SEED_GENRES}
+    return {"status": "updated", "count": len(genre_seed.SEED_GENRES)}

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -9,6 +9,7 @@ from .admin_economy_routes import router as economy_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
 from .admin_monitoring_routes import router as monitoring_router
+from .admin_music_routes import router as music_router
 from .admin_npc_routes import router as npc_router
 from .admin_quest_routes import router as quest_router
 from .admin_schema_routes import router as schema_router
@@ -27,4 +28,5 @@ router.include_router(npc_router)
 router.include_router(quest_router)
 router.include_router(schema_router)
 router.include_router(venue_router)
+router.include_router(music_router)
 

--- a/backend/schemas/admin_music_schema.py
+++ b/backend/schemas/admin_music_schema.py
@@ -1,0 +1,20 @@
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class SkillSchema(BaseModel):
+    id: int
+    name: str
+    category: str
+    parent_id: Optional[int] = None
+
+
+class GenreSchema(BaseModel):
+    id: int
+    name: str
+    subgenres: List[str] = []
+    popularity: Dict[str, Dict[str, float]] = {}
+
+
+__all__ = ["SkillSchema", "GenreSchema"]

--- a/backend/seeds/genre_seed.py
+++ b/backend/seeds/genre_seed.py
@@ -1,0 +1,60 @@
+"""Seed data for music genres with demographic preferences."""
+
+from backend.models.genre import Genre
+
+SEED_GENRES = [
+    Genre(
+        id=1,
+        name="Rock",
+        subgenres=["Hard Rock", "Indie Rock", "Punk Rock"],
+        popularity={
+            "age": {"teen": 0.6, "young_adult": 0.8, "adult": 0.7},
+            "countries": {"US": 0.8, "UK": 0.7, "JP": 0.5},
+            "genders": {"male": 0.7, "female": 0.6, "nonbinary": 0.6},
+            "orientations": {"hetero": 0.7, "lgbtq": 0.8},
+        },
+    ),
+    Genre(
+        id=2,
+        name="Pop",
+        subgenres=["Electropop", "Teen Pop", "Dance Pop"],
+        popularity={
+            "age": {"teen": 0.9, "young_adult": 0.8, "adult": 0.7},
+            "countries": {"US": 0.9, "BR": 0.8, "JP": 0.9},
+            "genders": {"male": 0.8, "female": 0.9, "nonbinary": 0.8},
+            "orientations": {"hetero": 0.85, "lgbtq": 0.9},
+        },
+    ),
+    Genre(
+        id=3,
+        name="Jazz",
+        subgenres=["Smooth Jazz", "Bebop"],
+        popularity={
+            "age": {"teen": 0.3, "young_adult": 0.5, "adult": 0.8, "senior": 0.9},
+            "countries": {"US": 0.6, "FR": 0.7, "JP": 0.5},
+            "genders": {"male": 0.6, "female": 0.6, "nonbinary": 0.6},
+            "orientations": {"hetero": 0.6, "lgbtq": 0.7},
+        },
+    ),
+    Genre(
+        id=4,
+        name="Electronic",
+        subgenres=["EDM", "House", "Techno"],
+        popularity={
+            "age": {"teen": 0.7, "young_adult": 0.9, "adult": 0.6},
+            "countries": {"DE": 0.8, "US": 0.7, "UK": 0.7},
+            "genders": {"male": 0.7, "female": 0.7, "nonbinary": 0.8},
+            "orientations": {"hetero": 0.7, "lgbtq": 0.85},
+        },
+    ),
+]
+
+GENRE_NAME_TO_ID = {genre.name: genre.id for genre in SEED_GENRES}
+
+
+def get_seed_genres() -> list[Genre]:
+    """Return the list of default genres."""
+    return SEED_GENRES
+
+
+__all__ = ["get_seed_genres", "SEED_GENRES", "GENRE_NAME_TO_ID"]

--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -8,6 +8,26 @@ SEED_SKILLS = [
     Skill(id=3, name="vocals", category="performance"),
     Skill(id=4, name="songwriting", category="creative"),
     Skill(id=5, name="performance", category="stage"),
+    # Expanded instrument skills
+    Skill(id=6, name="drums", category="instrument"),
+    Skill(id=7, name="keyboard", category="instrument"),
+    Skill(id=8, name="piano", category="instrument", parent_id=7),
+    Skill(id=9, name="violin", category="instrument"),
+    Skill(id=10, name="saxophone", category="instrument"),
+    Skill(id=11, name="trumpet", category="instrument"),
+    Skill(id=12, name="dj", category="instrument"),
+    Skill(id=13, name="turntablism", category="instrument", parent_id=12),
+    # Expanded performance skills
+    Skill(id=14, name="dance", category="performance"),
+    Skill(id=15, name="stage_presence", category="performance"),
+    Skill(id=16, name="crowd_interaction", category="performance"),
+    Skill(id=17, name="pyrotechnics", category="performance"),
+    # Expanded creative skills
+    Skill(id=18, name="composition", category="creative"),
+    Skill(id=19, name="arrangement", category="creative"),
+    Skill(id=20, name="music_production", category="creative"),
+    Skill(id=21, name="mixing", category="creative", parent_id=20),
+    Skill(id=22, name="mastering", category="creative", parent_id=20),
 ]
 
 SKILL_NAME_TO_ID = {skill.name: skill.id for skill in SEED_SKILLS}


### PR DESCRIPTION
## Summary
- broaden default skill list with more instrument, performance, and creative abilities
- introduce genre model with demographic popularity and seeding data
- add admin endpoints to view and replace skills and genres

## Testing
- `python -m ruff check backend/routes/admin_music_routes.py backend/routes/admin_routes.py backend/seeds/skill_seed.py backend/models/genre.py backend/seeds/genre_seed.py backend/schemas/admin_music_schema.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'starlette', SyntaxError in tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fda1f5a08325b3c97c6167b4e3df