### PR TITLE
refactor settings to pydantic BaseSettings

### DIFF
--- a/backend/auth/dependencies.py
+++ b/backend/auth/dependencies.py
@@ -22,9 +22,9 @@ async def get_current_user_id(req: Request) -> int:
     try:
         payload = jwt_helper.decode(
             token,
-            secret=settings.JWT_SECRET,
-            expected_iss=settings.JWT_ISS,
-            expected_aud=settings.JWT_AUD,
+            secret=settings.auth.jwt_secret,
+            expected_iss=settings.auth.jwt_iss,
+            expected_aud=settings.auth.jwt_aud,
         )
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail={'code':'AUTH_INVALID','message':str(e)})

--- a/backend/auth/service.py
+++ b/backend/auth/service.py
@@ -48,18 +48,18 @@ class AuthService:
         """
 
         now = jwt_helper.now_ts()
-        exp = now + settings.ACCESS_TOKEN_TTL_MIN * 60
+        exp = now + settings.auth.access_token_ttl_min * 60
         jti = uuid.uuid4().hex
         payload = {
-            "iss": settings.JWT_ISS,
-            "aud": settings.JWT_AUD,
+            "iss": settings.auth.jwt_iss,
+            "aud": settings.auth.jwt_aud,
             "iat": now,
             "nbf": now,
             "exp": exp,
             "sub": str(user_id),
             "jti": jti,
         }
-        token = jwt_helper.encode(payload, secret=settings.JWT_SECRET)
+        token = jwt_helper.encode(payload, secret=settings.auth.jwt_secret)
         expires_at = datetime.fromtimestamp(exp, UTC).isoformat()
         with get_conn(self.db_path) as conn:
             conn.execute(
@@ -74,7 +74,7 @@ class AuthService:
     def _new_refresh_token(self, user_id: int, user_agent: str = "", ip: str = "") -> Dict[str, Any]:
         token = secrets.token_urlsafe(48)
         token_hash = self._hash_refresh(token)
-        expires = _now() + timedelta(days=settings.REFRESH_TOKEN_TTL_DAYS)
+        expires = _now() + timedelta(days=settings.auth.refresh_token_ttl_days)
         with get_conn(self.db_path) as conn:
             conn.execute("""INSERT INTO refresh_tokens (user_id, token_hash, expires_at, user_agent, ip)
                           VALUES (?, ?, ?, ?, ?)""", (user_id, token_hash, expires.isoformat(), user_agent[:200], ip[:64]))

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,7 +29,7 @@ app = FastAPI(title="RockMundo API with Events, Lifestyle, and Sponsorships")
 app.add_exception_handler(HTTPException, http_exception_handler)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.CORS_ALLOWED_ORIGINS,
+    allow_origins=settings.cors.allowed_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/middleware/rate_limit.py
+++ b/backend/middleware/rate_limit.py
@@ -21,8 +21,8 @@ class RateLimitMiddleware:
         limit: int | None = None,
         backend: str | None = None,
     ) -> None:
-        self.limit = limit or settings.RATE_LIMIT_REQUESTS_PER_MIN
-        self.backend = (backend or settings.RATE_LIMIT_STORAGE).lower()
+        self.limit = limit or settings.rate_limit.requests_per_min
+        self.backend = (backend or settings.rate_limit.storage).lower()
 
         self._memory: Dict[str, Tuple[int, float]] = {}
         self._redis = None
@@ -30,7 +30,7 @@ class RateLimitMiddleware:
             try:  # pragma: no cover - redis optional in tests
                 import redis.asyncio as aioredis
 
-                self._redis = aioredis.from_url(settings.RATE_LIMIT_REDIS_URL)
+                self._redis = aioredis.from_url(settings.rate_limit.redis_url)
             except Exception:  # fall back to memory if redis unavailable
                 self.backend = "memory"
 

--- a/backend/services/achievement_service.py
+++ b/backend/services/achievement_service.py
@@ -18,10 +18,10 @@ class AchievementService:
 
         Args:
             db_path: Optional path to the SQLite database. Defaults to
-                :data:`core.config.settings.DB_PATH`.
+                :data:`core.config.settings.database.path`.
         """
 
-        self.db_path = db_path or settings.DB_PATH
+        self.db_path = db_path or settings.database.path
         self.ensure_schema()
         self._ensure_default_definitions()
 

--- a/backend/services/discord_service.py
+++ b/backend/services/discord_service.py
@@ -14,7 +14,7 @@ class DiscordServiceError(Exception):
 
 def send_message(content: str) -> None:
     """Send a message to a Discord webhook."""
