### PR TITLE
refactor: introduce release aggregate

### DIFF
--- a/backend/migrations/sql/090_release_aggregate.sql
+++ b/backend/migrations/sql/090_release_aggregate.sql
@@ -1,0 +1,18 @@
+CREATE TABLE releases (
+    id INTEGER PRIMARY KEY,
+    band_id INTEGER,
+    title TEXT NOT NULL,
+    format TEXT CHECK(format IN ('single','ep','lp')) NOT NULL,
+    release_date DATE,
+    total_runtime INTEGER DEFAULT 0,
+    collaboration_id INTEGER,
+    distribution_channels TEXT
+);
+
+CREATE TABLE tracks (
+    id INTEGER PRIMARY KEY,
+    release_id INTEGER NOT NULL REFERENCES releases(id),
+    title TEXT NOT NULL,
+    duration INTEGER NOT NULL,
+    track_number INTEGER NOT NULL
+);

--- a/backend/migrations/versions/0021_090_release_aggregate.py
+++ b/backend/migrations/versions/0021_090_release_aggregate.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from alembic import op
+
+revision = '0021'
+down_revision = '0020'
+branch_labels = None
+depends_on = None
+
+SQL_FILE = Path(__file__).resolve().parent.parent / 'sql' / '090_release_aggregate.sql'
+
+def upgrade() -> None:
+    op.execute(SQL_FILE.read_text())
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS tracks;")
+    op.execute("DROP TABLE IF EXISTS releases;")

--- a/backend/models/music.py
+++ b/backend/models/music.py
@@ -1,44 +1,31 @@
-from sqlalchemy import (
-    Column, Integer, String, ForeignKey, DateTime, Text, Table, Enum
-)
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Text, Enum
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql import func
 
 Base = declarative_base()
 
-# Link table between albums and songs
-album_song_link = Table(
-    "album_song_link",
-    Base.metadata,
-    Column("album_id", Integer, ForeignKey("albums.id")),
-    Column("song_id", Integer, ForeignKey("songs.id"))
-)
 
-class Song(Base):
-    __tablename__ = "songs"
+class Release(Base):
+    __tablename__ = "releases"
 
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String, index=True)
-    genre = Column(String)
+    format = Column(Enum("single", "ep", "lp", name="release_format"))
+    release_date = Column(DateTime(timezone=True), server_default=func.now())
+    total_runtime = Column(Integer, default=0)
+    band_id = Column(Integer, ForeignKey("bands.id"), nullable=True)
+    collaboration_id = Column(Integer, ForeignKey("band_collaborations.id"), nullable=True)
+    distribution_channels = Column(Text)
+
+    tracks = relationship("Track", order_by="Track.track_number", cascade="all, delete-orphan")
+
+
+class Track(Base):
+    __tablename__ = "tracks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    release_id = Column(Integer, ForeignKey("releases.id"))
+    title = Column(String, index=True)
     duration = Column(Integer)  # in seconds
-    difficulty = Column(Integer)  # 1 to 10
-    lyrics = Column(Text)
-
-    band_id = Column(Integer, ForeignKey("bands.id"), nullable=True)
-    collaboration_id = Column(Integer, ForeignKey("band_collaborations.id"), nullable=True)
-
-    release_date = Column(DateTime(timezone=True), server_default=func.now())
-
-class Album(Base):
-    __tablename__ = "albums"
-
-    id = Column(Integer, primary_key=True, index=True)
-    title = Column(String, index=True)
-    type = Column(String)  # "album" or "ep"
-    release_date = Column(DateTime(timezone=True), server_default=func.now())
-
-    band_id = Column(Integer, ForeignKey("bands.id"), nullable=True)
-    collaboration_id = Column(Integer, ForeignKey("band_collaborations.id"), nullable=True)
-
-    songs = relationship("Song", secondary=album_song_link)
+    track_number = Column(Integer)

--- a/backend/routes/album_routes.py
+++ b/backend/routes/album_routes.py
@@ -7,24 +7,24 @@ album_routes = Blueprint('album_routes', __name__)
 album_service = AlbumService(db=None)
 
 @album_routes.route('/albums', methods=['POST'])
-def create_album():
+def create_release():
     data = request.json
     try:
-        return jsonify(album_service.create_album(data)), 201
-    except Exception as e:
+        return jsonify(album_service.create_release(data)), 201
+    except ValueError as e:
         return jsonify({'error': str(e)}), 400
 
 @album_routes.route('/albums/band/<int:band_id>', methods=['GET'])
