### PR TITLE
Implement basic economy ledger with SQLAlchemy models

### DIFF
--- a/backend/economy/models.py
+++ b/backend/economy/models.py
@@ -1,38 +1,68 @@
-from dataclasses import dataclass
+"""SQLAlchemy models for core economy tables.
+
+These lightweight ORM mappings are used by the economy service for
+accounting operations.  They intentionally contain only the fields required
+for the tests in this kata.
+"""
+
+from __future__ import annotations
+
 from datetime import datetime
 
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.ext.declarative import declarative_base
 
-@dataclass
-class Account:
+
+# A local ``Base`` is used so that the tables can be created on demand in the
+# tests without interfering with the vast number of other models in the
+# project.
+Base = declarative_base()
+
+
+class Account(Base):
     """Represents a user's currency account."""
 
-    id: int
-    user_id: int
-    currency: str
-    balance_cents: int
-    created_at: datetime
+    __tablename__ = "accounts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, unique=True, nullable=False)
+    currency = Column(String, nullable=False, default="USD")
+    balance_cents = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
 
 
-@dataclass
-class Transaction:
+class Transaction(Base):
     """Record of money moving between accounts or external sources."""
 
-    id: int
-    type: str  # deposit, withdrawal, transfer
-    amount_cents: int
-    currency: str
-    src_account_id: int | None
-    dest_account_id: int | None
-    created_at: datetime
+    __tablename__ = "transactions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    type = Column(String, nullable=False)  # deposit, withdrawal, transfer
+    amount_cents = Column(Integer, nullable=False)
+    currency = Column(String, nullable=False)
+    src_account_id = Column(Integer, ForeignKey("accounts.id"))
+    dest_account_id = Column(Integer, ForeignKey("accounts.id"))
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
 
 
-@dataclass
-class LedgerEntry:
+class LedgerEntry(Base):
     """Account-level delta for a transaction."""
 
-    id: int
-    account_id: int
-    transaction_id: int
-    delta_cents: int
-    balance_after: int
-    created_at: datetime
+    __tablename__ = "ledger_entries"
+
+    id = Column(Integer, primary_key=True, index=True)
+    account_id = Column(Integer, ForeignKey("accounts.id"), nullable=False)
+    transaction_id = Column(
+        Integer, ForeignKey("transactions.id"), nullable=False
+    )
+    delta_cents = Column(Integer, nullable=False)
+    balance_after = Column(Integer, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+


### PR DESCRIPTION
## Summary
- Add SQLAlchemy Account, Transaction, and LedgerEntry ORM models
- Expand economy service with deposit, withdraw, transfer, and transaction history using SQLAlchemy
- Add tests covering financial flows and ledger audits

## Testing
- `pytest backend/tests/economy/test_economy_service.py::test_deposit_withdraw_transfer -q` *(fails: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68b37fecee708325a6cac78150356d80