### PR TITLE
Add hidden XP rewards for new player interactions

### DIFF
--- a/backend/services/economy_service.py
+++ b/backend/services/economy_service.py
@@ -5,8 +5,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from backend.models.banking import ExchangeRate, InterestAccount, Loan
+from services.xp_reward_service import xp_reward_service
 
+from backend.models.banking import Loan
 from backend.models.economy_config import get_config
 from backend.utils.logging import get_logger
 
@@ -238,6 +239,7 @@ class EconomyService:
                 (to_user_id, tx_id, amount_cents, to_balance),
             )
             conn.commit()
+            xp_reward_service.grant_hidden_xp(to_user_id, reason="transfer")
 
     def list_transactions(self, user_id: int, limit: int = 50) -> list[TransactionRecord]:
         with sqlite3.connect(self.db_path) as conn:

--- a/backend/services/gifting_service.py
+++ b/backend/services/gifting_service.py
@@ -1,9 +1,11 @@
 # File: backend/services/gifting_service.py
-import sqlite3
 import json
+import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional
+
+from services.xp_reward_service import xp_reward_service
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 
@@ -129,6 +131,8 @@ class GiftingService:
                 self._notify(cur, data.recipient_user_id, "You've received a gift!", f"A {work_type} was gifted to you.", None)
 
                 conn.commit()
+                # Secretly reward new players with a bit of XP
+                xp_reward_service.grant_hidden_xp(data.recipient_user_id, reason="gift")
                 return gift_id
             except Exception:
                 conn.rollback()
@@ -193,6 +197,7 @@ class GiftingService:
                 self._notify(cur, data.recipient_user_id, "You've received tickets!", f"Gifted tickets for event {data.event_id}.", None)
 
                 conn.commit()
+                xp_reward_service.grant_hidden_xp(data.recipient_user_id, reason="gift")
                 return gift_id
             except Exception:
                 conn.rollback()

--- a/backend/services/karma_service.py
+++ b/backend/services/karma_service.py
@@ -1,12 +1,15 @@
 
-from models.karma_event import KarmaEvent
 from datetime import datetime
+
+from models.karma_event import KarmaEvent
+from services.xp_reward_service import xp_reward_service
+
 
 class KarmaService:
     def __init__(self, db):
         self.db = db
 
-    def adjust_karma(self, user_id, amount, reason, source):
+    def adjust_karma(self, user_id, amount, reason, source, grant_xp: bool = False):
         event = KarmaEvent(
             id=None,
             user_id=user_id,
@@ -17,6 +20,8 @@ class KarmaService:
         )
         self.db.insert_karma_event(event)
         self.db.update_user_karma(user_id, amount)
+        if grant_xp and amount > 0:
+            xp_reward_service.grant_hidden_xp(user_id, reason="karma", amount=int(amount))
 
     def get_karma_history(self, user_id):
         return self.db.get_karma_events(user_id)

--- a/backend/services/xp_reward_service.py
+++ b/backend/services/xp_reward_service.py
@@ -1,0 +1,123 @@
+"""Hidden XP reward utilities."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class XPRewardService:
+    """Utility service for awarding hidden XP to new or low-level players."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+
+    # ------------------------------------------------------------------
+    def _ensure_schema(self, cur: sqlite3.Cursor) -> None:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS hidden_xp_rewards (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                amount INTEGER NOT NULL,
+                reason TEXT NOT NULL,
+                created_at TEXT DEFAULT (datetime('now'))
+            )
+            """
+        )
+
+    def _is_new_or_low_level(self, cur: sqlite3.Cursor, user_id: int) -> bool:
+        """Return True if the account is new or low level.
+
+        The checks are best-effort and tolerate missing tables.
+        """
+        # Recently created account?
+        try:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='accounts'"
+            )
+            if cur.fetchone():
+                cur.execute(
+                    "SELECT created_at FROM accounts WHERE user_id = ?", (user_id,)
+                )
+                row = cur.fetchone()
+                if row is None:
+                    return True
+                try:
+                    created = datetime.fromisoformat(row[0])
+                    if datetime.utcnow() - created <= timedelta(days=7):
+                        return True
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+        # Low level?
+        try:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='user_levels'"
+            )
+            if cur.fetchone():
+                cur.execute(
+                    "SELECT level FROM user_levels WHERE user_id = ?", (user_id,)
+                )
+                row = cur.fetchone()
+                if row and int(row[0]) <= 5:
+                    return True
+        except Exception:
+            pass
+        return False
+
+    # ------------------------------------------------------------------
+    def grant_hidden_xp(self, user_id: int, reason: str, amount: int = 10) -> bool:
+        """Grant hidden XP to the given user if they qualify.
+
+        Parameters
+        ----------
+        user_id:
+            Recipient of the secret XP.
+        reason:
+            Context for auditing, e.g. ``gift`` or ``transfer``.
+        amount:
+            Amount of XP to award. Defaults to 10.
+        Returns
+        -------
+        bool
+            ``True`` if XP was granted, ``False`` otherwise.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            self._ensure_schema(cur)
+            if not self._is_new_or_low_level(cur, user_id):
+                return False
+            cur.execute(
+                "INSERT INTO hidden_xp_rewards (user_id, amount, reason) VALUES (?, ?, ?)",
+                (user_id, amount, reason),
+            )
+            # Update user_xp table if present
+            try:
+                cur.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='user_xp'"
+                )
+                if cur.fetchone():
+                    cur.execute(
+                        """
+                        INSERT INTO user_xp(user_id, xp)
+                        VALUES (?, ?)
+                        ON CONFLICT(user_id) DO UPDATE SET xp = xp + excluded.xp
+                        """,
+                        (user_id, amount),
+                    )
+            except Exception:
+                pass
+            conn.commit()
+            return True
+
+
+xp_reward_service = XPRewardService()
+
+__all__ = ["XPRewardService", "xp_reward_service"]


### PR DESCRIPTION
## Summary
- Award hidden XP to new or low-level players through gifting and currency transfers
- Enable optional hidden XP grants on positive karma changes
- Centralize secret XP awards with a dedicated service and audit log

## Testing
- `ruff check backend/services/gifting_service.py backend/services/economy_service.py backend/services/karma_service.py backend/services/xp_reward_service.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi.exceptions')*


------
https://chatgpt.com/codex/tasks/task_e_68b327c4dfc883258b1bf9082abc4a75