### PR TITLE
Add XP event system with admin management and frontend support

### DIFF
--- a/backend/models/xp_event.py
+++ b/backend/models/xp_event.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class XPEvent:
+    """Represents a temporary experience multiplier event."""
+
+    id: Optional[int]
+    name: str
+    start_time: datetime
+    end_time: datetime
+    multiplier: float
+    skill_target: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["start_time"] = self.start_time.isoformat()
+        data["end_time"] = self.end_time.isoformat()
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "XPEvent":
+        return cls(
+            id=data.get("id"),
+            name=data["name"],
+            start_time=datetime.fromisoformat(data["start_time"]),
+            end_time=datetime.fromisoformat(data["end_time"]),
+            multiplier=data["multiplier"],
+            skill_target=data.get("skill_target"),
+        )

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -6,7 +6,6 @@ from .admin_analytics_routes import router as analytics_router
 from .admin_audit_routes import router as audit_router
 from .admin_business_routes import router as business_router
 from .admin_economy_routes import router as economy_router
-from .admin_xp_routes import router as xp_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
 from .admin_monitoring_routes import router as monitoring_router
@@ -15,6 +14,8 @@ from .admin_npc_routes import router as npc_router
 from .admin_quest_routes import router as quest_router
 from .admin_schema_routes import router as schema_router
 from .admin_venue_routes import router as venue_router
+from .admin_xp_event_routes import router as xp_event_router
+from .admin_xp_routes import router as xp_router
 
 router = APIRouter()
 
@@ -23,6 +24,7 @@ router.include_router(audit_router)
 router.include_router(business_router)
 router.include_router(economy_router)
 router.include_router(xp_router)
+router.include_router(xp_event_router)
 router.include_router(jobs_router)
 router.include_router(media_router)
 router.include_router(monitoring_router)

--- a/backend/routes/admin_schema_routes.py
+++ b/backend/routes/admin_schema_routes.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Request
-from pydantic import BaseModel
-from typing import Dict, Any, List
+from datetime import datetime
+from typing import Any, Dict, List
 
 from auth.dependencies import get_current_user_id, require_role
 
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
 
 
 class NPCSchema(BaseModel):
@@ -38,6 +39,14 @@ class XPConfigSchema(BaseModel):
     rested_xp_rate: float | None = None
 
 
+class XPEventSchema(BaseModel):
+    name: str
+    start_time: datetime
+    end_time: datetime
+    multiplier: float
+    skill_target: str | None = None
+
+
 router = APIRouter(prefix="/schema", tags=["AdminSchema"])
 
 
@@ -68,3 +77,9 @@ async def economy_schema(req: Request) -> Dict[str, Any]:
 async def xp_schema(req: Request) -> Dict[str, Any]:
     await _ensure_admin(req)
     return XPConfigSchema.model_json_schema()
+
+
+@router.get("/xp_event")
+async def xp_event_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return XPEventSchema.model_json_schema()

--- a/backend/routes/admin_xp_event_routes.py
+++ b/backend/routes/admin_xp_event_routes.py
@@ -1,0 +1,56 @@
+"""Admin routes for managing XP multiplier events."""
+
+from datetime import datetime
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.models.xp_event import XPEvent
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.xp_event_service import XPEventService
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+router = APIRouter(
+    prefix="/xp/events", tags=["AdminXPEvents"], dependencies=[Depends(audit_dependency)]
+)
+svc = XPEventService()
+
+
+class XPEventIn(BaseModel):
+    name: str
+    start_time: datetime
+    end_time: datetime
+    multiplier: float
+    skill_target: str | None = None
+
+
+@router.get("/")
+async def list_events(req: Request) -> list[XPEvent]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    return svc.list_events()
+
+
+@router.post("/")
+async def create_event(payload: XPEventIn, req: Request) -> XPEvent:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    ev = XPEvent(id=None, **payload.dict())
+    return svc.create_event(ev)
+
+
+@router.put("/{event_id}")
+async def update_event(event_id: int, payload: XPEventIn, req: Request) -> XPEvent:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    try:
+        return svc.update_event(event_id, **payload.dict())
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.delete("/{event_id}")
+async def delete_event(event_id: int, req: Request) -> dict[str, str]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    svc.delete_event(event_id)
+    return {"status": "deleted"}

