### PR TITLE
feat: expand skill progression system

### DIFF
--- a/backend/models/skill.py
+++ b/backend/models/skill.py
@@ -4,12 +4,15 @@ from typing import Optional
 
 @dataclass
 class Skill:
-    """Represents a learnable skill."""
+    """Represents a learnable skill with progression."""
 
     id: int
     name: str
     category: str
     parent_id: Optional[int] = None
+    xp: int = 0
+    level: int = 1
+    modifier: float = 1.0
 
 
 __all__ = ["Skill"]

--- a/backend/services/lifestyle_scheduler.py
+++ b/backend/services/lifestyle_scheduler.py
@@ -4,6 +4,7 @@ import sqlite3
 from datetime import datetime
 from pathlib import Path
 
+from .skill_service import skill_service
 from .xp_event_service import XPEventService
 
 DB_PATH = Path(__file__).resolve().parent.parent / "rockmundo.db"
@@ -60,6 +61,9 @@ def apply_lifestyle_decay_and_xp_effects():
                 INSERT INTO xp_modifiers (user_id, modifier, date)
                 VALUES (?, ?, ?)
             """, (user_id, modifier, datetime.utcnow().date()))
+
+            # Daily lifestyle decay affects skills slightly
+            skill_service.apply_daily_decay(user_id)
 
         conn.commit()
 

--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -1,13 +1,16 @@
-import sqlite3
 import json
+import sqlite3
 from datetime import datetime, timedelta
+
 from backend.database import DB_PATH
-from backend.services import fan_service, chart_service
+from backend.services import chart_service, fan_service
+from backend.services.skill_service import skill_service
 
 # Map event_type to handler functions
 EVENT_HANDLERS = {
     "fan_decay": fan_service.decay_fan_loyalty,
     "weekly_charts": chart_service.calculate_weekly_chart,
+    "skill_decay": skill_service.decay_all,
     # Add more event handlers here as needed
 }
 

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -1,0 +1,122 @@
+"""Service layer for managing skill progression.
+
+The service keeps an in-memory record of a user's skills while
+coordinating XP modifiers from lifestyle effects and global XP events.
+It is intentionally lightweight – perfect for unit testing and small
+demo environments.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+from pathlib import Path
+from typing import Dict, Tuple
+
+from backend.database import DB_PATH
+from backend.models.skill import Skill
+from backend.models.xp_config import get_config
+from backend.services.xp_event_service import XPEventService
+
+
+class SkillService:
+    """Track and mutate skill progression for users."""
+
+    def __init__(
+        self,
+        xp_events: XPEventService | None = None,
+        db_path: Path | None = None,
+    ) -> None:
+        self.xp_events = xp_events or XPEventService()
+        self.db_path = db_path or DB_PATH
+        # Keyed by (user_id, skill_id)
+        self._skills: Dict[Tuple[int, int], Skill] = {}
+        # Track XP earned per day to enforce caps
+        self._xp_today: Dict[Tuple[int, int, date], int] = {}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _lifestyle_modifier(self, user_id: int) -> float:
+        """Return the last lifestyle XP modifier for the user."""
+
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cur = conn.cursor()
+                cur.execute(
+                    "SELECT modifier FROM xp_modifiers WHERE user_id = ? ORDER BY date DESC LIMIT 1",
+                    (user_id,),
+                )
+                row = cur.fetchone()
+        except sqlite3.Error:
+            row = None
+        return row[0] if row else 1.0
+
+    def _get_skill(self, user_id: int, skill: Skill) -> Skill:
+        key = (user_id, skill.id)
+        if key not in self._skills:
+            self._skills[key] = Skill(
+                id=skill.id,
+                name=skill.name,
+                category=skill.category,
+                parent_id=skill.parent_id,
+            )
+        return self._skills[key]
+
+    def _check_level(self, skill: Skill) -> None:
+        level = skill.xp // 100 + 1
+        if level != skill.level:
+            skill.level = level
+
+    # ------------------------------------------------------------------
+    # Public API
+    def train(self, user_id: int, skill: Skill, base_xp: int) -> Skill:
+        """Apply training XP to a skill respecting modifiers and caps."""
+
+        inst = self._get_skill(user_id, skill)
+
+        modifier = self._lifestyle_modifier(user_id)
+        modifier *= self.xp_events.get_active_multiplier(skill.name)
+
+        gain = int(base_xp * modifier)
+
+        today = date.today()
+        cap = get_config().daily_cap
+        if cap:
+            used = self._xp_today.get((user_id, skill.id, today), 0)
+            allowed = max(0, cap - used)
+            if gain > allowed:
+                gain = allowed
+            self._xp_today[(user_id, skill.id, today)] = used + gain
+
+        inst.xp += gain
+        self._check_level(inst)
+        return inst
+
+    def apply_decay(self, user_id: int, skill_id: int, amount: int) -> Skill | None:
+        """Reduce XP for a skill and update its level."""
+
+        inst = self._skills.get((user_id, skill_id))
+        if not inst:
+            return None
+        inst.xp = max(0, inst.xp - amount)
+        self._check_level(inst)
+        return inst
+
+    def apply_daily_decay(self, user_id: int, amount: int = 1) -> None:
+        """Apply decay to all tracked skills for a user."""
+
+        for (uid, _sid), skill in list(self._skills.items()):
+            if uid == user_id:
+                self.apply_decay(uid, skill.id, amount)
+
+    def decay_all(self, amount: int = 1) -> None:
+        """Global decay across all users (scheduler hook)."""
+
+        for (uid, sid) in list(self._skills.keys()):
+            self.apply_decay(uid, sid, amount)
+
+
+skill_service = SkillService()
+
+__all__ = ["SkillService", "skill_service"]
+

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -1,0 +1,68 @@
+import sqlite3
+from pathlib import Path
+
+from backend.models.skill import Skill
+from backend.models.xp_config import XPConfig, get_config, set_config
+from backend.services.skill_service import SkillService
+
+
+class DummyXPEvents:
+    def __init__(self, mult: float):
+        self.mult = mult
+
+    def get_active_multiplier(self, skill: str | None = None) -> float:  # pragma: no cover - simple proxy
+        return self.mult
+
+
+def _setup_db(tmp_path: Path, modifier: float) -> Path:
+    db = tmp_path / "db.sqlite"
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE xp_modifiers (user_id INTEGER, modifier REAL, date TEXT)")
+    cur.execute(
+        "INSERT INTO xp_modifiers (user_id, modifier, date) VALUES (1, ?, '2024-01-01')",
+        (modifier,),
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_skill_gain_with_modifiers(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path, 1.5)
+    svc = SkillService(xp_events=DummyXPEvents(2.0), db_path=db)
+    skill = Skill(id=1, name="guitar", category="instrument")
+
+    updated = svc.train(1, skill, 10)
+    assert updated.xp == 30
+    assert updated.level == 1
+
+    updated = svc.train(1, skill, 40)
+    assert updated.xp == 150
+    assert updated.level == 2
+
+
+def test_skill_daily_cap() -> None:
+    old_cfg = get_config()
+    set_config(XPConfig(daily_cap=100))
+    svc = SkillService(xp_events=DummyXPEvents(1.0))
+    skill = Skill(id=2, name="drums", category="instrument")
+
+    svc.train(1, skill, 80)
+    updated = svc.train(1, skill, 50)
+
+    assert updated.xp == 100
+    assert updated.level == 2
+    set_config(old_cfg)
+
+
+def test_skill_decay() -> None:
+    svc = SkillService(xp_events=DummyXPEvents(1.0))
+    skill = Skill(id=3, name="vocals", category="performance")
+
+    svc.train(1, skill, 120)
+    updated = svc.apply_decay(1, 3, 30)
+
+    assert updated.xp == 90
+    assert updated.level == 1
+


### PR DESCRIPTION
## Summary
- extend Skill model with XP, level, and modifier fields
- add SkillService for training, XP modifiers, and decay handling
- hook skill progression into random events, lifestyle effects, and scheduler
- test skill gain, daily cap, and decay scenarios

## Testing
- `ruff check backend/models/skill.py backend/services/skill_service.py backend/services/random_event_service.py backend/services/lifestyle_scheduler.py backend/services/scheduler_service.py tests/test_skill_service.py`
- `PYTHONPATH=. pytest tests/test_skill_service.py tests/test_onboarding_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b37c30836c832599c822a94ed245f4