### PR TITLE
Add XP item model, service, and admin/frontend integration

### DIFF
--- a/backend/models/xp_item.py
+++ b/backend/models/xp_item.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+
+@dataclass
+class XPItem:
+    """Represents an XP modifying item that can be used by players."""
+
+    id: Optional[int]
+    name: str
+    effect_type: Literal["flat", "boost"]
+    amount: float
+    duration: int

--- a/backend/routes/admin_schema_routes.py
+++ b/backend/routes/admin_schema_routes.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal
 
 from auth.dependencies import get_current_user_id, require_role
 
@@ -47,6 +47,13 @@ class XPEventSchema(BaseModel):
     skill_target: str | None = None
 
 
+class XPItemSchema(BaseModel):
+    name: str
+    effect_type: Literal["flat", "boost"]
+    amount: float
+    duration: int
+
+
 router = APIRouter(prefix="/schema", tags=["AdminSchema"])
 
 
@@ -83,3 +90,9 @@ async def xp_schema(req: Request) -> Dict[str, Any]:
 async def xp_event_schema(req: Request) -> Dict[str, Any]:
     await _ensure_admin(req)
     return XPEventSchema.model_json_schema()
+
+
+@router.get("/xp_item")
+async def xp_item_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return XPItemSchema.model_json_schema()

--- a/backend/routes/admin_xp_item_routes.py
+++ b/backend/routes/admin_xp_item_routes.py
@@ -1,0 +1,54 @@
+"""Admin routes for managing XP items."""
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.models.xp_item import XPItem
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.xp_item_service import XPItemService, xp_item_service
+
+router = APIRouter(
+    prefix="/xp/items", tags=["AdminXPItems"], dependencies=[Depends(audit_dependency)]
+)
+svc: XPItemService = xp_item_service
+
+
+class XPItemIn(BaseModel):
+    name: str
+    effect_type: str = Field(pattern="^(flat|boost)$")
+    amount: float
+    duration: int
+
+
+@router.get("/")
+async def list_items(req: Request) -> list[XPItem]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    return svc.list_items()
+
+
+@router.post("/")
+async def create_item(payload: XPItemIn, req: Request) -> XPItem:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    item = XPItem(id=None, **payload.dict())
+    return svc.create_item(item)
+
+
+@router.put("/{item_id}")
+async def update_item(item_id: int, payload: XPItemIn, req: Request) -> XPItem:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    try:
+        return svc.update_item(item_id, **payload.dict())
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.delete("/{item_id}")
+async def delete_item(item_id: int, req: Request) -> dict[str, str]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    svc.delete_item(item_id)
+    return {"status": "deleted"}

--- a/backend/routes/gifting_routes.py
+++ b/backend/routes/gifting_routes.py
@@ -1,19 +1,16 @@
 from auth.dependencies import get_current_user_id, require_role
-# File: backend/routes/gifting_routes.py
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, conint
 from typing import List, Optional
 
-from services.gifting_service import GiftingService, GiftingError, DigitalGiftIn, TicketGiftIn, TicketGiftItem
-
-# Auth dependency (replace with your real one)
-try:
-    from auth.dependencies import require_role
-except Exception:
-    def require_role(roles):
-        async def _noop():
-            return True
-        return _noop
+from services.gifting_service import (
+    GiftingService,
+    GiftingError,
+    DigitalGiftIn,
+    TicketGiftIn,
+    TicketGiftItem,
+)
+from services.xp_item_service import xp_item_service
 
 router = APIRouter(prefix="/gifts", tags=["Gifting"])
 svc = GiftingService()
@@ -21,31 +18,37 @@ svc.ensure_schema()
 
 # -------- payload models --------
 class DigitalGiftPayload(BaseModel):
-    
-sender_user_id: int
+    sender_user_id: int
     recipient_user_id: int
