### PR TITLE
feat(metrics): add gauge and histogram

### DIFF
--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,4 +1,4 @@
-from backend.utils.metrics import Counter, generate_latest
+from backend.utils.metrics import Counter, Gauge, Histogram, generate_latest
 
 
 def test_generate_latest_contains_counter_value():
@@ -6,3 +6,22 @@ def test_generate_latest_contains_counter_value():
     c.labels("value").inc()
     output = generate_latest().decode()
     assert "test_counter{label=\"value\"} 1" in output
+
+
+def test_gauge_operations():
+    g = Gauge("test_gauge", "a test gauge", ("label",))
+    gauge_label = g.labels("value")
+    gauge_label.inc(2)
+    gauge_label.dec(1)
+    gauge_label.set(5)
+    output = generate_latest().decode()
+    assert "test_gauge{label=\"value\"} 5" in output
+
+
+def test_histogram_observe():
+    h = Histogram("test_histogram", "a test histogram", [0.1, 1.0, 5.0], ("label",))
+    h.labels("value").observe(0.5)
+    output = generate_latest().decode()
+    assert "test_histogram_bucket{label=\"value\",le=\"1.0\"} 1" in output
+    assert "test_histogram_count{label=\"value\"} 1" in output
+    assert "test_histogram_sum{label=\"value\"} 0.5" in output

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import threading
-from typing import Dict, Iterable, Tuple
+from typing import Dict, Iterable, List, Tuple, Union
 
-_REGISTRY: Dict[str, "Counter"] = {}
+_REGISTRY: Dict[str, Union["Counter", "Gauge", "Histogram"]] = {}
 
 
 class Counter:
@@ -41,17 +41,133 @@ class Counter:
             yield labels, value
 
 
+class Gauge:
+    """A gauge metric supporting increment, decrement and set operations."""
+
+    def __init__(self, name: str, description: str, labelnames: Iterable[str] = ()):  # pragma: no cover - exercised indirectly
+        self.name = name
+        self.description = description
+        self.labelnames = tuple(labelnames)
+        self._values: Dict[Tuple[str, ...], float] = {}
+        self._lock = threading.Lock()
+        _REGISTRY[self.name] = self
+
+    class _LabelGauge:
+        def __init__(self, parent: "Gauge", key: Tuple[str, ...]):
+            self._parent = parent
+            self._key = key
+
+        def inc(self, amount: float = 1) -> None:
+            with self._parent._lock:
+                self._parent._values[self._key] = self._parent._values.get(self._key, 0.0) + amount
+
+        def dec(self, amount: float = 1) -> None:
+            self.inc(-amount)
+
+        def set(self, value: float) -> None:
+            with self._parent._lock:
+                self._parent._values[self._key] = value
+
+    def labels(self, *labelvalues: str) -> "Gauge._LabelGauge":
+        if len(labelvalues) != len(self.labelnames):
+            raise ValueError("Incorrect label count")
+        key = tuple(labelvalues)
+        with self._lock:
+            self._values.setdefault(key, 0.0)
+        return Gauge._LabelGauge(self, key)
+
+    def collect(self):  # pragma: no cover - trivial
+        for labels, value in self._values.items():
+            yield labels, value
+
+
+class Histogram:
+    """A simple histogram implementation compatible with Prometheus."""
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        buckets: Iterable[float],
+        labelnames: Iterable[str] = (),
+    ):  # pragma: no cover - exercised indirectly
+        self.name = name
+        self.description = description
+        self.labelnames = tuple(labelnames)
+        self.buckets: List[float] = sorted(buckets)
+        if not self.buckets or self.buckets[-1] != float("inf"):
+            self.buckets.append(float("inf"))
+        self._values: Dict[Tuple[str, ...], Dict[str, Union[List[int], float, int]]] = {}
+        self._lock = threading.Lock()
+        _REGISTRY[self.name] = self
+
+    class _LabelHistogram:
+        def __init__(self, parent: "Histogram", key: Tuple[str, ...]):
+            self._parent = parent
+            self._key = key
+
+        def observe(self, amount: float) -> None:
+            with self._parent._lock:
+                data = self._parent._values.setdefault(
+                    self._key,
+                    {"buckets": [0] * len(self._parent.buckets), "sum": 0.0, "count": 0},
+                )
+                for i, b in enumerate(self._parent.buckets):
+                    if amount <= b:
+                        data["buckets"][i] += 1
+                data["sum"] += amount
+                data["count"] += 1
+
+    def labels(self, *labelvalues: str) -> "Histogram._LabelHistogram":
+        if len(labelvalues) != len(self.labelnames):
+            raise ValueError("Incorrect label count")
+        key = tuple(labelvalues)
+        with self._lock:
+            self._values.setdefault(
+                key, {"buckets": [0] * len(self.buckets), "sum": 0.0, "count": 0}
+            )
+        return Histogram._LabelHistogram(self, key)
+
+    def collect(self):  # pragma: no cover - trivial
+        for labels, value in self._values.items():
+            yield labels, value
+
+
 def generate_latest() -> bytes:
     lines = []
     for c in _REGISTRY.values():
         lines.append(f"# HELP {c.name} {c.description}")
