### PR TITLE
Add persistent contract negotiation service with record contracts

### DIFF
--- a/backend/models/record_contract.py
+++ b/backend/models/record_contract.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class RoyaltyTier:
+    """Represents a thresholded royalty rate."""
+
+    threshold_units: int
+    rate: float
+
+
+@dataclass
+class RecordContract:
+    """Typed representation of a recording contract."""
+
+    advance_cents: int
+    royalty_tiers: List[RoyaltyTier] = field(default_factory=list)
+    term_months: int = 0
+    territory: str = "worldwide"
+    recoupable_budgets_cents: int = 0
+    options: List[str] = field(default_factory=list)
+    obligations: List[str] = field(default_factory=list)

--- a/backend/schemas/labels_schemas.py
+++ b/backend/schemas/labels_schemas.py
@@ -1,15 +1,49 @@
-from pydantic import BaseModel
-from typing import Optional
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
 
 class LabelCreateSchema(BaseModel):
-    label_id: str
     name: str
     owner_id: Optional[int]
     is_npc: Optional[bool] = True
 
-class ContractOfferSchema(BaseModel):
-    contract_id: str
-    label_id: str
+
+class RoyaltyTierSchema(BaseModel):
+    threshold_units: int
+    rate: float
+
+
+class RecordContractSchema(BaseModel):
+    advance_cents: int
+    royalty_tiers: List[RoyaltyTierSchema] = Field(default_factory=list)
+    term_months: int
+    territory: str
+    recoupable_budgets_cents: int = 0
+    options: List[str] = Field(default_factory=list)
+    obligations: List[str] = Field(default_factory=list)
+
+
+class OfferRequestSchema(BaseModel):
+    label_id: int
     band_id: int
-    revenue_split: float
-    duration_weeks: int
+    terms: RecordContractSchema
+
+
+class CounterOfferSchema(BaseModel):
+    terms: RecordContractSchema
+
+
+class NegotiationSchema(BaseModel):
+    id: int
+    label_id: int
+    band_id: int
+    stage: str
+    recoupable_cents: int
+    recouped_cents: int
+    terms: RecordContractSchema
+
+    class Config:
+        orm_mode = True

--- a/backend/tests/labels/test_contract_negotiation_service.py
+++ b/backend/tests/labels/test_contract_negotiation_service.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.models.label_management_models import NegotiationStage
+from backend.services.contract_negotiation_service import ContractNegotiationService
+from backend.services.economy_service import EconomyService
+
+
+def setup_services():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    econ = EconomyService(db_path=path)
+    econ.ensure_schema()
+    svc = ContractNegotiationService(economy=econ, db_path=path)
+    return econ, svc
+
+
+def test_negotiation_flow_and_recoupment():
+    economy, service = setup_services()
+    # label has funds for advance and royalties
+    economy.deposit(1, 5000)
+    terms = {
+        "advance_cents": 1000,
+        "royalty_tiers": [{"threshold_units": 0, "rate": 0.1}],
+        "term_months": 12,
+        "territory": "US",
+        "recoupable_budgets_cents": 500,
+        "options": [],
+        "obligations": [],
+    }
+    neg = service.create_offer(1, 2, terms)
+    assert neg.stage == NegotiationStage.OFFER
+
+    neg = service.counter_offer(neg.id, terms)
+    assert neg.stage == NegotiationStage.COUNTER
+
+    neg = service.accept_offer(neg.id)
+    assert neg.stage == NegotiationStage.ACCEPTED
+    assert neg.recoupable_cents == 1500
+
+    # deposit revenue for royalty payout
+    economy.deposit(1, 1000)
+    neg = service.apply_royalty_payment(neg.id, 700)
+    assert neg.recouped_cents == 700


### PR DESCRIPTION
## Summary
- define typed `RecordContract` model with royalty tiers and recoupable budgets
- persist contract negotiations using SQLAlchemy with recoupment logic
- expose offer/counter/accept negotiation endpoints on label routes

## Testing
- `pytest backend/tests/labels/test_contract_negotiation_service.py -q`
- `pytest -q` *(fails: No module named 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_68b41a3c1dc88325ba943f7f10ee3157