### PR TITLE
Add cached RBAC role lookup

### DIFF
--- a/backend/services/rbac_service.py
+++ b/backend/services/rbac_service.py
@@ -1,0 +1,29 @@
+"""RBAC service with cached user role lookups."""
+from functools import lru_cache
+from typing import Set
+
+from utils.db import get_conn
+
+
+@lru_cache(maxsize=1024)
+def get_roles_for_user(user_id: int) -> Set[str]:
+    """Return the set of role names assigned to ``user_id``."""
+    with get_conn() as conn:
+        rows = conn.execute(
+            """
+            SELECT r.name FROM user_roles ur
+            JOIN roles r ON r.id = ur.role_id
+            WHERE ur.user_id = ?
+            """,
+            (user_id,),
+        ).fetchall()
+    return {row["name"] for row in rows}
+
+def clear_role_cache(user_id: int | None = None) -> None:
+    """Invalidate cached role lookups.
+
+    ``functools.lru_cache`` does not provide a way to clear a single entry,
+    so the entire cache is cleared. The ``user_id`` argument is accepted to
+    make calling sites explicit about which user's roles changed.
+    """
+    get_roles_for_user.cache_clear()


### PR DESCRIPTION
## Summary
- add cached role lookup service with LRU cache and invalidation helper
- use cached RBAC service in `require_role`

## Testing
- `ruff check backend/auth/dependencies.py backend/services/rbac_service.py`
- `pytest backend/tests/test_auth_rbac.py`
- `pytest backend/tests/test_auth_flow.py` *(fails: ImportError: cannot import name 'EmailStr' from 'pydantic')*
- `pip install pydantic` *(fails: No matching distribution found for pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68b33226ed248325a6d591d261a714d3