-def get_band_albums(band_id):
-    return jsonify(album_service.list_albums_by_band(band_id))
+def get_band_releases(band_id):
+    return jsonify(album_service.list_releases_by_band(band_id))
 
-@album_routes.route('/albums/<int:album_id>', methods=['PUT'])
-def update_album(album_id):
+@album_routes.route('/albums/<int:release_id>', methods=['PUT'])
+def update_release(release_id):
     updates = request.json
-    album_service.update_album(album_id, updates)
+    album_service.update_release(release_id, updates)
     return '', 204
 
-@album_routes.route('/albums/<int:album_id>/publish', methods=['POST'])
-def publish_album(album_id):
-    album_service.publish_album(album_id)
+@album_routes.route('/albums/<int:release_id>/publish', methods=['POST'])
+def publish_release(release_id):
+    album_service.publish_release(release_id)
     return '', 200

--- a/backend/services/album_service.py
+++ b/backend/services/album_service.py
@@ -4,89 +4,115 @@ from backend.database import DB_PATH
 from backend.services import band_service
 
 
-def create_album(band_id: int, title: str, album_type: str, song_ids: list, shared_with_band_id=None) -> dict:
-    if album_type == "EP" and len(song_ids) > 4:
-        return {"error": "EPs cannot contain more than 4 songs"}
+class AlbumService:
+    def __init__(self, db: str | None = DB_PATH):
+        self.db = db or DB_PATH
 
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
+    def create_release(self, data: dict) -> dict:
+        band_id = data.get("band_id")
+        title = data.get("title")
+        release_format = data.get("format")
+        tracks = data.get("tracks", [])
+        distribution_channels = ",".join(data.get("distribution_channels", []))
 
-    cur.execute("""
-        INSERT INTO albums (band_id, title, album_type, shared_with_band_id, release_date)
-        VALUES (?, ?, ?, ?, NULL)
-    """, (band_id, title, album_type, shared_with_band_id))
-    album_id = cur.lastrowid
+        if release_format == "ep" and len(tracks) > 4:
+            raise ValueError("EPs cannot contain more than 4 tracks")
 
-    # Link songs to album
-    for song_id in song_ids:
-        cur.execute("""
-            INSERT INTO album_songs (album_id, song_id)
-            VALUES (?, ?)
-        """, (album_id, song_id))
+        total_runtime = sum(t.get("duration", 0) for t in tracks)
 
-    conn.commit()
-    conn.close()
+        conn = sqlite3.connect(self.db)
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO releases (band_id, title, format, release_date, total_runtime, distribution_channels)
+            VALUES (?, ?, ?, NULL, ?, ?)
+            """,
+            (band_id, title, release_format, total_runtime, distribution_channels),
+        )
+        release_id = cur.lastrowid
 
-    return {"status": "ok", "album_id": album_id}
+        for i, track in enumerate(tracks, start=1):
+            cur.execute(
+                """
+                INSERT INTO tracks (release_id, title, duration, track_number)
+                VALUES (?, ?, ?, ?)
+                """,
+                (release_id, track["title"], track["duration"], i),
+            )
 
-
-def get_albums_by_band(band_id: int) -> list:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-
-    cur.execute("""
-        SELECT id, title, album_type, release_date, shared_with_band_id
-        FROM albums
-        WHERE band_id = ?
-        ORDER BY release_date DESC NULLS LAST
-    """, (band_id,))
-    albums = cur.fetchall()
-    conn.close()
-
-    return [dict(zip(["album_id", "title", "type", "release_date", "collab_band_id"], row)) for row in albums]
-
-
-def update_album(album_id: int, updates: dict) -> dict:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-
-    for field, value in updates.items():
-        cur.execute(f"UPDATE albums SET {field} = ? WHERE id = ?", (value, album_id))
-
-    conn.commit()
-    conn.close()
-    return {"status": "ok", "message": "Album updated"}
-
-
-def publish_album(album_id: int) -> dict:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-
-    release_date = datetime.now().date()
-    cur.execute("UPDATE albums SET release_date = ? WHERE id = ?", (release_date, album_id))
-
-    # Fame and revenue gain simulation
-    cur.execute("""
-        SELECT band_id, shared_with_band_id FROM albums WHERE id = ?
-    """, (album_id,))
-    row = cur.fetchone()
-    if not row:
+        conn.commit()
         conn.close()
-        return {"error": "Album not found"}
+        return {"status": "ok", "release_id": release_id}
 
-    band_id, collab_id = row
-    fame_gain = 50
-    revenue = 1000
+    def list_releases_by_band(self, band_id: int) -> list:
+        conn = sqlite3.connect(self.db)
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT id, title, format, release_date, total_runtime, distribution_channels
+            FROM releases
+            WHERE band_id = ?
+            ORDER BY release_date DESC NULLS LAST
+            """,
+            (band_id,),
+        )
+        releases = cur.fetchall()
+        conn.close()
+        return [
+            dict(
+                zip(
+                    [
+                        "release_id",
+                        "title",
+                        "format",
+                        "release_date",
+                        "total_runtime",
+                        "distribution_channels",
+                    ],
+                    row,
+                )
+            )
+            for row in releases
+        ]
 
