### PR TITLE
refactor: use pooled DB connection in achievement service

### DIFF
--- a/backend/services/achievement_service.py
+++ b/backend/services/achievement_service.py
@@ -1,29 +1,35 @@
+"""Achievement service for managing definitions and user progress."""
+
 from __future__ import annotations
 
-import sqlite3
 from datetime import datetime
-from pathlib import Path
 from typing import Dict, List, Optional
 
 from backend.models.achievement import Achievement, PlayerAchievement
-
-DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+from core.config import settings
+from utils.db import get_conn
 
 
 class AchievementService:
     """Service to manage achievements and player progress."""
 
-    def __init__(self, db_path: Optional[str] = None):
-        self.db_path = str(db_path or DB_PATH)
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        """Initialize the service.
+
+        Args:
+            db_path: Optional path to the SQLite database. Defaults to
+                :data:`core.config.settings.DB_PATH`.
+        """
+
+        self.db_path = db_path or settings.DB_PATH
         self.ensure_schema()
         self._ensure_default_definitions()
 
     # -------------------- schema --------------------
-    def _conn(self) -> sqlite3.Connection:
-        return sqlite3.connect(self.db_path)
-
     def ensure_schema(self) -> None:
-        with self._conn() as conn:
+        """Create required database tables if they do not already exist."""
+
+        with get_conn(self.db_path) as conn:
             cur = conn.cursor()
             cur.execute(
                 """
@@ -47,27 +53,38 @@ class AchievementService:
                 )
                 """
             )
-            conn.commit()
 
     def _ensure_default_definitions(self) -> None:
         """Insert default achievement definitions if missing."""
+
         defaults = [
             ("chart_topper", "Chart Topper", "Reach #1 on any chart"),
             ("first_tour", "On the Road", "Confirm your first tour"),
             ("first_property", "Property Owner", "Purchase your first property"),
         ]
-        with self._conn() as conn:
+        with get_conn(self.db_path) as conn:
             cur = conn.cursor()
             for code, name, desc in defaults:
                 cur.execute(
                     "INSERT OR IGNORE INTO achievements (code, name, description) VALUES (?, ?, ?)",
                     (code, name, desc),
                 )
-            conn.commit()
 
     # -------------------- operations --------------------
     def _achievement_id(self, code: str) -> int:
-        with self._conn() as conn:
+        """Resolve an achievement code to its database ID.
+
+        Args:
+            code: Unique achievement code.
+
+        Returns:
+            The integer primary key for the achievement.
+
+        Raises:
+            ValueError: If the achievement code is unknown.
+        """
+
+        with get_conn(self.db_path) as conn:
             cur = conn.cursor()
             cur.execute("SELECT id FROM achievements WHERE code = ?", (code,))
             row = cur.fetchone()
@@ -76,10 +93,19 @@ class AchievementService:
             return int(row[0])
 
     def grant(self, user_id: int, code: str) -> bool:
-        """Grant an achievement to a user. Returns True if newly unlocked."""
+        """Grant an achievement to a user.
+
+        Args:
+            user_id: Identifier of the user receiving the achievement.
+            code: Achievement code to grant.
+
+        Returns:
+            ``True`` if the achievement was newly unlocked, ``False`` otherwise.
+        """
+
         aid = self._achievement_id(code)
         now = datetime.utcnow().isoformat()
-        with self._conn() as conn:
+        with get_conn(self.db_path) as conn:
             cur = conn.cursor()
             cur.execute(
                 "SELECT unlocked_at FROM user_achievements WHERE user_id=? AND achievement_id=?",
@@ -98,29 +124,53 @@ class AchievementService:
                     "INSERT INTO user_achievements (user_id, achievement_id, progress, unlocked_at) VALUES (?, ?, 0, ?)",
                     (user_id, aid, now),
                 )
-            conn.commit()
             return True
 
     def revoke(self, user_id: int, code: str) -> bool:
+        """Revoke an achievement from a user.
+
+        Args:
+            user_id: Identifier of the user.
+            code: Achievement code to revoke.
+
+        Returns:
+            ``True`` if a record was removed, ``False`` otherwise.
+        """
+
         aid = self._achievement_id(code)
-        with self._conn() as conn:
+        with get_conn(self.db_path) as conn:
             cur = conn.cursor()
             cur.execute(
                 "DELETE FROM user_achievements WHERE user_id=? AND achievement_id=?",
                 (user_id, aid),
             )
-            conn.commit()
             return cur.rowcount > 0
 
     def list_achievements(self) -> List[Dict[str, str]]:
-        with self._conn() as conn:
+        """Return all defined achievements.
+
+        Returns:
+            A list of dictionaries with keys ``code``, ``name`` and ``description``.
+        """
+
+        with get_conn(self.db_path) as conn:
             cur = conn.cursor()
             cur.execute("SELECT code, name, description FROM achievements ORDER BY id")
             rows = cur.fetchall()
             return [dict(zip(["code", "name", "description"], r)) for r in rows]
 
     def get_user_achievements(self, user_id: int) -> List[Dict[str, Optional[str]]]:
-        with self._conn() as conn:
+        """Retrieve achievement progress for a user.
+
+        Args:
+            user_id: Identifier of the user.
+
+        Returns:
+            A list of dictionaries containing achievement data and progress
+            information.
+        """
+
+        with get_conn(self.db_path) as conn:
             cur = conn.cursor()
             cur.execute(
                 """
@@ -133,5 +183,7 @@ class AchievementService:
             )
             rows = cur.fetchall()
             return [
-                dict(zip(["code", "name", "description", "unlocked_at", "progress"], r)) for r in rows
+                dict(zip(["code", "name", "description", "unlocked_at", "progress"], r))
+                for r in rows
             ]
+


### PR DESCRIPTION
## Summary
- refactor achievement service to use pooled DB connection from `utils.db.get_conn`
- rely on `core.config` settings for DB path and document service methods

## Testing
- `pytest backend/tests/achievements/test_achievements.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b33aa5b7948325a0825991b3f65907