### PR TITLE
Adopt async SQLite helper and auth service

### DIFF
--- a/aiosqlite.py
+++ b/aiosqlite.py
@@ -1,0 +1,94 @@
+"""Minimal stub of :mod:`aiosqlite` used for tests.
+
+This is *not* a full implementation but provides the small subset of
+functionality required by the exercises.  It wraps the standard :mod:`sqlite3`
+module and executes blocking operations in a thread pool so the API mirrors
+the real ``aiosqlite`` package.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from typing import Any, Iterable
+
+Row = sqlite3.Row
+
+
+class Cursor:
+    def __init__(self, cursor: sqlite3.Cursor):
+        self._cursor = cursor
+
+    async def execute(self, sql: str, params: Iterable[Any] | None = None):
+        params = tuple(params or ())
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._cursor.execute, sql, params)
+        return self
+
+    async def executemany(self, sql: str, seq: Iterable[Iterable[Any]]):
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._cursor.executemany, sql, list(seq))
+        return self
+
+    async def fetchone(self):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._cursor.fetchone)
+
+    async def fetchall(self):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._cursor.fetchall)
+
+    @property
+    def lastrowid(self) -> int:
+        return self._cursor.lastrowid
+
+
+class Connection:
+    def __init__(self, path: str):
+        self._conn = sqlite3.connect(path, check_same_thread=False)
+        self.row_factory = None
+
+    async def execute(self, sql: str, params: Iterable[Any] | None = None):
+        cur = self._conn.cursor()
+        if self.row_factory is not None:
+            self._conn.row_factory = self.row_factory
+            cur = self._conn.cursor()
+        params = tuple(params or ())
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, cur.execute, sql, params)
+        return Cursor(cur)
+
+    async def executemany(self, sql: str, seq: Iterable[Iterable[Any]]):
+        cur = self._conn.cursor()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, cur.executemany, sql, list(seq))
+        return Cursor(cur)
+
+    async def executescript(self, script: str):
+        cur = self._conn.cursor()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, cur.executescript, script)
+        return Cursor(cur)
+
+    async def commit(self) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._conn.commit)
+
+    async def rollback(self) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._conn.rollback)
+
+    async def close(self) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._conn.close)
+
+    # For synchronous wrapper
+    def cursor(self) -> Cursor:  # pragma: no cover - minimal usage
+        if self.row_factory is not None:
+            self._conn.row_factory = self.row_factory
+        return Cursor(self._conn.cursor())
+
+
+async def connect(path: str) -> Connection:
+    return Connection(path)
+

--- a/backend/auth/routes.py
+++ b/backend/auth/routes.py
@@ -1,16 +1,16 @@
 # File: backend/auth/routes.py
-from fastapi import APIRouter, HTTPException, Request, Depends
-from pydantic import BaseModel, EmailStr, Field
-from typing import Optional, List, Dict, Any
-from datetime import datetime, timedelta
 import random
 import uuid
+from datetime import datetime, timedelta
+from typing import Optional
 
-from auth.service import AuthService
-from auth.jwt import decode
 from auth.dependencies import get_current_user_id, require_role
-from utils.db import get_conn
+from auth.service import AuthService
+from fastapi import APIRouter, Depends, HTTPException, Request
 from models.admin import AdminSession, admin_sessions
+from utils.db import aget_conn
+
+from pydantic import BaseModel, EmailStr, Field
 
 router = APIRouter(prefix="/auth", tags=["Auth"])
 svc = AuthService()
@@ -35,32 +35,52 @@ class RevokeTokenIn(BaseModel):
     jti: str
 
 @router.post("/register")
-def register(payload: RegisterIn):
+async def register(payload: RegisterIn):
     try:
-        return svc.register(email=payload.email, password=payload.password, display_name=payload.display_name or "")
+        return await svc.register(
+            email=payload.email,
+            password=payload.password,
+            display_name=payload.display_name or "",
+        )
     except ValueError as e:
         code = str(e)
         if code == "EMAIL_TAKEN":
-            raise HTTPException(status_code=409, detail={"code":"EMAIL_TAKEN","message":"Email already registered"})
+            raise HTTPException(
+                status_code=409,
+                detail={"code": "EMAIL_TAKEN", "message": "Email already registered"},
+            )
         raise
 
 @router.post("/login")
-def login(req: Request, payload: LoginIn):
-    ua = req.headers.get('user-agent', '')
-    ip = req.client.host if req.client else ''
+async def login(req: Request, payload: LoginIn):
+    ua = req.headers.get("user-agent", "")
+    ip = req.client.host if req.client else ""
     try:
-        return svc.login(email=payload.email, password=payload.password, user_agent=ua, ip=ip)
+        return await svc.login(
+            email=payload.email,
+            password=payload.password,
+            user_agent=ua,
+            ip=ip,
+        )
     except ValueError as e:
         if str(e) == "INVALID_CREDENTIALS":
-            raise HTTPException(status_code=401, detail={"code":"INVALID_CREDENTIALS","message":"Invalid email or password"})
+            raise HTTPException(
+                status_code=401,
+                detail={
+                    "code": "INVALID_CREDENTIALS",
+                    "message": "Invalid email or password",
+                },
+            )
         raise
 
 @router.post("/refresh")
-def refresh(req: Request, payload: RefreshIn):
-    ua = req.headers.get('user-agent', '')
-    ip = req.client.host if req.client else ''
+async def refresh(req: Request, payload: RefreshIn):
+    ua = req.headers.get("user-agent", "")
+    ip = req.client.host if req.client else ""
     try:
-        return svc.refresh(refresh_token=payload.refresh_token, user_agent=ua, ip=ip)
+        return await svc.refresh(
+            refresh_token=payload.refresh_token, user_agent=ua, ip=ip
+        )
     except ValueError as e:
         code = str(e)
         mapping = {
@@ -69,28 +89,41 @@ def refresh(req: Request, payload: RefreshIn):
             "REFRESH_EXPIRED": (401, "Refresh token expired"),
         }
         status_code, msg = mapping.get(code, (400, code))
-        raise HTTPException(status_code=status_code, detail={"code":code, "message":msg})
+        raise HTTPException(status_code=status_code, detail={"code": code, "message": msg})
 
 @router.post("/logout")
-def logout(payload: LogoutIn):
-    return svc.logout(refresh_token=payload.refresh_token)
+async def logout(payload: LogoutIn):
+    return await svc.logout(refresh_token=payload.refresh_token)
 
 
 @router.post("/tokens/revoke", dependencies=[Depends(require_role(["admin"]))])
-def revoke_token(payload: RevokeTokenIn):
-    if not svc.revoke_access_token(payload.jti):
-        raise HTTPException(status_code=404, detail={"code": "TOKEN_NOT_FOUND", "message": "Token not found"})
+async def revoke_token(payload: RevokeTokenIn):
+    if not await svc.revoke_access_token(payload.jti):
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "TOKEN_NOT_FOUND", "message": "Token not found"},
+        )
     return {"ok": True}
 
 @router.get("/me")
-def me(user_id: int = Depends(get_current_user_id)):
-    with get_conn() as conn:
-        row = conn.execute("SELECT id, email, display_name, is_active, created_at FROM users WHERE id=?", (user_id,)).fetchone()
+async def me(user_id: int = Depends(get_current_user_id)):
+    async with aget_conn() as conn:
+        cur = await conn.execute(
+            "SELECT id, email, display_name, is_active, created_at FROM users WHERE id=?",
+            (user_id,),
+        )
+        row = await cur.fetchone()
         if not row:
-            raise HTTPException(status_code=404, detail={"code":"USER_NOT_FOUND","message":"User not found"})
-        # roles
-        roles = conn.execute("""SELECT r.name FROM user_roles ur JOIN roles r ON r.id = ur.role_id WHERE ur.user_id=?""", (user_id,)).fetchall()
-        return {**dict(row), "roles": [r['name'] for r in roles]}
+            raise HTTPException(
+                status_code=404,
+                detail={"code": "USER_NOT_FOUND", "message": "User not found"},
+            )
+        roles_cur = await conn.execute(
+            """SELECT r.name FROM user_roles ur JOIN roles r ON r.id = ur.role_id WHERE ur.user_id=?""",
+            (user_id,),
+        )
+        roles = await roles_cur.fetchall()
+        return {**dict(row), "roles": [r["name"] for r in roles]}
 
 # Admin role management
 class RoleAssignIn(BaseModel):
@@ -98,21 +131,35 @@ class RoleAssignIn(BaseModel):
     role: str
 
 @router.post("/roles/assign", dependencies=[Depends(require_role(["admin"]))])
-def assign_role(payload: RoleAssignIn):
-    with get_conn() as conn:
-        r = conn.execute("SELECT id FROM roles WHERE name=?", (payload.role,)).fetchone()
+async def assign_role(payload: RoleAssignIn):
+    async with aget_conn() as conn:
+        cur = await conn.execute("SELECT id FROM roles WHERE name=?", (payload.role,))
+        r = await cur.fetchone()
         if not r:
-            raise HTTPException(status_code=404, detail={"code":"ROLE_NOT_FOUND","message":"Role not found"})
-        conn.execute("INSERT OR IGNORE INTO user_roles (user_id, role_id) VALUES (?, ?)", (payload.user_id, r['id']))
+            raise HTTPException(
+                status_code=404,
+                detail={"code": "ROLE_NOT_FOUND", "message": "Role not found"},
+            )
+        await conn.execute(
+            "INSERT OR IGNORE INTO user_roles (user_id, role_id) VALUES (?, ?)",
+            (payload.user_id, r["id"]),
+        )
         return {"ok": True}
 
 @router.post("/roles/revoke", dependencies=[Depends(require_role(["admin"]))])
-def revoke_role(payload: RoleAssignIn):
-    with get_conn() as conn:
-        r = conn.execute("SELECT id FROM roles WHERE name=?", (payload.role,)).fetchone()
+async def revoke_role(payload: RoleAssignIn):
+    async with aget_conn() as conn:
+        cur = await conn.execute("SELECT id FROM roles WHERE name=?", (payload.role,))
+        r = await cur.fetchone()
         if not r:
-            raise HTTPException(status_code=404, detail={"code":"ROLE_NOT_FOUND","message":"Role not found"})
-        conn.execute("DELETE FROM user_roles WHERE user_id=? AND role_id=?", (payload.user_id, r['id']))
+            raise HTTPException(
+                status_code=404,
+                detail={"code": "ROLE_NOT_FOUND", "message": "Role not found"},
+            )
+        await conn.execute(
+            "DELETE FROM user_roles WHERE user_id=? AND role_id=?",
+            (payload.user_id, r["id"]),
+        )
         return {"ok": True}
 
 

--- a/backend/auth/service.py
+++ b/backend/auth/service.py
@@ -1,13 +1,16 @@
 # File: backend/auth/service.py
 from __future__ import annotations
-from typing import Optional, Dict, Any
-from datetime import datetime, timedelta, timezone
-import hashlib, secrets, uuid
 
-from utils.db import get_conn
-from core.security import hash_password, verify_password
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
 from auth import jwt as jwt_helper
 from core.config import settings
+from core.security import hash_password, verify_password
+from utils.db import aget_conn
 
 UTC = timezone.utc
 
@@ -23,24 +26,32 @@ class AuthService:
         self.db_path = db_path
 
     # --- users ---
-    def register(self, email: str, password: str, display_name: str = "") -> Dict[str, Any]:
+    async def register(self, email: str, password: str, display_name: str = "") -> Dict[str, Any]:
         email = email.strip().lower()
-        with get_conn(self.db_path) as conn:
-            cur = conn.cursor()
-            cur.execute("SELECT id FROM users WHERE email=?", (email,))
-            if cur.fetchone():
+        async with aget_conn(self.db_path) as conn:
+            cur = await conn.execute("SELECT id FROM users WHERE email=?", (email,))
+            if await cur.fetchone():
                 raise ValueError("EMAIL_TAKEN")
             pw = hash_password(password)
-            cur.execute("INSERT INTO users (email, password_hash, display_name) VALUES (?, ?, ?)", (email, pw, display_name))
+            cur = await conn.execute(
+                "INSERT INTO users (email, password_hash, display_name) VALUES (?, ?, ?)",
+                (email, pw, display_name),
+            )
             user_id = int(cur.lastrowid)
             # default role 'user'
-            cur.execute("INSERT OR IGNORE INTO roles(name) VALUES('user')")
-            cur.execute("INSERT INTO user_roles (user_id, role_id) SELECT ?, id FROM roles WHERE name='user'", (user_id,))
-            cur.execute("INSERT INTO audit_log (user_id, action, meta) VALUES (?, 'user.register', json_object('email', ?))", (user_id, email))
+            await conn.execute("INSERT OR IGNORE INTO roles(name) VALUES('user')")
+            await conn.execute(
+                "INSERT INTO user_roles (user_id, role_id) SELECT ?, id FROM roles WHERE name='user'",
+                (user_id,),
+            )
+            await conn.execute(
+                "INSERT INTO audit_log (user_id, action, meta) VALUES (?, 'user.register', json_object('email', ?))",
+                (user_id, email),
+            )
             return {"id": user_id, "email": email, "display_name": display_name}
 
     # --- tokens ---
-    def _make_access_token(self, user_id: int) -> str:
+    async def _make_access_token(self, user_id: int) -> str:
         """Create an access JWT for a user and persist its identifier.
 
         A unique ``jti`` (JWT ID) is added to the payload and stored in the
