### PR TITLE
Add XP configuration management

### DIFF
--- a/backend/models/xp_config.py
+++ b/backend/models/xp_config.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+import json
+
+# Default location for persisted config
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "xp_config.json"
+
+
+@dataclass
+class XPConfig:
+    """Runtime tunable experience settings."""
+
+    daily_cap: int = 0
+    new_player_multiplier: float = 1.0
+    rested_xp_rate: float = 1.0
+
+
+def load_config(path: Path = CONFIG_PATH) -> XPConfig:
+    if path.exists():
+        data = json.loads(path.read_text())
+        return XPConfig(**data)
+    return XPConfig()
+
+
+def save_config(config: XPConfig, path: Path = CONFIG_PATH) -> None:
+    path.write_text(json.dumps(asdict(config)))
+
+
+# In-memory singleton used by services
+_config: XPConfig = load_config()
+
+
+def get_config() -> XPConfig:
+    return _config
+
+
+def set_config(config: XPConfig) -> None:
+    global _config
+    _config = config

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -6,6 +6,7 @@ from .admin_analytics_routes import router as analytics_router
 from .admin_audit_routes import router as audit_router
 from .admin_business_routes import router as business_router
 from .admin_economy_routes import router as economy_router
+from .admin_xp_routes import router as xp_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
 from .admin_monitoring_routes import router as monitoring_router
@@ -21,6 +22,7 @@ router.include_router(analytics_router)
 router.include_router(audit_router)
 router.include_router(business_router)
 router.include_router(economy_router)
+router.include_router(xp_router)
 router.include_router(jobs_router)
 router.include_router(media_router)
 router.include_router(monitoring_router)

--- a/backend/routes/admin_schema_routes.py
+++ b/backend/routes/admin_schema_routes.py
@@ -32,6 +32,12 @@ class EconomyConfigSchema(BaseModel):
     payout_rate: int | None = None
 
 
+class XPConfigSchema(BaseModel):
+    daily_cap: int | None = None
+    new_player_multiplier: float | None = None
+    rested_xp_rate: float | None = None
+
+
 router = APIRouter(prefix="/schema", tags=["AdminSchema"])
 
 
@@ -56,3 +62,9 @@ async def quest_schema(req: Request) -> Dict[str, Any]:
 async def economy_schema(req: Request) -> Dict[str, Any]:
     await _ensure_admin(req)
     return EconomyConfigSchema.model_json_schema()
+
+
+@router.get("/xp")
+async def xp_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return XPConfigSchema.model_json_schema()

--- a/backend/routes/admin_xp_routes.py
+++ b/backend/routes/admin_xp_routes.py
@@ -1,0 +1,38 @@
+"""Admin routes for XP configuration."""
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services.xp_admin_service import XPAdminService
+from backend.models.xp_config import XPConfig
+from backend.services.admin_audit_service import audit_dependency
+
+router = APIRouter(
+    prefix="/xp", tags=["AdminXP"], dependencies=[Depends(audit_dependency)]
+)
+svc = XPAdminService()
+
+
+class ConfigUpdateIn(BaseModel):
+    daily_cap: int | None = None
+    new_player_multiplier: float | None = None
+    rested_xp_rate: float | None = None
+
+
+@router.get("/config")
+async def get_config(req: Request) -> XPConfig:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    return svc.get_config()
+
+
+@router.put("/config")
+async def update_config(payload: ConfigUpdateIn, req: Request) -> XPConfig:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    data = {k: v for k, v in payload.dict().items() if v is not None}
+    try:
+        return svc.update_config(**data)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))

--- a/backend/services/xp_admin_service.py
+++ b/backend/services/xp_admin_service.py
@@ -1,0 +1,29 @@
+"""Admin utilities for XP management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.models.xp_config import (
+    XPConfig,
+    get_config,
+    set_config,
+    save_config,
+)
+
+
+class XPAdminService:
+    def __init__(self, config_path: Path | None = None) -> None:
+        self.config_path = config_path or Path(__file__).resolve().parents[1] / "xp_config.json"
+
+    def get_config(self) -> XPConfig:
+        return get_config()
+
+    def update_config(self, **changes) -> XPConfig:
+        cfg = get_config()
+        for k, v in changes.items():
+            if hasattr(cfg, k) and v is not None:
+                setattr(cfg, k, v)
+        set_config(cfg)
+        save_config(cfg, self.config_path)
+        return cfg

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -9,6 +9,7 @@ const navItems: NavItem[] = [
   { label: 'NPCs', href: '/admin/npcs' },
   { label: 'Quests', href: '/admin/quests' },
   { label: 'Economy', href: '/admin/economy' },
+  { label: 'XP', href: '/admin/xp' },
   { label: 'Venues', href: '/admin/venues' },
   { label: 'Audit Logs', href: '/admin/audit' },
 ];

--- a/frontend/src/admin/components/XPConfigForm.tsx
+++ b/frontend/src/admin/components/XPConfigForm.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import SchemaForm from './SchemaForm';
+
+const XPConfigForm: React.FC = () => (
+  <SchemaForm schemaUrl="/admin/schema/xp" submitUrl="/admin/xp/config" method="PUT" />
+);
+
+export default XPConfigForm;


### PR DESCRIPTION
## Summary
- add XPConfig model with fields like daily_cap and rested_xp_rate
- provide XPAdminService and admin routes for XP settings
- expose XP config schema and frontend form with sidebar link

## Testing
- `ruff check backend/models/xp_config.py backend/services/xp_admin_service.py backend/routes/admin_xp_routes.py backend/routes/admin_schema_routes.py backend/routes/admin_routes.py frontend/src/admin/components/XPConfigForm.tsx frontend/src/admin/components/Sidebar.tsx`
- `pytest` *(fails: _field() missing 1 required positional argument: 'default')*

------
https://chatgpt.com/codex/tasks/task_e_68b3241719c08325a72b4d8a83753213