### PR TITLE
Add plural-aware i18n and locale listing endpoint

### DIFF
--- a/backend/locales/en/LC_MESSAGES/messages.po
+++ b/backend/locales/en/LC_MESSAGES/messages.po
@@ -1,5 +1,6 @@
 msgid ""
 msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
 "Language: en\n"
 
 msgid "Welcome to RockMundo API"
@@ -67,3 +68,16 @@ msgstr "Weekly job not available"
 
 msgid "No sponsorship set for this venue"
 msgstr "No sponsorship set for this venue"
+
+msgid "%(num)d file"
+msgid_plural "%(num)d files"
+msgstr[0] "%(num)d file"
+msgstr[1] "%(num)d files"
+
+msgctxt "action"
+msgid "Open"
+msgstr "Open"
+
+msgctxt "status"
+msgid "Open"
+msgstr "Open"

--- a/backend/locales/es/LC_MESSAGES/messages.po
+++ b/backend/locales/es/LC_MESSAGES/messages.po
@@ -1,5 +1,6 @@
 msgid ""
 msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
 "Language: es\n"
 
 msgid "Welcome to RockMundo API"
@@ -67,3 +68,16 @@ msgstr "Trabajo semanal no disponible"
 
 msgid "No sponsorship set for this venue"
 msgstr "No hay patrocinio establecido para este lugar"
