### PR TITLE
Add recording session scheduling modules and frontend form

### DIFF
--- a/backend/models/recording_session.py
+++ b/backend/models/recording_session.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List
+
+
+@dataclass
+class RecordingSession:
+    """Represents a scheduled studio recording session."""
+
+    id: int
+    band_id: int
+    studio: str
+    start: str
+    end: str
+    track_statuses: Dict[int, str] = field(default_factory=dict)
+    personnel: List[int] = field(default_factory=list)
+    cost_cents: int = 0
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "band_id": self.band_id,
+            "studio": self.studio,
+            "start": self.start,
+            "end": self.end,
+            "track_statuses": dict(self.track_statuses),
+            "personnel": list(self.personnel),
+            "cost_cents": self.cost_cents,
+            "created_at": self.created_at,
+        }
+
+
+__all__ = ["RecordingSession"]

--- a/backend/routes/recording_routes.py
+++ b/backend/routes/recording_routes.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id
+from backend.services.economy_service import EconomyService
+from backend.services.recording_service import RecordingService
+
+router = APIRouter(prefix="/recording", tags=["recording"])
+svc = RecordingService(economy=EconomyService())
+
+
+class SessionCreate(BaseModel):
+    studio: str
+    start: str
+    end: str
+    tracks: List[int] = []
+    cost_cents: int
+
+
+class PersonnelAssign(BaseModel):
+    user_id: int
+
+
+class TrackUpdate(BaseModel):
+    status: str
+
+
+@router.post("/sessions")
+def create_session(payload: SessionCreate, user_id: int = Depends(get_current_user_id)):
+    try:
+        session = svc.schedule_session(
+            band_id=user_id,
+            studio=payload.studio,
+            start=payload.start,
+            end=payload.end,
+            tracks=payload.tracks,
+            cost_cents=payload.cost_cents,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return session.to_dict()
+
+
+@router.get("/sessions")
+def list_sessions(user_id: int = Depends(get_current_user_id)):
+    return [s.to_dict() for s in svc.list_sessions(band_id=user_id)]
+
+
+@router.get("/sessions/{session_id}")
+def get_session(session_id: int, user_id: int = Depends(get_current_user_id)):
+    session = svc.get_session(session_id)
+    if not session or session.band_id != user_id:
+        raise HTTPException(status_code=404, detail="session_not_found")
+    return session.to_dict()
+
+
+@router.delete("/sessions/{session_id}")
+def delete_session(session_id: int, user_id: int = Depends(get_current_user_id)):
+    session = svc.get_session(session_id)
+    if not session or session.band_id != user_id:
+        raise HTTPException(status_code=404, detail="session_not_found")
+    svc.delete_session(session_id)
+    return {"ok": True}
+
+
+@router.post("/sessions/{session_id}/personnel")
+def assign_personnel(
+    session_id: int, payload: PersonnelAssign, user_id: int = Depends(get_current_user_id)
+):
+    session = svc.get_session(session_id)
+    if not session or session.band_id != user_id:
+        raise HTTPException(status_code=404, detail="session_not_found")
+    svc.assign_personnel(session_id, payload.user_id)
+    return {"ok": True}
+
+
+@router.put("/sessions/{session_id}/tracks/{track_id}")
+def update_track(
+    session_id: int, track_id: int, payload: TrackUpdate, user_id: int = Depends(get_current_user_id)
+):
+    session = svc.get_session(session_id)
+    if not session or session.band_id != user_id:
+        raise HTTPException(status_code=404, detail="session_not_found")
+    svc.update_track_status(session_id, track_id, payload.status)
+    return {"ok": True, "track_statuses": session.track_statuses}

--- a/backend/services/recording_service.py
+++ b/backend/services/recording_service.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from backend.models.recording_session import RecordingSession
+from backend.services.economy_service import EconomyError, EconomyService
+
+
+class RecordingService:
+    """In-memory management of studio recording sessions."""
+
+    def __init__(self, economy: Optional[EconomyService] = None) -> None:
+        self.economy = economy or EconomyService()
+        try:  # ensure economy tables exist
+            self.economy.ensure_schema()
+        except Exception:
+            pass
+        self.sessions: Dict[int, RecordingSession] = {}
+        self._id_seq = 1
+
+    # ------------------------------------------------------------------
+    def schedule_session(
+        self,
+        band_id: int,
+        studio: str,
+        start: str,
+        end: str,
+        tracks: List[int],
+        cost_cents: int,
+    ) -> RecordingSession:
+        """Schedule a new recording session and charge the band."""
+
+        try:
+            self.economy.withdraw(band_id, cost_cents)
+        except EconomyError as e:
+            raise ValueError(str(e)) from e
+        session = RecordingSession(
+            id=self._id_seq,
+            band_id=band_id,
+            studio=studio,
+            start=start,
+            end=end,
+            track_statuses={tid: "pending" for tid in tracks},
+            cost_cents=cost_cents,
+        )
+        self.sessions[session.id] = session
+        self._id_seq += 1
+        return session
+
+    def assign_personnel(self, session_id: int, user_id: int) -> None:
+        session = self.sessions.get(session_id)
+        if not session:
+            raise KeyError("session_not_found")
+        if user_id not in session.personnel:
+            session.personnel.append(user_id)
+
+    def update_track_status(self, session_id: int, track_id: int, status: str) -> None:
+        session = self.sessions.get(session_id)
+        if not session:
+            raise KeyError("session_not_found")
+        session.track_statuses[track_id] = status
+
+    def get_session(self, session_id: int) -> Optional[RecordingSession]:
+        return self.sessions.get(session_id)
+
+    def list_sessions(self, band_id: Optional[int] = None) -> List[RecordingSession]:
+        if band_id is None:
+            return list(self.sessions.values())
+        return [s for s in self.sessions.values() if s.band_id == band_id]
+
+    def delete_session(self, session_id: int) -> None:
+        self.sessions.pop(session_id, None)
+
+
+recording_service = RecordingService()
+
+__all__ = ["RecordingService", "recording_service"]

--- a/frontend/pages/recording_session_form.html
+++ b/frontend/pages/recording_session_form.html
@@ -1,0 +1,17 @@
+<h2>Book Recording Session</h2>
+<form id="bookingForm">
+  <input type="text" name="studio" placeholder="Studio" required />
+  <input type="datetime-local" name="start" required />
+  <input type="datetime-local" name="end" required />
+  <input type="number" name="cost_cents" placeholder="Cost (cents)" required />
+  <input type="text" name="tracks" placeholder="Track IDs comma separated" />
+  <button type="submit">Schedule Session</button>
+</form>
+
+<h2>Track Progress</h2>
+<form id="progressForm">
+  <input type="number" name="session_id" placeholder="Session ID" required />
+  <input type="number" name="track_id" placeholder="Track ID" required />
+  <input type="text" name="status" placeholder="Status" required />
+  <button type="submit">Update Status</button>
+</form>


### PR DESCRIPTION
## Summary
- add `RecordingSession` model with studio, timing, track status, and cost fields
- implement `RecordingService` handling scheduling, personnel, and economy deductions
- expose recording session CRUD/scheduling routes and create a frontend booking/progress form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic.fields')*
- `pip install pydantic boto3 -q` *(fails: Could not find a version that satisfies the requirement boto3)*

------
https://chatgpt.com/codex/tasks/task_e_68b417d7a9b4832598423a223ff81042