-        lines.append(f"# TYPE {c.name} counter")
-        for labels, value in c.collect():
-            if c.labelnames:
-                label_str = ",".join(f'{n}="{v}"' for n, v in zip(c.labelnames, labels))
-                lines.append(f"{c.name}{{{label_str}}} {value}")
-            else:
-                lines.append(f"{c.name} {value}")
+        if isinstance(c, Counter):
+            lines.append(f"# TYPE {c.name} counter")
+            for labels, value in c.collect():
+                if c.labelnames:
+                    label_str = ",".join(f'{n}="{v}"' for n, v in zip(c.labelnames, labels))
+                    lines.append(f"{c.name}{{{label_str}}} {value}")
+                else:
+                    lines.append(f"{c.name} {value}")
+        elif isinstance(c, Gauge):
+            lines.append(f"# TYPE {c.name} gauge")
+            for labels, value in c.collect():
+                if c.labelnames:
+                    label_str = ",".join(f'{n}="{v}"' for n, v in zip(c.labelnames, labels))
+                    lines.append(f"{c.name}{{{label_str}}} {value}")
+                else:
+                    lines.append(f"{c.name} {value}")
+        elif isinstance(c, Histogram):
+            lines.append(f"# TYPE {c.name} histogram")
+            for labels, data in c.collect():
+                base_labels = list(zip(c.labelnames, labels))
+                for b, count in zip(c.buckets, data["buckets"]):
+                    lbls = base_labels + [("le", "+Inf" if b == float("inf") else str(b))]
+                    label_str = ",".join(f'{n}="{v}"' for n, v in lbls)
+                    lines.append(f"{c.name}_bucket{{{label_str}}} {count}")
+                if base_labels:
+                    label_str = ",".join(f'{n}="{v}"' for n, v in base_labels)
+                    lines.append(f"{c.name}_sum{{{label_str}}} {data['sum']}")
+                    lines.append(f"{c.name}_count{{{label_str}}} {data['count']}")
+                else:
+                    lines.append(f"{c.name}_sum {data['sum']}")
+                    lines.append(f"{c.name}_count {data['count']}")
     return "\n".join(lines).encode("utf-8")
 
 


### PR DESCRIPTION
## Summary
- extend metrics registry to hold counters, gauges and histograms
- add Gauge with inc/dec/set per-label operations
- add Histogram with configurable buckets and observation tracking
- update metrics exposition and tests

## Testing
- `ruff check backend/utils/metrics.py backend/tests/test_metrics.py`
- `pytest backend/tests/test_metrics.py backend/tests/test_metrics_smoke.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic.class_validators')*
- `pip install 'pydantic<2' -q` *(fails: Could not find a version that satisfies the requirement pydantic<2)*

------
https://chatgpt.com/codex/tasks/task_e_68b36fe6d5348325a77a373f87ba6ed9