-    url = getattr(settings, "DISCORD_WEBHOOK_URL", "")
+    url = settings.auth.discord_webhook_url
     if not url:
         raise DiscordServiceError("DISCORD_WEBHOOK_URL is not configured")
     if requests is None:

--- a/backend/tests/services/test_discord_service.py
+++ b/backend/tests/services/test_discord_service.py
@@ -21,7 +21,7 @@ def test_send_message_posts_content(monkeypatch):
 
             return Resp()
 
-    monkeypatch.setattr(settings, "DISCORD_WEBHOOK_URL", "https://example.com/webhook")
+    monkeypatch.setattr(settings.auth, "discord_webhook_url", "https://example.com/webhook")
     monkeypatch.setattr(discord_service, "requests", DummyRequests())
 
     discord_service.send_message("hello world")
@@ -43,7 +43,7 @@ def test_send_message_raises_on_error(monkeypatch):
         def post(self, *args, **kwargs):
             return fake_post(*args, **kwargs)
 
-    monkeypatch.setattr(settings, "DISCORD_WEBHOOK_URL", "https://example.com/webhook")
+    monkeypatch.setattr(settings.auth, "discord_webhook_url", "https://example.com/webhook")
     monkeypatch.setattr(discord_service, "requests", DummyRequests())
 
     with pytest.raises(discord_service.DiscordServiceError):
@@ -51,6 +51,6 @@ def test_send_message_raises_on_error(monkeypatch):
 
 
 def test_send_message_requires_url(monkeypatch):
-    monkeypatch.setattr(settings, "DISCORD_WEBHOOK_URL", "")
+    monkeypatch.setattr(settings.auth, "discord_webhook_url", "")
     with pytest.raises(discord_service.DiscordServiceError):
         discord_service.send_message("oops")

--- a/backend/tests/test_auth_flow.py
+++ b/backend/tests/test_auth_flow.py
@@ -65,7 +65,12 @@ def test_register_login_refresh_me_logout():
     assert at and rt
 
     # Token should decode with expected claims
-    payload = decode(at, secret=settings.JWT_SECRET, expected_iss=settings.JWT_ISS, expected_aud=settings.JWT_AUD)
+    payload = decode(
+        at,
+        secret=settings.auth.jwt_secret,
+        expected_iss=settings.auth.jwt_iss,
+        expected_aud=settings.auth.jwt_aud,
+    )
     assert payload["sub"] == str(uid)
     assert payload.get("jti")
 
@@ -94,7 +99,12 @@ def test_register_login_refresh_me_logout():
     at2 = r.json()["access_token"]
     assert at2 and at2 != at
 
-    payload2 = decode(at2, secret=settings.JWT_SECRET, expected_iss=settings.JWT_ISS, expected_aud=settings.JWT_AUD)
+    payload2 = decode(
+        at2,
+        secret=settings.auth.jwt_secret,
+        expected_iss=settings.auth.jwt_iss,
+        expected_aud=settings.auth.jwt_aud,
+    )
     assert payload2["sub"] == str(uid)
 
     # Logout (revoke current refresh)

--- a/backend/utils/auth_utils.py
+++ b/backend/utils/auth_utils.py
@@ -5,7 +5,7 @@ from services.auth_service import get_user_by_username, verify_password
 
 from backend.auth.jwt import encode
 
-ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_TTL_MIN
+ACCESS_TOKEN_EXPIRE_MINUTES = settings.auth.access_token_ttl_min
 
 
 def create_access_token(username: str, role: str) -> str:
@@ -15,10 +15,10 @@ def create_access_token(username: str, role: str) -> str:
         "sub": username,
         "role": role,
         "exp": expire,
-        "iss": settings.JWT_ISS,
-        "aud": settings.JWT_AUD,
+        "iss": settings.auth.jwt_iss,
+        "aud": settings.auth.jwt_aud,
     }
-    return encode(to_encode, settings.JWT_SECRET)
+    return encode(to_encode, settings.auth.jwt_secret)
 
 
 def verify_user_credentials(username: str, password: str) -> dict | None:

--- a/backend/utils/db.py
+++ b/backend/utils/db.py
@@ -7,7 +7,7 @@ from queue import Queue
 
 try:
     from core.config import settings
