### PR TITLE
Refactor band service to SQLAlchemy sessions

### DIFF
--- a/backend/routes/band.py
+++ b/backend/routes/band.py
@@ -1,69 +1,59 @@
 from auth.dependencies import get_current_user_id, require_role
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
-from models.band import Band, BandMember, BandCollaboration
+
 from schemas.band import (
-    BandCreate, BandResponse,
+    BandCreate,
+    BandResponse,
     BandMemberInvite,
-    BandCollaborationCreate, BandCollaborationResponse
+    BandCollaborationCreate,
+    BandCollaborationResponse,
 )
-from database import get_db
+from services import band_service
 from utils.i18n import _
 
 router = APIRouter(prefix="/bands", tags=["Bands"])
 
-@router.post("/", response_model=BandResponse, dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
-def create_band(band: BandCreate, db: Session = Depends(get_db)):
-    existing = db.query(Band).filter_by(name=band.name).first()
-    if existing:
-        raise HTTPException(status_code=400, detail=_("Band name already exists"))
-    new_band = Band(**band.dict())
-    db.add(new_band)
-    db.commit()
-    db.refresh(new_band)
-
-    # Add founder as first member
-    db.add(BandMember(
-        character_id=band.founder_id,
-        band_id=new_band.id,
-        role="Founder",
-        is_manager=True
-    ))
-    db.commit()
-
-    return new_band
+@router.post(
+    "/",
+    response_model=BandResponse,
+    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+)
+def create_band(band: BandCreate):
+    created = band_service.create_band(band.founder_id, band.name, band.genre)
+    return BandResponse(
+        id=created.id,
+        name=created.name,
+        founder_id=created.founder_id,
+        genre=created.genre,
+        formed_at=created.formed_at,
+    )
 
 @router.get("/{band_id}", response_model=BandResponse)
-def get_band(band_id: int, db: Session = Depends(get_db)):
-    band = db.query(Band).get(band_id)
-    if not band:
+def get_band(band_id: int):
+    info = band_service.get_band_info(band_id)
+    if not info:
         raise HTTPException(status_code=404, detail=_("Band not found"))
-    return band
+    return BandResponse(
+        id=info["id"],
+        name=info["name"],
+        founder_id=info["founder_id"],
+        genre=info["genre"],
+        formed_at=info["formed_at"],
+    )
 
 @router.post("/invite")
-def invite_member(invite: BandMemberInvite, db: Session = Depends(get_db)):
-    exists = db.query(BandMember).filter_by(
-        character_id=invite.character_id, band_id=invite.band_id
-    ).first()
-    if exists:
-        raise HTTPException(status_code=400, detail=_("Already a band member"))
-    db.add(BandMember(**invite.dict()))
-    db.commit()
+def invite_member(invite: BandMemberInvite):
+    band_service.add_member(invite.band_id, invite.character_id, invite.role)
     return {"message": _("Member invited")}
 
 @router.post("/collaborate", response_model=BandCollaborationResponse)
-def create_collaboration(collab: BandCollaborationCreate, db: Session = Depends(get_db)):
+def create_collaboration(collab: BandCollaborationCreate):
     if collab.band_1_id == collab.band_2_id:
         raise HTTPException(status_code=400, detail=_("A band cannot collaborate with itself"))
-    new_collab = BandCollaboration(**collab.dict())
-    db.add(new_collab)
-    db.commit()
-    db.refresh(new_collab)
-    return new_collab
+    return band_service.create_collaboration(
+        collab.band_1_id, collab.band_2_id, collab.project_type, collab.title
+    )
 
 @router.get("/{band_id}/collaborations", response_model=list[BandCollaborationResponse])
-def list_collaborations(band_id: int, db: Session = Depends(get_db)):
-    return db.query(BandCollaboration).filter(
-        (BandCollaboration.band_1_id == band_id) |
-        (BandCollaboration.band_2_id == band_id)
-    ).all()
+def list_collaborations(band_id: int):
+    return band_service.list_collaborations(band_id)

--- a/backend/tests/bands/test_band_service.py
+++ b/backend/tests/bands/test_band_service.py
@@ -1,0 +1,44 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.band_service import Base, BandMember, BandService
+
+
+def get_service():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    return BandService(SessionLocal), SessionLocal
+
+
+def test_band_lifecycle_and_payouts():
+    svc, SessionLocal = get_service()
+
+    band = svc.create_band(user_id=1, band_name="AI Band", genre="rock")
+    assert band.id is not None
+
+    # founder automatically added; add two more members then remove one
+    svc.add_member(band.id, 2, "drummer")
+    svc.add_member(band.id, 3, "bassist")
+    svc.remove_member(band.id, 2)
+
+    info = svc.get_band_info(band.id)
+    assert info and {m["user_id"] for m in info["members"]} == {1, 3}
+
+    split = svc.split_earnings(band.id, 100)
+    assert split["per_member"] == 50
+    assert split["payouts"] == {1: 50, 3: 50}
+
+    # verify membership persisted
+    with SessionLocal() as session:
+        members = session.query(BandMember).filter_by(band_id=band.id).all()
+        assert len(members) == 2
+
+
+def test_collaboration_split():
+    svc, _ = get_service()
+    band = svc.create_band(user_id=1, band_name="Band1", genre="rock")
+    result = svc.split_earnings(band.id, 80, collaboration_band_id=2)
+    assert result["band_1_share"] == 40
+    assert result["band_2_share"] == 40
+


### PR DESCRIPTION
## Summary
- Replace raw sqlite3 usage with SQLAlchemy models and sessions in band service
- Expose transactional band operations and collaborations
- Update band routes to leverage the refactored service
- Add regression tests for band creation, membership management and payouts

## Testing
- `pytest backend/tests/bands/test_band_service.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b37e3f61c88325a4cf298f49727eaa