-    earnings = band_service.split_earnings(band_id, revenue, collab_id)
+    def update_release(self, release_id: int, updates: dict) -> dict:
+        conn = sqlite3.connect(self.db)
+        cur = conn.cursor()
+        for field, value in updates.items():
+            cur.execute(f"UPDATE releases SET {field} = ? WHERE id = ?", (value, release_id))
+        conn.commit()
+        conn.close()
+        return {"status": "ok", "message": "Release updated"}
 
-    conn.commit()
-    conn.close()
+    def publish_release(self, release_id: int) -> dict:
+        conn = sqlite3.connect(self.db)
+        cur = conn.cursor()
 
-    return {
-        "status": "ok",
-        "release_date": str(release_date),
-        "fame_gain": fame_gain,
-        "revenue": revenue,
-        "earnings": earnings
-    }
+        release_date = datetime.now().date()
+        cur.execute("UPDATE releases SET release_date = ? WHERE id = ?", (release_date, release_id))
+
+        cur.execute(
+            "SELECT band_id FROM releases WHERE id = ?",
+            (release_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            conn.close()
+            return {"error": "Release not found"}
+
+        band_id = row[0]
+        fame_gain = 50
+        revenue = 1000
+
+        earnings = band_service.split_earnings(band_id, revenue, None)
+
+        conn.commit()
+        conn.close()
+
+        return {
+            "status": "ok",
+            "release_date": str(release_date),
+            "fame_gain": fame_gain,
+            "revenue": revenue,
+            "earnings": earnings,
+        }

--- a/frontend/pages/album_form.html
+++ b/frontend/pages/album_form.html
@@ -1,14 +1,14 @@
 
-<h2>Create Album</h2>
+<h2>Create Release</h2>
 <form id="albumForm">
-  <input type="text" name="title" placeholder="Album Title" required />
-  <select name="album_type">
-    <option value="EP">EP (max 4 songs)</option>
-    <option value="LP">LP</option>
-    <option value="Single">Single</option>
+  <input type="text" name="title" placeholder="Title" required />
+  <select name="format">
+    <option value="single">Single</option>
+    <option value="ep">EP (max 4 tracks)</option>
+    <option value="lp">LP</option>
   </select>
   <input type="text" name="genre" placeholder="Genre" required />
-  <label>Select Songs:</label>
+  <label>Select Tracks:</label>
   <div id="songSelector"></div>
   <select name="distribution_channels" multiple>
     <option value="digital">Digital</option>
@@ -16,5 +16,5 @@
     <option value="streaming">Streaming</option>
   </select>
   <input type="file" name="cover_art" />
-  <button type="submit">Create Album</button>
+  <button type="submit">Create Release</button>
 </form>

--- a/frontend/pages/song_form.html
+++ b/frontend/pages/song_form.html
@@ -5,7 +5,7 @@
   <input type="number" name="duration_sec" placeholder="Duration (sec)" required />
   <input type="text" name="genre" placeholder="Genre" required />
   <textarea name="lyrics" placeholder="Lyrics"></textarea>
-  <select name="format">
+  <select name="distribution_channels" multiple>
     <option value="digital">Digital</option>
     <option value="vinyl">Vinyl</option>
     <option value="streaming">Streaming</option>


### PR DESCRIPTION
## Summary
- replace Song/Album models with Release aggregate including track order and runtime
- validate release formats and record distribution channels in album service and routes
- sync album and song forms and add migration for new release tables

## Testing
- `pytest` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b4192964748325b7f43a7b79c95703