### PR TITLE
feat: configurable tracing exporters

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+import os
+
 from auth.routes import admin_mfa_router
 from core.config import settings
 from database import init_db
@@ -41,8 +43,17 @@ app.add_middleware(AdminMFAMiddleware)
 
 @app.on_event("startup")
 def startup() -> None:
+    """Initialize logging, tracing and database connections.
+
+    The tracing exporter can be selected with the ``TRACING_EXPORTER``
+    environment variable. Supported values are ``console`` (default),
+    ``otlp`` and ``jaeger``. Additional variables such as ``JAEGER_HOST``
+    and ``JAEGER_PORT`` configure exporter specifics.
+    """
+
     setup_logging()
-    setup_tracing()
+    exporter = os.getenv("TRACING_EXPORTER", "console")
+    setup_tracing(exporter)
     init_db()
     init_pool()
 


### PR DESCRIPTION
## Summary
- allow choosing OpenTelemetry exporter via `setup_tracing(exporter)`
- document tracing setup in application startup so deployments can enable OTLP or Jaeger exporters

## Testing
- `ruff check backend/utils/tracing.py backend/main.py`
- `pytest` *(fails: ImportError: cannot import name 'AnyUrl' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b367407ca88325ada5ec5c7893a9cd