### PR TITLE
Expand NPC model with AI behavior generation

### DIFF
--- a/backend/models/npc.py
+++ b/backend/models/npc.py
@@ -12,6 +12,9 @@ class NPC:
     identity: str
     npc_type: str
     dialogue_hooks: Dict[str, str] = field(default_factory=dict)
+    interaction_hooks: Dict[str, str] = field(default_factory=dict)
+    goals: Dict[str, Any] = field(default_factory=dict)
+    routine: Dict[str, Any] = field(default_factory=dict)
     stats: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -20,5 +23,8 @@ class NPC:
             "identity": self.identity,
             "npc_type": self.npc_type,
             "dialogue_hooks": dict(self.dialogue_hooks),
+            "interaction_hooks": dict(self.interaction_hooks),
+            "goals": dict(self.goals),
+            "routine": dict(self.routine),
             "stats": dict(self.stats),
         }

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -7,9 +7,11 @@ from seeds.skill_seed import SKILL_NAME_TO_ID
 
 from backend.database import DB_PATH
 from backend.models.event_effect import EventEffect
+from backend.models.npc import NPC
 
 from .city_service import city_service
 from .weather_service import weather_service
+from .npc_ai_service import npc_ai_service
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +62,12 @@ def roll_for_daily_event(user_id, lifestyle_data, active_skills):
         }
 
     return None
+
+
+def roll_for_npc_daily_events(npc: NPC, lifestyle_data=None):
+    """Generate daily NPC events via the AI service."""
+    lifestyle_data = lifestyle_data or {}
+    return npc_ai_service.generate_daily_behavior(npc, lifestyle_data)
 
 
 def apply_event_effect(user_id, event_data):

--- a/backend/services/npc_ai_service.py
+++ b/backend/services/npc_ai_service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import random
+from typing import Dict, List, Optional
+
+from backend.models.npc import NPC
+
+
+class NPCAIService:
+    """Generate daily behaviors for NPCs based on their goals and routines."""
+
+    def generate_daily_behavior(
+        self, npc: NPC, lifestyle: Optional[Dict[str, str]] = None
+    ) -> List[Dict[str, str]]:
+        events: List[Dict[str, str]] = []
+        lifestyle = lifestyle or {}
+
+        if npc.goals.get("gig") and random.random() < 0.3:
+            events.append(
+                {
+                    "type": "gig",
+                    "npc_id": npc.id,
+                    "location": npc.routine.get("preferred_venue", "local club"),
+                }
+            )
+        if npc.goals.get("release") and random.random() < 0.1:
+            events.append(
+                {
+                    "type": "release",
+                    "npc_id": npc.id,
+                    "title": f"New single from {npc.identity}",
+                }
+            )
+        if npc.interaction_hooks and random.random() < 0.2:
+            hook, response = random.choice(list(npc.interaction_hooks.items()))
+            events.append(
+                {
+                    "type": "interaction",
+                    "npc_id": npc.id,
+                    "hook": hook,
+                    "response": response,
+                }
+            )
+        return events
+
+
+npc_ai_service = NPCAIService()

--- a/backend/services/npc_service.py
+++ b/backend/services/npc_service.py
@@ -36,12 +36,24 @@ class NPCService:
         self.db = db or _InMemoryNPCDB()
 
     # ---- CRUD ------------------------------------------------------------
-    def create_npc(self, identity: str, npc_type: str, dialogue_hooks=None, stats=None) -> Dict:
+    def create_npc(
+        self,
+        identity: str,
+        npc_type: str,
+        dialogue_hooks=None,
+        stats=None,
+        goals=None,
+        routine=None,
+        interaction_hooks=None,
+    ) -> Dict:
         npc = NPC(
             id=None,
             identity=identity,
             npc_type=npc_type,
             dialogue_hooks=dialogue_hooks or {},
+            interaction_hooks=interaction_hooks or {},
+            goals=goals or {},
+            routine=routine or {},
             stats=stats or {},
         )
         self.db.add(npc)