-    DEFAULT_DB = settings.DB_PATH
+    DEFAULT_DB = settings.database.path
 except Exception:
     DEFAULT_DB = str(Path(__file__).resolve().parents[1] / "rockmundo.db")
 

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -1,14 +1,113 @@
+"""Minimal subset of the :mod:`pydantic` API used in tests.
+
+This lightweight implementation provides ``BaseModel``, ``BaseSettings`` and
+``Field`` with very small feature sets so that the rest of the project can
+define configuration models without requiring the real dependency.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, get_args, get_origin
+
+
+class FieldInfo:
+    """Store metadata about a model field."""
+
+    def __init__(self, default: Any = None, *, default_factory=None, env: str | None = None):
+        self.default = default
+        self.default_factory = default_factory
+        self.env = env
+
+
+def Field(default: Any = None, *, default_factory=None, env: str | None = None, **kwargs) -> FieldInfo:
+    """Return a ``FieldInfo`` describing a model field.
+
+    Only the ``default``, ``default_factory`` and ``env`` parameters are
+    recognised; all other arguments are accepted for compatibility but ignored.
+    """
+
+    return FieldInfo(default, default_factory=default_factory, env=env)
+
+
 class BaseModel:
-    def __init__(self, **data):
+    """Very small subset of :class:`pydantic.BaseModel`."""
+
+    def __init__(self, **data: Any) -> None:
+        annotations = getattr(self.__class__, "__annotations__", {})
+        for name, annotation in annotations.items():
+            field = getattr(self.__class__, name, None)
+            if isinstance(field, FieldInfo):
+                value = field.default_factory() if field.default_factory is not None else field.default
+                env_name = field.env
+            else:
+                value = field
+                env_name = None
+            if env_name:
+                env_val = os.getenv(env_name)
+                if env_val is not None:
+                    value = self._coerce(env_val, annotation)
+            setattr(self, name, value)
+
         for key, value in data.items():
             setattr(self, key, value)
 
-    def dict(self):
+    def dict(self) -> dict[str, Any]:  # pragma: no cover - trivial
         return self.__dict__.copy()
 
+    @staticmethod
+    def _coerce(value: str, field_type: Any) -> Any:
+        """Convert environment string values to the declared type."""
 
-def Field(default=None, *, default_factory=None, **kwargs):
-    """Return a default value similar to pydantic.Field."""
-    if default_factory is not None:
-        return default_factory()
-    return default
+        origin = get_origin(field_type)
+        if field_type == int:
+            return int(value)
+        if field_type == float:
+            return float(value)
+        if field_type == bool:
+            return value.lower() in {"1", "true", "yes", "on"}
+        if origin == list and get_args(field_type) == (str,):
+            return [v.strip() for v in value.split(",") if v.strip()]
+        return value
+
+
+class BaseSettings(BaseModel):
+    """Minimal ``BaseSettings`` reading values from environment variables."""
+
+    class Config:
+        env_file = None  # type: ignore[assignment]
+
+    def __init__(self, **data: Any) -> None:
+        cfg = getattr(self.__class__, "Config", None)
+        env_file = getattr(cfg, "env_file", None)
+        if env_file:
+            path = Path(env_file)
+            if path.exists():
+                for line in path.read_text().splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    k, v = line.split("=", 1)
+                    os.environ.setdefault(k.strip(), v.strip())
+
+        super().__init__(**data)
+
+
+def create_model(name: str, **fields: Any) -> type:
+    """Dynamically create a ``BaseModel`` subclass.
+
+    This minimal stand-in only supports declaring field annotations and default
+    values. It is sufficient for FastAPI's usage in the tests.
+    """
+
+    annotations: dict[str, Any] = {}
+    attrs: dict[str, Any] = {}
+    for field_name, value in fields.items():
+        if isinstance(value, tuple):
+            annotations[field_name] = value[0]
+            attrs[field_name] = value[1]
+        else:
+            annotations[field_name] = value
+    attrs["__annotations__"] = annotations
+    return type(name, (BaseModel,), attrs)

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -1,0 +1,4 @@
+"""Simplified Pydantic version module for tests."""
+
+VERSION = "0.0"
+


### PR DESCRIPTION
## Summary
- replace `Settings` with pydantic `BaseSettings` and nested database/auth/rate-limit/CORS models
- update backend components to use new structured settings
- extend internal pydantic stub with `BaseSettings`, `create_model`, and version module

## Testing
- `ruff check backend/core/config.py backend/middleware/rate_limit.py backend/utils/auth_utils.py backend/utils/db.py backend/auth/service.py backend/auth/dependencies.py backend/services/achievement_service.py backend/services/discord_service.py backend/main.py backend/tests/services/test_discord_service.py backend/tests/test_auth_flow.py` *(fails: import order and lint errors)*
- `pytest backend/tests/services/test_discord_service.py backend/tests/test_auth_flow.py` *(fails: ImportError: cannot import name 'AnyUrl' from 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b35ed660ac8325b352eeda71674b3a