-    work_type: str   # 'song' | 'album'
+    work_type: str  # 'song' | 'album'
     work_id: int
     price_cents: conint(ge=0)
     currency: str = "USD"
     message: Optional[str] = None
 
+
 class TicketGiftItemPayload(BaseModel):
-    
-ticket_type_id: int
+    ticket_type_id: int
     qty: conint(gt=0)
 
+
 class TicketGiftPayload(BaseModel):
-    
-sender_user_id: int
+    sender_user_id: int
     recipient_user_id: int
     event_id: int
     items: List[TicketGiftItemPayload]
     currency: str = "USD"
     message: Optional[str] = None
 
+
+class XPItemGiftPayload(BaseModel):
+    sender_user_id: int
+    recipient_user_id: int
+    item_id: int
+
+
 # -------- endpoints --------
-@router.post("/digital", dependencies=[Depends(require_role(["band_member","admin","moderator"]))])
+@router.post("/digital", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
 def gift_digital(payload: DigitalGiftPayload):
     try:
         gift_id = svc.gift_digital(DigitalGiftIn(**payload.model_dump()))
@@ -53,26 +56,40 @@ def gift_digital(payload: DigitalGiftPayload):
     except GiftingError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-@router.post("/tickets", dependencies=[Depends(require_role(["band_member","admin","moderator"]))])
+
+@router.post("/tickets", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
 def gift_tickets(payload: TicketGiftPayload):
     try:
         items = [TicketGiftItem(**i.model_dump()) for i in payload.items]
-        gift_id = svc.gift_tickets(TicketGiftIn(
-            sender_user_id=payload.sender_user_id,
-            recipient_user_id=payload.recipient_user_id,
-            event_id=payload.event_id,
-            items=items,
-            currency=payload.currency,
-            message=payload.message
-        ))
+        gift_id = svc.gift_tickets(
+            TicketGiftIn(
+                sender_user_id=payload.sender_user_id,
+                recipient_user_id=payload.recipient_user_id,
+                event_id=payload.event_id,
+                items=items,
+                currency=payload.currency,
+                message=payload.message,
+            )
+        )
         return {"gift_id": gift_id}
     except GiftingError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-@router.get("/inbox/{user_id}", dependencies=[Depends(require_role(["band_member","admin","moderator"]))])
+
+@router.post("/xp-item", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+def gift_xp_item(payload: XPItemGiftPayload):
+    try:
+        xp_item_service.assign_to_user(payload.recipient_user_id, payload.item_id)
+        return {"status": "gifted"}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/inbox/{user_id}", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
 def gifts_inbox(user_id: int, limit: int = 50, offset: int = 0):
     return svc.list_inbox(user_id, limit, offset)
 
-@router.get("/sent/{user_id}", dependencies=[Depends(require_role(["band_member","admin","moderator"]))])
+
+@router.get("/sent/{user_id}", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
 def gifts_sent(user_id: int, limit: int = 50, offset: int = 0):
     return svc.list_sent(user_id, limit, offset)

--- a/backend/services/xp_item_service.py
+++ b/backend/services/xp_item_service.py
@@ -1,0 +1,83 @@
+"""Service layer for managing XP modifying items."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict, List, Tuple
+
+from backend.models.xp_item import XPItem
+
+
+class XPItemService:
+    def __init__(self) -> None:
+        self._items: Dict[int, XPItem] = {}
+        self._inventories: Dict[int, List[int]] = {}
+        self._active_boosts: Dict[int, List[Tuple[float, datetime]]] = {}
+        self._id_seq = 1
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def list_items(self) -> List[XPItem]:
+        return list(self._items.values())
+
+    def create_item(self, item: XPItem) -> XPItem:
+        item.id = self._id_seq
+        self._items[item.id] = item
+        self._id_seq += 1
+        return item
+
+    def update_item(self, item_id: int, **changes) -> XPItem:
+        itm = self._items.get(item_id)
+        if not itm:
+            raise ValueError("Item not found")
+        for k, v in changes.items():
+            if hasattr(itm, k) and v is not None:
+                setattr(itm, k, v)
+        return itm
+
+    def delete_item(self, item_id: int) -> None:
+        if item_id in self._items:
+            del self._items[item_id]
+
+    # ------------------------------------------------------------------
+    # Inventory management
+    # ------------------------------------------------------------------
+    def assign_to_user(self, user_id: int, item_id: int) -> None:
+        if item_id not in self._items:
+            raise ValueError("invalid item")
+        self._inventories.setdefault(user_id, []).append(item_id)
+
+    def _pop_from_inventory(self, user_id: int, item_id: int) -> XPItem:
+        inv = self._inventories.get(user_id, [])
+        if item_id not in inv:
+            raise ValueError("item not in inventory")
+        inv.remove(item_id)
+        return self._items[item_id]
+
+    # ------------------------------------------------------------------
+    # Effect application
+    # ------------------------------------------------------------------
+    def apply_item(self, user_id: int, item_id: int) -> float:
+        item = self._pop_from_inventory(user_id, item_id)
+        if item.effect_type == "flat":
+            return item.amount
+        expires = datetime.utcnow() + timedelta(seconds=item.duration)
+        self._active_boosts.setdefault(user_id, []).append((item.amount, expires))
+        return 0.0
+
+    def get_active_multiplier(self, user_id: int) -> float:
+        now = datetime.utcnow()
+        boosts = self._active_boosts.get(user_id, [])
+        active: List[Tuple[float, datetime]] = []
+        mult = 1.0
+        for amt, exp in boosts:
+            if exp > now:
+                mult *= amt
+                active.append((amt, exp))
+        self._active_boosts[user_id] = active
+        return mult
+
+
+xp_item_service = XPItemService()
+
+__all__ = ["XPItemService", "xp_item_service"]

--- a/frontend/src/admin/App.tsx
+++ b/frontend/src/admin/App.tsx
@@ -4,6 +4,7 @@ import Sidebar from './components/Sidebar';
 import { AuditTable } from './audit';
 import { MonitoringWidget } from './monitoring';
 import XPEventForm from './components/XPEventForm';
+import XPItemForm from './components/XPItemForm';
 
 const App: React.FC = () => {
   const path = window.location.pathname;
@@ -20,6 +21,8 @@ const App: React.FC = () => {
     content = <AuditTable />;
   } else if (path.includes('/admin/xp-events')) {
     content = <XPEventForm />;
+  } else if (path.includes('/admin/xp-items')) {
+    content = <XPItemForm />;
   }
 
   return (

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -11,6 +11,7 @@ const navItems: NavItem[] = [
   { label: 'Economy', href: '/admin/economy' },
   { label: 'XP', href: '/admin/xp' },
   { label: 'XP Events', href: '/admin/xp-events' },
+  { label: 'XP Items', href: '/admin/xp-items' },
   { label: 'Venues', href: '/admin/venues' },
   { label: 'Audit Logs', href: '/admin/audit' },
 ];

--- a/frontend/src/admin/components/XPItemForm.tsx
+++ b/frontend/src/admin/components/XPItemForm.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import SchemaForm from './SchemaForm';
+
+const XPItemForm: React.FC = () => (
+  <SchemaForm schemaUrl="/admin/schema/xp_item" submitUrl="/admin/xp/items" />
+);
+
+export default XPItemForm;


### PR DESCRIPTION
## Summary
- add XPItem dataclass model and in-memory service for managing items and effects
- provide admin CRUD routes and schema for XP items
- allow gifting XP items and expose management form in admin UI

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi.exceptions', ModuleNotFoundError: No module named 'starlette', ModuleNotFoundError: No module named 'boto3')*


------
https://chatgpt.com/codex/tasks/task_e_68b3267b6bfc8325a968512c94ffe8ce