### PR TITLE
Use histogram for request latency and add tests

### DIFF
--- a/backend/tests/test_metrics_smoke.py
+++ b/backend/tests/test_metrics_smoke.py
@@ -22,3 +22,15 @@ def test_metrics_endpoint_exposes_counters(tmp_path):
     body = resp.text
     assert "economy_transactions_total" in body
     assert "realtime_messages_published_total" in body
+
+
+def test_request_latency_histogram_records_requests():
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+
+    metrics = client.get("/metrics")
+    assert metrics.status_code == 200
+    body = metrics.text
+    assert 'http_request_duration_ms_bucket{method="GET",path="/",status="200",le="+Inf"}' in body
+    assert 'http_request_duration_ms_count{method="GET",path="/",status="200"}' in body


### PR DESCRIPTION
## Summary
- switch request latency metric to a histogram with millisecond buckets
- observe request latency values instead of incrementing a counter
- add smoke test to assert request latency histogram exposure

## Testing
- `ruff check backend/middleware/observability.py backend/tests/test_metrics_smoke.py`
- `pytest backend/tests/test_metrics_smoke.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic.class_validators')*

------
https://chatgpt.com/codex/tasks/task_e_68b3717a528c83259cd57e4d4c291b87