### PR TITLE
Add typed event routes and OpenAPI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,8 @@ jobs:
       - name: Run tests
         run: |
           pytest --cov=backend --cov-report=term-missing -q
+
+      - name: Validate OpenAPI schema
+        run: |
+          python backend/scripts/generate_openapi.py
+          python -m json.tool openapi.json > /dev/null

--- a/backend/routes/event_routes.py
+++ b/backend/routes/event_routes.py
@@ -1,18 +1,24 @@
-# routes/event_routes.py
+"""Route definitions for random daily events."""
+
+from fastapi import APIRouter
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
 from services.event_service import apply_event_effect, roll_for_daily_event
 
-from fastapi import APIRouter
+from backend.schemas.events_schemas import EventRollRequest, EventRollResponse
+
 
 router = APIRouter()
 
-@router.post("/events/daily-roll")
-def trigger_daily_event(user_id: int):
+
+@router.post("/events/daily-roll", response_model=EventRollResponse)
+def trigger_daily_event(payload: EventRollRequest) -> EventRollResponse:
+    """Trigger a daily random event for a user and apply its effects."""
+
     lifestyle = {"drinking": "high"}  # normally from DB
     skills = [SKILL_NAME_TO_ID["vocals"], SKILL_NAME_TO_ID["guitar"]]
-    event = roll_for_daily_event(user_id, lifestyle, skills)
+    event = roll_for_daily_event(payload.user_id, lifestyle, skills)
     if event:
-        apply_event_effect(user_id, event)
-        return {"message": "Event triggered", "event": event}
-    return {"message": "No event today"}
+        apply_event_effect(payload.user_id, event)
+        return EventRollResponse(message="Event triggered", event=event)
+    return EventRollResponse(message="No event today")

--- a/backend/routes/events_routes.py
+++ b/backend/routes/events_routes.py
@@ -1,21 +1,55 @@
-from auth.dependencies import get_current_user_id, require_role
-from fastapi import APIRouter
-from services.events_service import *
+"""Routes for managing seasonal events."""
+
+from fastapi import APIRouter, Depends
+
+from auth.dependencies import require_role
+from services.events_service import (
+    create_seasonal_event,
+    end_seasonal_event,
+    get_active_event,
+    get_past_events,
+)
+
+from backend.schemas.events_schemas import (
+    ActiveEventResponse,
+    CreateEventSchema,
+    EndEventSchema,
+    EventHistoryResponse,
+    EventResponse,
+)
+
 
 router = APIRouter()
 
-@router.post("/events/create", dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
-def create_event(payload: dict):
-    return create_seasonal_event(payload)
 
-@router.post("/events/end")
-def end_event(payload: dict):
-    return end_seasonal_event(payload["event_id"])
+@router.post(
+    "/events/create",
+    response_model=EventResponse,
+    dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))],
+)
+def create_event(payload: CreateEventSchema) -> EventResponse:
+    """Create and start a new seasonal event."""
 
-@router.get("/events/current")
-def get_current_event():
+    return create_seasonal_event(payload.model_dump())
+
+
+@router.post("/events/end", response_model=EventResponse)
+def end_event(payload: EndEventSchema) -> EventResponse:
+    """End an existing seasonal event."""
+
+    return end_seasonal_event(payload.event_id)
+
+
+@router.get("/events/current", response_model=ActiveEventResponse)
+def get_current_event() -> ActiveEventResponse:
+    """Retrieve the currently active seasonal event."""
+
     return get_active_event()
 
-@router.get("/events/history")
-def get_event_history():
+
+@router.get("/events/history", response_model=EventHistoryResponse)
+def get_event_history() -> EventHistoryResponse:
+    """Return a list of past seasonal events."""
+
     return get_past_events()
+

--- a/backend/schemas/events_schemas.py
+++ b/backend/schemas/events_schemas.py
@@ -1,13 +1,75 @@
-from pydantic import BaseModel
-from typing import Optional
+"""Pydantic models for event-related operations.
 
-class CreateEventSchema(BaseModel):
+This module defines request and response bodies used by the event
+routers.  They provide type safety and power the generated OpenAPI
+documentation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class Event(BaseModel):
+    """Representation of an in-game seasonal event."""
+
     event_id: str
     name: str
     theme: str
     description: str
     start_date: str
-    modifiers: dict
+    end_date: Optional[str] = None
+    modifiers: Dict[str, Any]
+    active: bool = True
+
+
+class CreateEventSchema(BaseModel):
+    """Payload for creating a new seasonal event."""
+
+    event_id: str
+    name: str
+    theme: str
+    description: str
+    start_date: str
+    modifiers: Dict[str, Any]
+
 
 class EndEventSchema(BaseModel):
+    """Payload for ending an active seasonal event."""
+
     event_id: str
+
+
+class EventResponse(BaseModel):
+    """Standard response after starting or ending an event."""
+
+    status: str
+    event: Event
+
+
+class ActiveEventResponse(BaseModel):
+    """Response model for retrieving the current active event."""
+
+    active_event: Optional[Event]
+
+
+class EventHistoryResponse(BaseModel):
+    """Response model containing the history of past events."""
+
+    history: List[Event]
+
+
+class EventRollRequest(BaseModel):
+    """Request body for rolling a daily random event."""
+
+    user_id: int
+
+
+class EventRollResponse(BaseModel):
+    """Response after attempting to trigger a daily event."""
+
+    message: str
+    event: Optional[Dict[str, Any]] = None
+

--- a/backend/scripts/generate_openapi.py
+++ b/backend/scripts/generate_openapi.py
@@ -1,0 +1,33 @@
+"""Generate the OpenAPI schema for the FastAPI application.
+
+The script is used in CI to ensure that the application and its route
+definitions produce a valid OpenAPI specification.  It writes the schema
+to ``openapi.json`` in the repository root.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+# Ensure project root and ``backend`` package are on the import path so that
+# modules like ``auth`` can be imported when this script is executed directly.
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend"))
+
+from backend.api import app  # noqa: E402  (import after path manipulation)
+
+
+def main() -> None:
+    schema = app.openapi()
+    out_path = Path("openapi.json")
+    out_path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+    print(f"Wrote OpenAPI schema → {out_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - utility script
+    main()
+


### PR DESCRIPTION
## Summary
- add Pydantic schemas for event endpoints
- document event routes and return typed responses
- validate generated OpenAPI schema in CI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic.class_validators')*
- `python backend/scripts/generate_openapi.py` *(fails: ModuleNotFoundError: No module named 'pydantic.class_validators')*

------
https://chatgpt.com/codex/tasks/task_e_68b36e0c57cc8325976cb1335e95ab9d