--- a/backend/services/xp_event_service.py
+++ b/backend/services/xp_event_service.py
@@ -1,0 +1,74 @@
+"""Service layer for managing XP boost events."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from backend.models.xp_event import XPEvent
+
+
+class XPEventService:
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or Path(__file__).resolve().parents[1] / "xp_events.json"
+        self._events: List[XPEvent] = self._load()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    def _load(self) -> List[XPEvent]:
+        if self.path.exists():
+            data = json.loads(self.path.read_text())
+            return [XPEvent.from_dict(e) for e in data]
+        return []
+
+    def _save(self) -> None:
+        data = [e.to_dict() for e in self._events]
+        self.path.write_text(json.dumps(data))
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    def list_events(self) -> List[XPEvent]:
+        return list(self._events)
+
+    def create_event(self, event: XPEvent) -> XPEvent:
+        next_id = max((e.id or 0 for e in self._events), default=0) + 1
+        event.id = next_id
+        self._events.append(event)
+        self._save()
+        return event
+
+    def update_event(self, event_id: int, **changes) -> XPEvent:
+        ev = self.get_event(event_id)
+        if ev is None:
+            raise ValueError("Event not found")
+        for k, v in changes.items():
+            if hasattr(ev, k) and v is not None:
+                setattr(ev, k, v)
+        self._save()
+        return ev
+
+    def delete_event(self, event_id: int) -> None:
+        self._events = [e for e in self._events if e.id != event_id]
+        self._save()
+
+    def get_event(self, event_id: int) -> Optional[XPEvent]:
+        return next((e for e in self._events if e.id == event_id), None)
+
+    # ------------------------------------------------------------------
+    # Event lookup
+    def get_active_events(self, skill: str | None = None) -> List[XPEvent]:
+        now = datetime.utcnow()
+        return [
+            e
+            for e in self._events
+            if e.start_time <= now <= e.end_time
+            and (e.skill_target is None or e.skill_target == skill)
+        ]
+
+    def get_active_multiplier(self, skill: str | None = None) -> float:
+        mult = 1.0
+        for e in self.get_active_events(skill):
+            mult *= e.multiplier
+        return mult

--- a/frontend/src/admin/App.tsx
+++ b/frontend/src/admin/App.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Sidebar from './components/Sidebar';
 import { AuditTable } from './audit';
 import { MonitoringWidget } from './monitoring';
+import XPEventForm from './components/XPEventForm';
 
 const App: React.FC = () => {
   const path = window.location.pathname;
@@ -17,6 +18,8 @@ const App: React.FC = () => {
 
   if (path.includes('/admin/audit')) {
     content = <AuditTable />;
+  } else if (path.includes('/admin/xp-events')) {
+    content = <XPEventForm />;
   }
 
   return (

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -10,6 +10,7 @@ const navItems: NavItem[] = [
   { label: 'Quests', href: '/admin/quests' },
   { label: 'Economy', href: '/admin/economy' },
   { label: 'XP', href: '/admin/xp' },
+  { label: 'XP Events', href: '/admin/xp-events' },
   { label: 'Venues', href: '/admin/venues' },
   { label: 'Audit Logs', href: '/admin/audit' },
 ];

--- a/frontend/src/admin/components/XPEventForm.tsx
+++ b/frontend/src/admin/components/XPEventForm.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import SchemaForm from './SchemaForm';
+
+const XPEventForm: React.FC = () => (
+  <SchemaForm schemaUrl="/admin/schema/xp_event" submitUrl="/admin/xp/events" />
+);
+
+export default XPEventForm;


### PR DESCRIPTION
## Summary
- add `XPEvent` model and service for temporary XP boost events
- expose admin API to manage XP events and wire into application routers and schema
- apply active event multipliers to quest rewards and lifestyle XP modifiers
- add frontend form and navigation for XP event management

## Testing
- `ruff check backend/routes/admin_xp_event_routes.py backend/services/xp_event_service.py backend/models/xp_event.py backend/services/lifestyle_scheduler.py backend/services/quest_service.py backend/routes/admin_routes.py backend/routes/admin_schema_routes.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'starlette')*
- `pip install fastapi starlette boto3` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68b324cd0b0c8325a79ba4075b2f7978