### PR TITLE
Add observability middleware for tracing and metrics

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from auth.routes import admin_mfa_router
 from database import init_db
 from middleware.admin_mfa import AdminMFAMiddleware
 from middleware.locale import LocaleMiddleware
+from middleware.observability import ObservabilityMiddleware
 from middleware.rate_limit import RateLimitMiddleware
 from routes import (
     admin_routes,
@@ -21,6 +22,7 @@ from backend.utils.tracing import setup_tracing
 from fastapi import FastAPI, Response
 
 app = FastAPI(title="RockMundo API with Events, Lifestyle, and Sponsorships")
+app.add_middleware(ObservabilityMiddleware)
 app.add_middleware(RateLimitMiddleware)
 app.add_middleware(LocaleMiddleware)
 app.add_middleware(AdminMFAMiddleware)

--- a/backend/middleware/observability.py
+++ b/backend/middleware/observability.py
@@ -1,1 +1,64 @@
-<contents of backend/middleware/observability.py here>
+"""Request observability middleware.
+
+This middleware records simple request metrics and tracing spans.  Metrics are
+exported via the lightweight helpers in :mod:`backend.utils.metrics` and spans
+are emitted through :mod:`backend.utils.tracing`.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from backend.utils.metrics import Counter
+from backend.utils.tracing import get_tracer
+
+
+# Metrics ---------------------------------------------------------------------
+
+# Total number of processed HTTP requests.
+REQUEST_COUNT = Counter(
+    "http_requests_total", "Total HTTP requests", ("method", "path", "status")
+)
+
+# Cumulative request latency in milliseconds.
+REQUEST_LATENCY_MS = Counter(
+    "http_request_duration_ms_total",
+    "Total request latency in milliseconds",
+    ("method", "path", "status"),
+)
+
+
+# Tracer instance reused for all requests.
+_tracer = get_tracer(__name__)
+
+
+class ObservabilityMiddleware:
+    """Emit tracing spans and update request metrics."""
+
+    async def dispatch(self, request: Any, call_next):  # pragma: no cover - thin wrapper
+        method = getattr(request, "method", "GET")
+        url = getattr(request, "url", None)
+        path = getattr(url, "path", None) if url else getattr(request, "path", "")
+        span_name = f"{method} {path}"
+
+        start = time.perf_counter()
+        with _tracer.start_as_current_span(span_name):
+            try:
+                response = await call_next(request)
+                status = getattr(response, "status_code", 500)
+            except Exception:
+                # Record failures as 500 responses and re-raise.
+                status = 500
+                raise
+            finally:
+                elapsed_ms = int((time.perf_counter() - start) * 1000)
+                labels = (method, path, str(status))
+                REQUEST_COUNT.labels(*labels).inc()
+                REQUEST_LATENCY_MS.labels(*labels).inc(elapsed_ms)
+
+        return response
+
+
+__all__ = ["ObservabilityMiddleware"]
+


### PR DESCRIPTION
## Summary
- Implement ObservabilityMiddleware that records request counts, latency, and tracing spans
- Wire ObservabilityMiddleware into FastAPI app startup

## Testing
- `pytest backend/tests/test_metrics.py backend/tests/test_rate_limit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3374ad6708325a4e7f60067420829