@@ -61,8 +72,8 @@ class AuthService:
         }
         token = jwt_helper.encode(payload, secret=settings.auth.jwt_secret)
         expires_at = datetime.fromtimestamp(exp, UTC).isoformat()
-        with get_conn(self.db_path) as conn:
-            conn.execute(
+        async with aget_conn(self.db_path) as conn:
+            await conn.execute(
                 "INSERT INTO access_tokens (jti, user_id, expires_at) VALUES (?, ?, ?)",
                 (jti, user_id, expires_at),
             )
@@ -71,36 +82,46 @@ class AuthService:
     def _hash_refresh(self, token: str) -> str:
         return hashlib.sha256(token.encode('utf-8')).hexdigest()
 
-    def _new_refresh_token(self, user_id: int, user_agent: str = "", ip: str = "") -> Dict[str, Any]:
+    async def _new_refresh_token(self, user_id: int, user_agent: str = "", ip: str = "") -> Dict[str, Any]:
         token = secrets.token_urlsafe(48)
         token_hash = self._hash_refresh(token)
         expires = _now() + timedelta(days=settings.auth.refresh_token_ttl_days)
-        with get_conn(self.db_path) as conn:
-            conn.execute("""INSERT INTO refresh_tokens (user_id, token_hash, expires_at, user_agent, ip)
-                          VALUES (?, ?, ?, ?, ?)""", (user_id, token_hash, expires.isoformat(), user_agent[:200], ip[:64]))
+        async with aget_conn(self.db_path) as conn:
+            await conn.execute(
+                """INSERT INTO refresh_tokens (user_id, token_hash, expires_at, user_agent, ip)
+                          VALUES (?, ?, ?, ?, ?)""",
+                (user_id, token_hash, expires.isoformat(), user_agent[:200], ip[:64]),
+            )
         return {"refresh_token": token, "expires_at": expires.isoformat()}
 
-    def login(self, email: str, password: str, user_agent: str = "", ip: str = "") -> Dict[str, Any]:
+    async def login(self, email: str, password: str, user_agent: str = "", ip: str = "") -> Dict[str, Any]:
         email = email.strip().lower()
-        with get_conn(self.db_path) as conn:
-            cur = conn.cursor()
-            cur.execute("SELECT id, password_hash, is_active FROM users WHERE email=?", (email,))
-            row = cur.fetchone()
+        async with aget_conn(self.db_path) as conn:
+            cur = await conn.execute(
+                "SELECT id, password_hash, is_active FROM users WHERE email=?",
+                (email,),
+            )
+            row = await cur.fetchone()
             if not row or row[2] == 0 or not verify_password(password, row[1]):
                 raise ValueError("INVALID_CREDENTIALS")
             user_id = int(row[0])
-            access = self._make_access_token(user_id)
-            refresh = self._new_refresh_token(user_id, user_agent=user_agent, ip=ip)
-            conn.execute("INSERT INTO audit_log (user_id, action, meta) VALUES (?, 'auth.login', json_object('ua', ?, 'ip', ?))", (user_id, user_agent, ip))
+            access = await self._make_access_token(user_id)
+            refresh = await self._new_refresh_token(user_id, user_agent=user_agent, ip=ip)
+            await conn.execute(
+                "INSERT INTO audit_log (user_id, action, meta) VALUES (?, 'auth.login', json_object('ua', ?, 'ip', ?))",
+                (user_id, user_agent, ip),
+            )
             return {"access_token": access, **refresh, "token_type": "Bearer"}
 
-    def refresh(self, refresh_token: str, user_agent: str = "", ip: str = "") -> Dict[str, Any]:
+    async def refresh(self, refresh_token: str, user_agent: str = "", ip: str = "") -> Dict[str, Any]:
         token_hash = self._hash_refresh(refresh_token)
-        with get_conn(self.db_path) as conn:
-            cur = conn.cursor()
-            cur.execute("""SELECT user_id, expires_at, revoked_at FROM refresh_tokens
-                           WHERE token_hash=?""", (token_hash,))
-            row = cur.fetchone()
+        async with aget_conn(self.db_path) as conn:
+            cur = await conn.execute(
+                """SELECT user_id, expires_at, revoked_at FROM refresh_tokens
+                           WHERE token_hash=?""",
+                (token_hash,),
+            )
+            row = await cur.fetchone()
             if not row:
                 raise ValueError("REFRESH_INVALID")
             user_id = int(row[0])
@@ -108,24 +129,34 @@ class AuthService:
                 raise ValueError("REFRESH_REVOKED")
             if row[1] < _now().isoformat():
                 raise ValueError("REFRESH_EXPIRED")
-            # rotate: revoke old, issue new
-            conn.execute("UPDATE refresh_tokens SET revoked_at=datetime('now') WHERE token_hash=?", (token_hash,))
-            access = self._make_access_token(user_id)
-            new_r = self._new_refresh_token(user_id, user_agent=user_agent, ip=ip)
-            conn.execute("INSERT INTO audit_log (user_id, action, meta) VALUES (?, 'auth.refresh', json_object('ua', ?, 'ip', ?))", (user_id, user_agent, ip))
+            await conn.execute(
+                "UPDATE refresh_tokens SET revoked_at=datetime('now') WHERE token_hash=?",
+                (token_hash,),
+            )
+            access = await self._make_access_token(user_id)
+            new_r = await self._new_refresh_token(
+                user_id, user_agent=user_agent, ip=ip
+            )
+            await conn.execute(
+                "INSERT INTO audit_log (user_id, action, meta) VALUES (?, 'auth.refresh', json_object('ua', ?, 'ip', ?))",
+                (user_id, user_agent, ip),
+            )
             return {"access_token": access, **new_r, "token_type": "Bearer"}
 
-    def logout(self, refresh_token: str) -> Dict[str, Any]:
+    async def logout(self, refresh_token: str) -> Dict[str, Any]:
         token_hash = self._hash_refresh(refresh_token)
-        with get_conn(self.db_path) as conn:
-            conn.execute("UPDATE refresh_tokens SET revoked_at=datetime('now') WHERE token_hash=?", (token_hash,))
+        async with aget_conn(self.db_path) as conn:
+            await conn.execute(
+                "UPDATE refresh_tokens SET revoked_at=datetime('now') WHERE token_hash=?",
+                (token_hash,),
+            )
         return {"ok": True}
 
     # --- access token management ---
-    def revoke_access_token(self, jti: str) -> bool:
+    async def revoke_access_token(self, jti: str) -> bool:
         """Revoke an access token by its JWT ID."""
-        with get_conn(self.db_path) as conn:
-            cur = conn.execute(
+        async with aget_conn(self.db_path) as conn:
+            cur = await conn.execute(
                 "UPDATE access_tokens SET revoked_at=datetime('now') WHERE jti=? AND revoked_at IS NULL",
                 (jti,),
             )

--- a/backend/tests/analytics/test_analytics.py
+++ b/backend/tests/analytics/test_analytics.py
@@ -2,12 +2,12 @@ import asyncio
 
 import pytest
 import utils.db as db_utils
-from utils.db import get_conn
 from auth.service import AuthService
+from fastapi import HTTPException, Request
+from utils.db import get_conn
 
 from backend.auth.dependencies import get_current_user_id, require_role
 from backend.services.analytics_service import AnalyticsService
-from fastapi import HTTPException, Request
 
 DDL = """
 CREATE TABLE users(id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT);
@@ -51,7 +51,7 @@ def setup_db(path: str) -> AuthService:
 
 
 def token(user_id: int, svc: AuthService) -> str:
-    return svc._make_access_token(user_id)
+    return asyncio.run(svc._make_access_token(user_id))
 
 
 def test_metrics_and_permissions(tmp_path):

--- a/backend/utils/db.py
+++ b/backend/utils/db.py
@@ -1,106 +1,150 @@
 # File: backend/utils/db.py
-import sqlite3
-from pathlib import Path
-from typing import Optional, Tuple, Any, List, Dict
-from functools import lru_cache
-from queue import Queue
 
-try:
+"""Asynchronous database helpers using :mod:`aiosqlite`.
+
+This module provides two interfaces:
+
+``aget_conn``
+    An asynchronous context manager yielding an ``aiosqlite`` connection.
+
+``get_conn``
+    A synchronous wrapper retained for legacy code.  It uses ``asyncio.run``
+    under the hood so callers can continue to use a ``with`` block and regular
+    ``execute`` calls without ``await``.  New code should prefer
+    ``aget_conn``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import aiosqlite
+
+try:  # pragma: no cover - configuration is optional in tests
     from core.config import settings
+
     DEFAULT_DB = settings.database.path
-except Exception:
+except Exception:  # pragma: no cover - fallback for tests
     DEFAULT_DB = str(Path(__file__).resolve().parents[1] / "rockmundo.db")
 
-_WAL_INITIALISED = False
-_POOLS: Dict[str, Queue[sqlite3.Connection]] = {}
-_SQLITE_CONNECT = sqlite3.connect  # keep reference to the real connect
+
+class _SyncCursor:
+    """Synchronous wrapper around an ``aiosqlite`` cursor."""
+
+    def __init__(self, cursor: aiosqlite.Cursor):
+        self._cursor = cursor
+
+    def execute(self, sql: str, params: Tuple[Any, ...] | List[Any] = ()):
+        return asyncio.run(self._cursor.execute(sql, params))
+
+    def executemany(self, sql: str, seq: List[Tuple[Any, ...]]):
+        return asyncio.run(self._cursor.executemany(sql, seq))
+
+    def fetchone(self):
+        return asyncio.run(self._cursor.fetchone())
+
+    def fetchall(self):
+        return asyncio.run(self._cursor.fetchall())
+
+    @property
+    def lastrowid(self) -> int:
+        return self._cursor.lastrowid
 
 
-def init_pool(db_path: Optional[str] = None, size: int = 5) -> None:
-    """Initialise a connection pool for the given database."""
+class _SyncConnection:
+    """Synchronous facade for ``aiosqlite`` connections."""
 
-    global _POOLS, _WAL_INITIALISED
-    path = str(db_path or DEFAULT_DB)
-    if path in _POOLS:
-        return
+    def __init__(self, path: str):
+        self._conn = asyncio.run(aiosqlite.connect(path))
+        self._conn.row_factory = aiosqlite.Row
+        asyncio.run(self._conn.execute("PRAGMA foreign_keys = ON;"))
+        asyncio.run(self._conn.execute("PRAGMA busy_timeout = 5000;"))
 
-    pool = Queue(maxsize=size)
-    for _ in range(size):
-        conn = _SQLITE_CONNECT(path, timeout=5.0, isolation_level=None, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        cur = conn.cursor()
-        cur.execute("PRAGMA foreign_keys = ON;")
-        cur.execute("PRAGMA busy_timeout = 5000;")
-        if not _WAL_INITIALISED:
-            try:
-                cur.execute("PRAGMA journal_mode = WAL;")
-            except Exception:
-                pass
-            _WAL_INITIALISED = True
-        pool.put(conn)
-    _POOLS[path] = pool
+    def cursor(self) -> _SyncCursor:
+        return _SyncCursor(self._conn.cursor())
 
+    def execute(self, sql: str, params: Tuple[Any, ...] = ()):  # pragma: no cover - passthrough
+        return asyncio.run(self._conn.execute(sql, params))
 
-class PooledConnection:
-    """Lightweight wrapper returning connections to the pool on close."""
+    def executemany(self, sql: str, seq: List[Tuple[Any, ...]]):  # pragma: no cover - passthrough
+        return asyncio.run(self._conn.executemany(sql, seq))
 
-    def __init__(self, conn: sqlite3.Connection, pool: Queue[sqlite3.Connection]):
-        object.__setattr__(self, "_conn", conn)
-        object.__setattr__(self, "_pool", pool)
+    def executescript(self, script: str):  # pragma: no cover - passthrough
+        return asyncio.run(self._conn.executescript(script))
 
-    def __getattr__(self, name: str) -> Any:  # pragma: no cover - passthrough
-        return getattr(self._conn, name)
+    def commit(self) -> None:  # pragma: no cover - passthrough
+        asyncio.run(self._conn.commit())
 
-    def __setattr__(self, name: str, value: Any) -> None:  # pragma: no cover - passthrough
-        setattr(self._conn, name, value)
+    def rollback(self) -> None:  # pragma: no cover - passthrough
+        asyncio.run(self._conn.rollback())
 
-    def close(self) -> None:
-        # Instead of closing, return connection to the pool
-        self._pool.put(self._conn)
+    def close(self) -> None:  # pragma: no cover - passthrough
+        asyncio.run(self._conn.close())
 
-    # Context manager support
-    def __enter__(self) -> "PooledConnection":
+    # Context manager protocol -------------------------------------------------
+    def __enter__(self) -> "_SyncConnection":  # pragma: no cover - passthrough
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - passthrough
         if exc_type is None:
-            self._conn.commit()
+            asyncio.run(self._conn.commit())
         else:
-            self._conn.rollback()
-        self.close()
+            asyncio.run(self._conn.rollback())
+        asyncio.run(self._conn.close())
 
 
-def get_conn(db_path: Optional[str] = None, *args: Any, **kwargs: Any) -> sqlite3.Connection:
-    """Acquire a connection from the pool.
+def get_conn(db_path: Optional[str] = None) -> _SyncConnection:
+    """Return a synchronous ``aiosqlite`` connection.
 
-    Extra positional/keyword arguments are ignored but accepted so that this
-    function can transparently replace ``sqlite3.connect``.
+    This mirrors the old ``sqlite3.connect`` style API so existing code can
+    operate without ``await`` while the underlying implementation uses the
+    asynchronous driver.
     """
 
-    if db_path is None and args:
-        db_path = args[0]
+    path = str(db_path or DEFAULT_DB)
+    return _SyncConnection(path)
+
+
+@asynccontextmanager
+async def aget_conn(db_path: Optional[str] = None):
+    """Asynchronously yield a database connection."""
 
     path = str(db_path or DEFAULT_DB)
-    if path not in _POOLS:
-        init_pool(path)
-    pool = _POOLS[path]
-    conn = pool.get()
-    return PooledConnection(conn, pool)
+    conn = await aiosqlite.connect(path)
+    conn.row_factory = aiosqlite.Row
+    await conn.execute("PRAGMA foreign_keys = ON;")
+    await conn.execute("PRAGMA busy_timeout = 5000;")
+    try:
+        yield conn
+        await conn.commit()
+    except Exception:  # pragma: no cover - rollback on error
+        await conn.rollback()
+        raise
+    finally:
+        await conn.close()
 
 
-# Monkey patch sqlite3.connect so legacy code also uses the pool
-sqlite3.connect = get_conn  # type: ignore[assignment]
+async def _cached_query_async(
+    db_path: str, query: str, params: Tuple[Any, ...] = ()
+) -> List[Dict[str, Any]]:
+    async with aget_conn(db_path) as conn:
+        cur = await conn.execute(query, params)
+        rows = await cur.fetchall()
+        return [dict(r) for r in rows]
 
 
 @lru_cache(maxsize=128)
 def cached_query(
-    db_path: str,
-    query: str,
-    params: Tuple[Any, ...] = (),
+    db_path: str, query: str, params: Tuple[Any, ...] = ()
 ) -> List[Dict[str, Any]]:
-    """Execute a query and cache the results."""
+    """Execute a query and cache the results synchronously."""
 
-    with get_conn(db_path) as conn:
-        cur = conn.cursor()
-        cur.execute(query, params)
-        return [dict(r) for r in cur.fetchall()]
+    return asyncio.run(_cached_query_async(db_path, query, params))
+
+
+__all__ = ["get_conn", "aget_conn", "cached_query"]
+


### PR DESCRIPTION
## Summary
- add minimal aiosqlite-based DB utility with async and sync helpers
- convert AuthService and related routes/dependencies to async
- adjust analytics test for async token generation

## Testing
- `ruff check backend/auth/dependencies.py backend/auth/routes.py backend/auth/service.py backend/tests/analytics/test_analytics.py backend/utils/db.py aiosqlite.py`
- `pytest backend/tests/test_auth_flow.py -q` *(fails: ImportError: cannot import name 'AnyUrl' from 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b369c730a48325a4747b33e51d1125