### PR TITLE
Add service latency histograms and tests

### DIFF
--- a/backend/tests/video/test_video_service.py
+++ b/backend/tests/video/test_video_service.py
@@ -1,7 +1,9 @@
 import tempfile
 
-from services.video_service import VideoService
 from services.economy_service import EconomyService
+from services.video_service import SERVICE_LATENCY_MS, VideoService
+
+from backend.utils.metrics import generate_latest
 
 
 def setup_service():
@@ -29,3 +31,15 @@ def test_view_tracking_and_revenue_distribution():
         svc.record_view(video.id)
     assert svc.get_video(video.id).view_count == 3
     assert economy.get_balance(1) == 3
+
+
+def test_record_view_latency_metric():
+    svc, _ = setup_service()
+    video = svc.upload_video(owner_id=1, title="Demo", filename="demo.mp4")
+    svc.mark_transcoded(video.id)
+    before = SERVICE_LATENCY_MS._values.get(("video_service", "record_view"), {"count": 0})["count"]
+    svc.record_view(video.id)
+    after = SERVICE_LATENCY_MS._values[("video_service", "record_view")]["count"]
+    assert after == before + 1
+    output = generate_latest().decode()
+    assert 'service_latency_ms_count{service="video_service",operation="record_view"}' in output


### PR DESCRIPTION
## Summary
- instrument analytics and video services with shared `service_latency_ms` histogram and latency observations
- add tests verifying latency metrics emission for AnalyticsService and VideoService

## Testing
- `ruff check backend/services/analytics_service.py backend/services/video_service.py backend/tests/analytics/test_analytics.py backend/tests/video/test_video_service.py`
- `pytest backend/tests/analytics/test_analytics.py backend/tests/video/test_video_service.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic.class_validators')*

------
https://chatgpt.com/codex/tasks/task_e_68b3717b4fa08325b7e9cd1edc64f0aa