### PR TITLE
Add token cleanup job and tests

### DIFF
--- a/backend/core/scheduler.py
+++ b/backend/core/scheduler.py
@@ -38,6 +38,7 @@ except Exception:
 from backend.jobs import (
     cleanup_idempotency,
     cleanup_rate_limits,
+    cleanup_tokens,
     backup_db,
     cleanup_event_effects,
 )  # type: ignore
@@ -57,6 +58,7 @@ def register_jobs() -> None:
     _registry.clear()
     _registry["cleanup_idempotency"] = cleanup_idempotency.run
     _registry["cleanup_rate_limits"] = cleanup_rate_limits.run
+    _registry["cleanup_tokens"] = cleanup_tokens.run
     _registry["backup_db"] = backup_db.run
     _registry["cleanup_event_effects"] = cleanup_event_effects.run
 

--- a/backend/jobs/cleanup_tokens.py
+++ b/backend/jobs/cleanup_tokens.py
@@ -1,0 +1,74 @@
+# cleanup_tokens.py
+"""
+Remove expired or revoked token entries from auth tables.
+
+Targets tables:
+- access_tokens(jti TEXT PRIMARY KEY, user_id INTEGER NOT NULL,
+  expires_at TEXT NOT NULL, revoked_at TEXT)
+- refresh_tokens(id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER,
+  token_hash TEXT, issued_at TEXT, expires_at TEXT, revoked_at TEXT,
+  user_agent TEXT, ip TEXT)
+
+This job removes rows whose `expires_at` has passed or whose
+`revoked_at` timestamp is in the past.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime, timezone
+from typing import Tuple
+
+# Prefer project's shared DB util if present
+try:  # pragma: no cover - optional import
+    from backend.core.db import get_conn  # type: ignore
+except Exception:  # pragma: no cover - fallback for tests/standalone
+    def get_conn() -> sqlite3.Connection:
+        db_path = os.getenv("DB_PATH", "app.db")
+        conn = sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA foreign_keys=ON;")
+        return conn
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _cleanup_table(cur: sqlite3.Cursor, table: str, now_iso: str) -> int:
+    cur.execute(
+        f"""
+        DELETE FROM {table}
+        WHERE datetime(expires_at) <= datetime(?)
+           OR (COALESCE(revoked_at, '') <> '' AND datetime(revoked_at) <= datetime(?))
+        """,
+        (now_iso, now_iso),
+    )
+    return cur.rowcount if cur.rowcount is not None else 0
+
+
+def run() -> Tuple[int, str]:
+    """Execute cleanup and return (rows_deleted, detail)."""
+    now_iso = _now_utc_iso()
+    with get_conn() as conn:
+        cur = conn.cursor()
+        deleted_access = 0
+        deleted_refresh = 0
+
+        try:
+            deleted_access = _cleanup_table(cur, "access_tokens", now_iso)
+        except sqlite3.OperationalError:
+            deleted_access = 0
+
+        try:
+            deleted_refresh = _cleanup_table(cur, "refresh_tokens", now_iso)
+        except sqlite3.OperationalError:
+            deleted_refresh = 0
+
+        conn.commit()
+
+    total = deleted_access + deleted_refresh
+    detail = f"access={deleted_access}, refresh={deleted_refresh}"
+    return total, detail

--- a/backend/tests/auth/test_token_cleanup.py
+++ b/backend/tests/auth/test_token_cleanup.py
@@ -1,0 +1,94 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.jobs import cleanup_tokens
+
+
+def _iso(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _setup_db(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE access_tokens (
+            jti TEXT PRIMARY KEY,
+            user_id INTEGER NOT NULL,
+            expires_at TEXT NOT NULL,
+            revoked_at TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE refresh_tokens (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            token_hash TEXT NOT NULL,
+            issued_at TEXT,
+            expires_at TEXT NOT NULL,
+            revoked_at TEXT,
+            user_agent TEXT,
+            ip TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_cleanup_removes_expired_and_revoked_tokens(tmp_path, monkeypatch):
+    db_path = tmp_path / "tokens.db"
+    _setup_db(str(db_path))
+
+    now = datetime.now(timezone.utc)
+    past = now - timedelta(days=1)
+    future = now + timedelta(days=1)
+
+    conn = sqlite3.connect(db_path)
+    # access tokens
+    conn.execute(
+        "INSERT INTO access_tokens (jti, user_id, expires_at, revoked_at) VALUES (?,?,?,?)",
+        ("expired", 1, _iso(past), None),
+    )
+    conn.execute(
+        "INSERT INTO access_tokens (jti, user_id, expires_at, revoked_at) VALUES (?,?,?,?)",
+        ("revoked", 1, _iso(future), _iso(past)),
+    )
+    conn.execute(
+        "INSERT INTO access_tokens (jti, user_id, expires_at, revoked_at) VALUES (?,?,?,?)",
+        ("active", 1, _iso(future), None),
+    )
+    # refresh tokens
+    conn.execute(
+        "INSERT INTO refresh_tokens (user_id, token_hash, issued_at, expires_at, revoked_at) VALUES (?,?,?,?,?)",
+        (1, "h1", _iso(past), _iso(past), None),
+    )
+    conn.execute(
+        "INSERT INTO refresh_tokens (user_id, token_hash, issued_at, expires_at, revoked_at) VALUES (?,?,?,?,?)",
+        (1, "h2", _iso(past), _iso(future), _iso(past)),
+    )
+    conn.execute(
+        "INSERT INTO refresh_tokens (user_id, token_hash, issued_at, expires_at, revoked_at) VALUES (?,?,?,?,?)",
+        (1, "h3", _iso(now), _iso(future), None),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    deleted, detail = cleanup_tokens.run()
+
+    assert deleted == 4
+    assert "access=2" in detail and "refresh=2" in detail
+
+    conn = sqlite3.connect(db_path)
+    remaining_access = conn.execute("SELECT jti FROM access_tokens").fetchall()
+    remaining_refresh = conn.execute("SELECT id FROM refresh_tokens").fetchall()
+    conn.close()
+
+    assert remaining_access == [("active",)]
+    assert len(remaining_refresh) == 1

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -11,6 +11,22 @@ import os
 from pathlib import Path
 from typing import Any, get_args, get_origin
 
+# Minimal stand-ins for types expected by FastAPI
+AnyUrl = str
+BaseConfig = object
+
+def field_validator(*_args, **_kwargs):  # pragma: no cover - simple no-op
+    def decorator(func):
+        return func
+
+    return decorator
+
+ConfigDict = dict
+
+
+class ValidationError(Exception):
+    pass
+
 
 class FieldInfo:
     """Store metadata about a model field."""


### PR DESCRIPTION
## Summary
- add cleanup_tokens job to remove expired or revoked access/refresh tokens
- register cleanup_tokens in job scheduler
- test token cleanup and extend pydantic stub for FastAPI compatibility

## Testing
- `pytest backend/tests/auth/test_token_cleanup.py --rootdir backend/tests/auth -q`
- `pytest backend/tests/auth --rootdir backend/tests/auth -q` *(fails: ModuleNotFoundError: No module named 'pydantic.class_validators')*


------
https://chatgpt.com/codex/tasks/task_e_68b36c5e42a48325b281f1e44c156ce4