### PR TITLE
Add frontend tests with Vitest and mock API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,20 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install pytest pytest-cov
 
-      - name: Run tests
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm install
+
+      - name: Run frontend tests
+        working-directory: frontend
+        run: npm test
+
+      - name: Run backend tests
         run: |
           pytest --cov=backend --cov-report=term-missing -q
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,11 +10,17 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build"
+    "build": "react-scripts build",
+    "test": "vitest --run --config tests/vitest.config.ts"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "vitest": "^1.6.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "jsdom": "^23.0.1"
   }
 }

--- a/frontend/tests/MonitoringWidget.test.tsx
+++ b/frontend/tests/MonitoringWidget.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import MonitoringWidget from '../src/admin/monitoring/MonitoringWidget';
+
+test('renders metrics from API', async () => {
+  render(<MonitoringWidget />);
+  expect(await screen.findByText(/CPU: 10%/)).toBeInTheDocument();
+  expect(await screen.findByText(/Memory: 20%/)).toBeInTheDocument();
+  expect(await screen.findByText(/Active Sessions: 5/)).toBeInTheDocument();
+});

--- a/frontend/tests/mockApi.ts
+++ b/frontend/tests/mockApi.ts
@@ -1,0 +1,15 @@
+export function createFetchMock() {
+  return async (input: RequestInfo, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.endsWith('/admin/monitoring/metrics')) {
+      return new Response(
+        JSON.stringify({ cpu: 10, memory: 20, active_sessions: 5 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+    return new Response('{}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  };
+}

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,0 +1,22 @@
+import { beforeAll, afterEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { createFetchMock } from './mockApi';
+
+beforeAll(() => {
+  vi.stubGlobal('fetch', createFetchMock());
+  class MockWebSocket {
+    url: string;
+    onmessage: ((this: WebSocket, ev: MessageEvent) => any) | null = null;
+    send() {}
+    close() {}
+    constructor(url: string) {
+      this.url = url;
+    }
+  }
+  vi.stubGlobal('WebSocket', MockWebSocket as any);
+});
+
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/tests/vitest.config.ts
+++ b/frontend/tests/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './setup.ts'
+  }
+});


### PR DESCRIPTION
## Summary
- configure Vitest for React components
- add MonitoringWidget sample test with mock API utilities
- run frontend tests in CI alongside backend suite

## Testing
- `npm install --registry=https://registry.npmjs.org` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement redis)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic.class_validators')*

------
https://chatgpt.com/codex/tasks/task_e_68b373b3d1b88325a7ec9c97bcc9b1f7