### PR TITLE
Add configurable rate limiting middleware

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -31,5 +31,13 @@ class Settings:
     ACCESS_TOKEN_TTL_MIN: int = int(os.getenv("ROCKMUNDO_ACCESS_TTL_MIN", "30"))
     REFRESH_TOKEN_TTL_DAYS: int = int(os.getenv("ROCKMUNDO_REFRESH_TTL_DAYS", "30"))
     DISCORD_WEBHOOK_URL: str = os.getenv("DISCORD_WEBHOOK_URL", "")
+    # Rate limiting
+    RATE_LIMIT_REQUESTS_PER_MIN: int = int(
+        os.getenv("ROCKMUNDO_RATE_LIMIT_REQUESTS_PER_MIN", "60")
+    )
+    RATE_LIMIT_STORAGE: str = os.getenv("ROCKMUNDO_RATE_LIMIT_STORAGE", "memory")
+    RATE_LIMIT_REDIS_URL: str = os.getenv(
+        "ROCKMUNDO_RATE_LIMIT_REDIS_URL", "redis://localhost:6379/0"
+    )
 
 settings = Settings()

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from auth.routes import admin_mfa_router
 from database import init_db
 from middleware.admin_mfa import AdminMFAMiddleware
 from middleware.locale import LocaleMiddleware
+from middleware.rate_limit import RateLimitMiddleware
 from routes import (
     admin_routes,
     event_routes,
@@ -11,8 +12,8 @@ from routes import (
     sponsorship,
     video_routes,
 )
-from utils.i18n import _
 from utils.db import init_pool
+from utils.i18n import _
 
 from backend.utils.logging import setup_logging
 from backend.utils.metrics import CONTENT_TYPE_LATEST, generate_latest
@@ -20,6 +21,7 @@ from backend.utils.tracing import setup_tracing
 from fastapi import FastAPI, Response
 
 app = FastAPI(title="RockMundo API with Events, Lifestyle, and Sponsorships")
+app.add_middleware(RateLimitMiddleware)
 app.add_middleware(LocaleMiddleware)
 app.add_middleware(AdminMFAMiddleware)
 

--- a/backend/middleware/rate_limit.py
+++ b/backend/middleware/rate_limit.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import time
+from typing import Dict, Tuple
+
+from core.config import settings
+
+from fastapi import HTTPException
+
+
+class RateLimitMiddleware:
+    """Simple per-client request rate limiting middleware.
+
+    Uses a token bucket that refills every minute. The storage backend can be an
+    in-memory dictionary or Redis. The middleware is lightweight and suitable
+    for the testing environment where a full ASGI stack may not be available.
+    """
+
+    def __init__(
+        self,
+        limit: int | None = None,
+        backend: str | None = None,
+    ) -> None:
+        self.limit = limit or settings.RATE_LIMIT_REQUESTS_PER_MIN
+        self.backend = (backend or settings.RATE_LIMIT_STORAGE).lower()
+
+        self._memory: Dict[str, Tuple[int, float]] = {}
+        self._redis = None
+        if self.backend == "redis":
+            try:  # pragma: no cover - redis optional in tests
+                import redis.asyncio as aioredis
+
+                self._redis = aioredis.from_url(settings.RATE_LIMIT_REDIS_URL)
+            except Exception:  # fall back to memory if redis unavailable
+                self.backend = "memory"
+
+    async def _allow(self, key: str) -> bool:
+        now = time.time()
+        if self.backend == "redis" and self._redis is not None:
+            count = await self._redis.incr(key)
+            if count == 1:
+                await self._redis.expire(key, 60)
+            return count <= self.limit
+
+        # In-memory store
+        count, start = self._memory.get(key, (0, now))
+        if now - start >= 60:
+            count, start = 0, now
+        count += 1
+        self._memory[key] = (count, start)
+        return count <= self.limit
+
+    async def dispatch(self, request, call_next):
+        client = getattr(request, "client", None)
+        host = getattr(client, "host", "anonymous")
+        key = f"rl:{host}"
+
+        if not await self._allow(key):
+            raise HTTPException(status_code=429, detail="Too Many Requests")
+
+        return await call_next(request)
+

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,32 @@
+import asyncio
+
+import pytest
+from middleware.rate_limit import RateLimitMiddleware
+
+from fastapi import HTTPException
+
+
+class DummyClient:
+    def __init__(self, host: str = "test") -> None:
+        self.host = host
+
+
+class DummyRequest:
+    def __init__(self, host: str = "test") -> None:
+        self.client = DummyClient(host)
+
+
+async def _ok(_req):
+    return "ok"
+
+
+def test_rate_limit_blocks_after_limit() -> None:
+    mw = RateLimitMiddleware(limit=2, backend="memory")
+    req = DummyRequest(host="1.2.3.4")
+
+    assert asyncio.run(mw.dispatch(req, _ok)) == "ok"
+    assert asyncio.run(mw.dispatch(req, _ok)) == "ok"
+
+    with pytest.raises(HTTPException):
+        asyncio.run(mw.dispatch(req, _ok))
+


### PR DESCRIPTION
## Summary
- implement per-client rate limiting middleware with optional Redis backend
- expose rate limit settings through core config
- register new middleware early in app setup

## Testing
- `pytest backend/tests/test_rate_limit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b334946564832595d7e6b96e0bd7cf