### PR TITLE
feat: configure cors middleware

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -20,7 +20,9 @@ def _load_dotenv(dotenv_path: Optional[str] = None) -> None:
 _load_dotenv()
 
 class Settings:
-    DB_PATH: str = os.getenv("ROCKMUNDO_DB_PATH", str((Path(__file__).resolve().parents[1] / "rockmundo.db")))
+    DB_PATH: str = os.getenv(
+        "ROCKMUNDO_DB_PATH", str((Path(__file__).resolve().parents[1] / "rockmundo.db"))
+    )
     ENV: str = os.getenv("ROCKMUNDO_ENV", "dev")
     LOG_LEVEL: str = os.getenv("ROCKMUNDO_LOG_LEVEL", "INFO")
     # Auth
@@ -39,5 +41,11 @@ class Settings:
     RATE_LIMIT_REDIS_URL: str = os.getenv(
         "ROCKMUNDO_RATE_LIMIT_REDIS_URL", "redis://localhost:6379/0"
     )
+    # CORS
+    CORS_ALLOWED_ORIGINS: list[str] = [
+        origin.strip()
+        for origin in os.getenv("ROCKMUNDO_CORS_ALLOWED_ORIGINS", "*").split(",")
+        if origin.strip()
+    ]
 
 settings = Settings()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from auth.routes import admin_mfa_router
+from core.config import settings
 from database import init_db
 from middleware.admin_mfa import AdminMFAMiddleware
 from middleware.locale import LocaleMiddleware
@@ -9,10 +10,10 @@ from routes import (
     event_routes,
     legacy_routes,
     lifestyle_routes,
+    locale_routes,
     social_routes,
     sponsorship,
     video_routes,
-    locale_routes,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -21,8 +22,15 @@ from backend.utils.logging import setup_logging
 from backend.utils.metrics import CONTENT_TYPE_LATEST, generate_latest
 from backend.utils.tracing import setup_tracing
 from fastapi import FastAPI, Response
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI(title="RockMundo API with Events, Lifestyle, and Sponsorships")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.CORS_ALLOWED_ORIGINS,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.add_middleware(ObservabilityMiddleware)
 app.add_middleware(RateLimitMiddleware)
 app.add_middleware(LocaleMiddleware)


### PR DESCRIPTION
## Summary
- import and configure CORS middleware
- expose allowed origins via settings

## Testing
- `ruff check backend/main.py backend/core/config.py`
- `pytest` *(fails: KeyboardInterrupt after running 100s)*

------
https://chatgpt.com/codex/tasks/task_e_68b3445e73ec8325889d6deeac136251