@@ -61,6 +73,12 @@ class NPCService:
             npc.npc_type = updates['npc_type']
         if 'dialogue_hooks' in updates and updates['dialogue_hooks'] is not None:
             npc.dialogue_hooks = updates['dialogue_hooks']
+        if 'interaction_hooks' in updates and updates['interaction_hooks'] is not None:
+            npc.interaction_hooks = updates['interaction_hooks']
+        if 'goals' in updates and updates['goals'] is not None:
+            npc.goals = updates['goals']
+        if 'routine' in updates and updates['routine'] is not None:
+            npc.routine = updates['routine']
         if 'stats' in updates and updates['stats'] is not None:
             npc.stats = updates['stats']
         return npc.to_dict()
@@ -69,13 +87,25 @@ class NPCService:
         return self.db.delete(npc_id)
 
     # ---- Simulation ------------------------------------------------------
-    def preview_npc(self, identity: str, npc_type: str, dialogue_hooks=None, stats=None) -> Dict:
+    def preview_npc(
+        self,
+        identity: str,
+        npc_type: str,
+        dialogue_hooks=None,
+        stats=None,
+        goals=None,
+        routine=None,
+        interaction_hooks=None,
+    ) -> Dict:
         """Simulate NPC stats without persisting to the DB."""
         npc = NPC(
             id=None,
             identity=identity,
             npc_type=npc_type,
             dialogue_hooks=dialogue_hooks or {},
+            interaction_hooks=interaction_hooks or {},
+            goals=goals or {},
+            routine=routine or {},
             stats=stats or {},
         )
         fame_gain = random.randint(0, npc.stats.get('activity', 5))

--- a/backend/tests/services/test_npc_ai_service.py
+++ b/backend/tests/services/test_npc_ai_service.py
@@ -1,0 +1,49 @@
+from backend.models.npc import NPC
+import services.npc_ai_service as npc_ai_module
+from services.npc_ai_service import npc_ai_service
+from services import event_service
+from services.npc_service import NPCService
+
+
+def test_generate_daily_behavior(monkeypatch):
+    npc = NPC(
+        id=1,
+        identity="TestNPC",
+        npc_type="artist",
+        goals={"gig": True, "release": True},
+        routine={"preferred_venue": "Town Hall"},
+        interaction_hooks={"hello": "Hi there!"},
+    )
+    monkeypatch.setattr(npc_ai_module.random, "random", lambda: 0.0)
+    events = npc_ai_service.generate_daily_behavior(npc)
+    types = {e["type"] for e in events}
+    assert {"gig", "release", "interaction"} <= types
+
+
+def test_npc_persistence_with_new_fields():
+    svc = NPCService()
+    npc = svc.create_npc(
+        "NPC",
+        "merchant",
+        goals={"gig": True},
+        routine={"schedule": "daily"},
+        interaction_hooks={"greet": "hello"},
+    )
+    stored = svc.get_npc(npc["id"])
+    assert stored["goals"]["gig"]
+    assert stored["routine"]["schedule"] == "daily"
+    assert stored["interaction_hooks"]["greet"] == "hello"
+
+
+def test_roll_for_npc_daily_events(monkeypatch):
+    npc = NPC(
+        id=2,
+        identity="NPC2",
+        npc_type="artist",
+        goals={"gig": True},
+        routine={},
+        interaction_hooks={}
+    )
+    monkeypatch.setattr(npc_ai_module.random, "random", lambda: 0.0)
+    events = event_service.roll_for_npc_daily_events(npc)
+    assert events and events[0]["type"] == "gig"


### PR DESCRIPTION
## Summary
- add goals, routines, and interaction hooks to NPC model
- create NPCAIService for daily gigs, releases, and interactions
- integrate NPC events into event service and persist new fields
- test NPC AI decision logic and persistence

## Testing
- `pytest backend/tests/services/test_event_service.py backend/tests/services/test_npc_ai_service.py`
- ⚠️ `pytest backend/tests/admin/test_npc_routes.py` *(missing `pydantic.fields` module)*

------
https://chatgpt.com/codex/tasks/task_e_68b37ff212788325975bb99040afd340