### PR TITLE
Add property marketplace models and renting

### DIFF
--- a/backend/models/property.py
+++ b/backend/models/property.py
@@ -1,18 +1,28 @@
+"""Models for property ownership and upgrades."""
+
 from dataclasses import dataclass
 from typing import Optional
+
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+
+Base = declarative_base()
 
 
 @dataclass
 class PropertyType:
     """Represents a kind of property that can be purchased."""
+
     name: str
     base_price: int
     base_rent: int
 
 
 @dataclass
-class PropertyUpgrade:
-    """Describes an upgrade applied to a property."""
+class PropertyUpgradeSpec:
+    """Schema describing an upgrade option for a property."""
+
     level: int
     cost: int
     rent_bonus: int
@@ -20,8 +30,9 @@ class PropertyUpgrade:
 
 
 @dataclass
-class Property:
-    """A property owned by a band or user."""
+class PropertyData:
+    """Convenience dataclass used by services."""
+
     id: Optional[int]
     owner_id: int
     name: str
@@ -31,5 +42,39 @@ class Property:
     base_rent: int
     level: int = 1
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict:  # pragma: no cover - trivial
         return self.__dict__
+
+
+class Property(Base):
+    """SQLAlchemy model for a property owned by a band or user."""
+
+    __tablename__ = "properties"
+
+    id = Column(Integer, primary_key=True, index=True)
+    owner_id = Column(Integer, index=True, nullable=False)
+    name = Column(String, nullable=False)
+    property_type = Column(String, nullable=False)
+    location = Column(String, nullable=False)
+    purchase_price = Column(Integer, nullable=False)
+    base_rent = Column(Integer, nullable=False)
+    level = Column(Integer, default=1)
+
+    upgrades = relationship(
+        "PropertyUpgrade", back_populates="property", cascade="all, delete-orphan"
+    )
+
+
+class PropertyUpgrade(Base):
+    """SQLAlchemy model representing a property upgrade."""
+
+    __tablename__ = "property_upgrades"
+
+    id = Column(Integer, primary_key=True, index=True)
+    property_id = Column(Integer, ForeignKey("properties.id"), nullable=False)
+    level = Column(Integer, nullable=False)
+    rent_bonus = Column(Integer, default=0)
+    rehearsal_bonus = Column(Integer, default=0)
+
+    property = relationship("Property", back_populates="upgrades")
+

--- a/backend/routes/property_routes.py
+++ b/backend/routes/property_routes.py
@@ -50,6 +50,17 @@ def upgrade_property(property_id: int, owner_id: int = Depends(get_current_user_
 
 
 @router.post(
+    "/rent/{property_id}",
+    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+)
+def rent_property(property_id: int, renter_id: int = Depends(get_current_user_id)):
+    try:
+        return svc.rent_property(property_id, renter_id)
+    except PropertyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post(
     "/sell/{property_id}",
     dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
 )

--- a/backend/tests/property/test_property_service.py
+++ b/backend/tests/property/test_property_service.py
@@ -56,3 +56,17 @@ def test_sell_property():
     assert sale == int(50000 * 0.8)
     assert svc.list_properties(1) == []
     assert econ.get_balance(1) == 100000 - 50000 + int(50000 * 0.8)
+
+
+def test_rent_flow_and_economics():
+    svc, econ, fame = setup_service()
+    owner_id, renter_id = 1, 2
+    econ.deposit(owner_id, 100000)
+    econ.deposit(renter_id, 10000)
+    pid = svc.buy_property(owner_id, "Studio", "studio", "NYC", 50000, 1000)
+    svc.upgrade_property(pid, owner_id)
+    result = svc.rent_property(pid, renter_id)
+    assert result["rent_paid"] == 1200
+    assert result["rehearsal_bonus"] == 2
+    assert econ.get_balance(renter_id) == 10000 - 1200
+    assert econ.get_balance(owner_id) == 1200


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for properties and their upgrades
- extend property service with upgrade tracking, renting and rent collection
- expose route to rent properties and test full economic lifecycle

## Testing
- `pytest backend/tests/property/test_property_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37ff3b6088325884d42af5233de5e