+
+msgid "%(num)d file"
+msgid_plural "%(num)d files"
+msgstr[0] "%(num)d archivo"
+msgstr[1] "%(num)d archivos"
+
+msgctxt "action"
+msgid "Open"
+msgstr "Abrir"
+
+msgctxt "status"
+msgid "Open"
+msgstr "Abierto"

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from routes import (
     social_routes,
     sponsorship,
     video_routes,
+    locale_routes,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -47,6 +48,7 @@ app.include_router(sponsorship.router, prefix="/api/sponsorships", tags=["Sponso
 app.include_router(social_routes.router, prefix="/api/social", tags=["Social"])
 app.include_router(video_routes.router, tags=["Videos"])
 app.include_router(legacy_routes.router, prefix="/api", tags=["Legacy"])
+app.include_router(locale_routes.router, prefix="/api", tags=["Locale"])
 
 
 @app.get("/metrics")

--- a/backend/middleware/locale.py
+++ b/backend/middleware/locale.py
@@ -1,14 +1,40 @@
 from starlette.middleware.base import BaseHTTPMiddleware
-from utils.i18n import set_locale, DEFAULT_LOCALE
+from utils.i18n import DEFAULT_LOCALE, SUPPORTED_LOCALES, set_locale
 
 
 class LocaleMiddleware(BaseHTTPMiddleware):
     """Middleware that sets the locale for each request."""
 
     async def dispatch(self, request, call_next):
-        lang = request.headers.get("Accept-Language", DEFAULT_LOCALE)
-        # take first language code before comma if multiple provided
-        lang = lang.split(",")[0]
-        set_locale(lang)
+        candidates: list[str] = []
+
+        # query string has highest priority
+        q = request.query_params.get("lang")
+        if q:
+            candidates.append(q)
+
+        # cookie next
+        cookie_lang = request.cookies.get("lang")
+        if cookie_lang:
+            candidates.append(cookie_lang)
+
+        # Accept-Language header may list multiple values with quality params
+        header = request.headers.get("Accept-Language", "")
+        for part in header.split(","):
+            code = part.split(";")[0].strip()
+            if code:
+                candidates.append(code)
+                base = code.split("-")[0]
+                if base and base != code:
+                    candidates.append(base)
+
+        # finally fall back to default locale
+        candidates.append(DEFAULT_LOCALE)
+
+        for lang in candidates:
+            if lang in SUPPORTED_LOCALES:
+                set_locale(lang)
+                break
+
         response = await call_next(request)
         return response

--- a/backend/routes/locale_routes.py
+++ b/backend/routes/locale_routes.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from utils.i18n import DEFAULT_LOCALE, SUPPORTED_LOCALES
+
+router = APIRouter()
+
+
+@router.get("/locales")
+def get_locales() -> dict[str, list[str] | str]:
+    """Expose supported locales and the default fallback."""
+    return {"default": DEFAULT_LOCALE, "locales": SUPPORTED_LOCALES}

--- a/backend/scripts/compile_translations.py
+++ b/backend/scripts/compile_translations.py
@@ -1,0 +1,25 @@
+"""Compile translation catalogs.
+
+Run during builds or CI to generate ``.mo`` files from the source ``.po``
+messages. Using compiled catalogs significantly speeds up application start.
+"""
+
+from pathlib import Path
+import subprocess
+
+
+LOCALES_DIR = Path(__file__).resolve().parents[1] / "locales"
+
+
+def main() -> None:
+    for locale_dir in LOCALES_DIR.iterdir():
+        po_path = locale_dir / "LC_MESSAGES" / "messages.po"
+        mo_path = locale_dir / "LC_MESSAGES" / "messages.mo"
+        if po_path.exists():
+            mo_path.parent.mkdir(parents=True, exist_ok=True)
+            subprocess.run(["msgfmt", str(po_path), "-o", str(mo_path)], check=True)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/backend/tests/test_i18n.py
+++ b/backend/tests/test_i18n.py
@@ -2,18 +2,33 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from middleware.locale import LocaleMiddleware
-from utils.i18n import _
+from utils.i18n import _, ngettext_, pgettext_, SUPPORTED_LOCALES, DEFAULT_LOCALE
 from routes.auth_routes import router as auth_router
+from routes.locale_routes import router as locale_router
 
 
 app = FastAPI()
 app.add_middleware(LocaleMiddleware)
 
+
 @app.get("/")
 def root():
     return {"message": _("Welcome to RockMundo API")}
 
+
+@app.get("/plural/{count}")
+def plural(count: int):
+    msg = ngettext_("%(num)d file", "%(num)d files", count) % {"num": count}
+    return {"message": msg}
+
+
+@app.get("/context/{kind}")
+def ctx(kind: str):
+    return {"message": pgettext_(kind, "Open")}
+
+
 app.include_router(auth_router)
+app.include_router(locale_router, prefix="/api")
 
 client = TestClient(app)
 
@@ -36,3 +51,23 @@ def test_error_translation():
     )
     assert resp.status_code == 401
     assert resp.json()["detail"] == "Credenciales inválidas"
+
+
+def test_plural_and_context_translation():
+    resp = client.get("/plural/2", headers={"Accept-Language": "es"})
+    assert resp.json()["message"] == "2 archivos"
+    resp = client.get("/context/status", headers={"Accept-Language": "es"})
+    assert resp.json()["message"] == "Abierto"
+
+
+def test_accept_language_fallback_order():
+    resp = client.get("/", headers={"Accept-Language": "fr, es"})
+    assert resp.json()["message"] == "Bienvenido a RockMundo API"
+
+
+def test_supported_locales_endpoint():
+    resp = client.get("/api/locales")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert DEFAULT_LOCALE == body["default"]
+    assert set(SUPPORTED_LOCALES).issubset(set(body["locales"]))

--- a/backend/utils/i18n.py
+++ b/backend/utils/i18n.py
@@ -1,10 +1,14 @@
 """Minimal locale utilities.
 
-This module provides a lightweight translation helper that reads ``.po`` files
-directly.  Compiled ``.mo`` catalogs are intentionally omitted from the
-repository, so translations are parsed at runtime and cached per locale.
+This module now leverages compiled ``.mo`` catalogs for fast startup while still
+falling back to parsing ``.po`` sources if necessary.  Plural forms and message
+contexts are supported via :class:`gettext.GNUTranslations`.
 """
 
+from __future__ import annotations
+
+import gettext
+import subprocess
 from contextvars import ContextVar
 from pathlib import Path
 from typing import Dict
@@ -12,8 +16,13 @@ from typing import Dict
 LOCALES_DIR = Path(__file__).resolve().parent.parent / "locales"
 DEFAULT_LOCALE = "en"
 
+# discover available locales at import time so the API can expose them
+SUPPORTED_LOCALES = sorted(
+    p.name for p in LOCALES_DIR.iterdir() if (p / "LC_MESSAGES" / "messages.po").exists()
+)
+
 _current_locale: ContextVar[str] = ContextVar("current_locale", default=DEFAULT_LOCALE)
-_translations: Dict[str, Dict[str, str]] = {}
+_translations: Dict[str, gettext.NullTranslations] = {}
 
 
 def set_locale(locale: str) -> None:
@@ -22,40 +31,70 @@ def set_locale(locale: str) -> None:
     _current_locale.set(locale)
 
 
-def _load_translations(locale: str) -> Dict[str, str]:
-    """Load translations from a ``.po`` file for *locale*.
+def _load_translations(locale: str) -> gettext.NullTranslations:
+    """Load translations for *locale*.
 
-    Only the simple ``msgid``/``msgstr`` pairs are supported which is
-    sufficient for the project's small catalogs.
+    If a compiled ``.mo`` catalog is present it is used directly.  Otherwise the
+    corresponding ``.po`` file is compiled on the fly using ``msgfmt``.
     """
 
-    catalog: Dict[str, str] = {}
-    po_path = LOCALES_DIR / locale / "LC_MESSAGES" / "messages.po"
-    with po_path.open("r", encoding="utf-8") as f:  # noqa: PTH123
-        msgid: str | None = None
-        for raw_line in f:
-            line = raw_line.strip()
-            if line.startswith("msgid "):
-                msgid = line[6:].strip().strip("\"")
-            elif line.startswith("msgstr ") and msgid is not None:
-                msgstr = line[7:].strip().strip("\"")
-                if msgid:
-                    catalog[msgid] = msgstr
-                msgid = None
-    return catalog
+    locale_dir = LOCALES_DIR / locale / "LC_MESSAGES"
+    mo_path = locale_dir / "messages.mo"
+    po_path = locale_dir / "messages.po"
+
+    if not mo_path.exists():
+        # Generate the compiled catalog; ``msgfmt`` is widely available and
+        # avoids a heavy runtime dependency such as ``polib``.
+        subprocess.run(["msgfmt", str(po_path), "-o", str(mo_path)], check=True)
+
+    with mo_path.open("rb") as fp:  # noqa: PTH123
+        return gettext.GNUTranslations(fp)
 
 
-def gettext_(message: str) -> str:
-    """Translate ``message`` for the current locale."""
-
+def _get_translations() -> gettext.NullTranslations:
     locale = _current_locale.get()
     if locale not in _translations:
         try:
             _translations[locale] = _load_translations(locale)
         except FileNotFoundError:
             _translations[locale] = _load_translations(DEFAULT_LOCALE)
-    return _translations[locale].get(message, message)
+    return _translations[locale]
+
+
+def gettext_(message: str) -> str:
+    """Translate ``message`` for the current locale."""
+
+    return _get_translations().gettext(message)
+
+
+def ngettext_(singular: str, plural: str, n: int) -> str:
+    """Return the pluralized translation for ``n``."""
+
+    return _get_translations().ngettext(singular, plural, n)
+
+
+def pgettext_(context: str, message: str) -> str:
+    """Return the translation for ``message`` in ``context``."""
+
+    return _get_translations().pgettext(context, message)
+
+
+def npgettext_(context: str, singular: str, plural: str, n: int) -> str:
+    """Return the pluralized translation within ``context``."""
+
+    return _get_translations().npgettext(context, singular, plural, n)
 
 
 _ = gettext_
+
+__all__ = [
+    "_",
+    "gettext_",
+    "ngettext_",
+    "pgettext_",
+    "npgettext_",
+    "set_locale",
+    "DEFAULT_LOCALE",
+    "SUPPORTED_LOCALES",
+]
 


### PR DESCRIPTION
## Summary
- support plural and context-aware translations using compiled `.mo` catalogs
- add locale detection fallback logic and list supported locales via `/api/locales`
- provide script to build translation catalogs

## Testing
- `python backend/scripts/compile_translations.py && echo compiled`
- `pytest backend/tests/test_i18n.py -q` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_68b3388394b08325a8a5db6a42f64112