### PR TITLE
Add indie release service and routes

### DIFF
--- a/backend/routes/indie_release_routes.py
+++ b/backend/routes/indie_release_routes.py
@@ -1,0 +1,31 @@
+"""Routes for purchasing indie release packages."""
+
+from flask import Blueprint, jsonify, request
+
+from backend.services.indie_release_service import IndieReleaseService
+
+indie_release_routes = Blueprint("indie_release_routes", __name__)
+service = IndieReleaseService()
+
+
+@indie_release_routes.route("/indie/releases", methods=["POST"])
+def purchase_release():
+    data = request.json or {}
+    band_id = int(data.get("band_id"))
+    distribution = data.get("distribution", "digital")
+    promotion = data.get("promotion", "none")
+    physical = data.get("physical", "none")
+    vendor_terms = data.get("vendor_terms") or {}
+    release = service.purchase_release(
+        band_id,
+        distribution,
+        promotion,
+        physical,
+        vendor_terms=vendor_terms,
+    )
+    return jsonify(release), 201
+
+
+@indie_release_routes.route("/indie/releases/<int:band_id>", methods=["GET"])
+def list_releases(band_id: int):
+    return jsonify(service.list_releases(band_id))

--- a/backend/services/indie_release_service.py
+++ b/backend/services/indie_release_service.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from backend.models.label_management_models import ClauseTemplate
+from backend.services.economy_service import EconomyService
+
+
+@dataclass
+class IndieRelease:
+    """Record of a purchased indie release package."""
+
+    id: int
+    band_id: int
+    distribution: str
+    promotion: str
+    physical: str
+    cost_cents: int
+    vendor_terms: Dict[str, Any] = field(default_factory=dict)
+
+
+class IndieReleaseService:
+    """Service to purchase indie release packages and track assets."""
+
+    def __init__(self, economy: Optional[EconomyService] = None):
+        self.economy = economy or EconomyService()
+        self.releases: Dict[int, IndieRelease] = {}
+        self._next_id = 1
+
+        # Pricing tables in cents
+        self.distribution_packages = {
+            "digital": 5000,
+            "worldwide": 15000,
+        }
+        self.promotion_packages = {
+            "none": 0,
+            "standard": 8000,
+            "plus": 20000,
+        }
+        self.physical_packages = {
+            "none": 0,
+            "cd": 7000,
+            "vinyl": 12000,
+        }
+
+        # Clause templates reused for optional third-party vendors
+        self.vendor_clauses = [
+            ClauseTemplate("vendor_name", "Third-party vendor", ""),
+            ClauseTemplate("vendor_fee_cents", "Vendor fee in cents", 0),
+        ]
+
+    # ------------------------------------------------------------------
+    def purchase_release(
+        self,
+        band_id: int,
+        distribution: str,
+        promotion: str,
+        physical: str,
+        vendor_terms: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Purchase a release package and deduct the cost from the band."""
+
+        cost = (
+            self.distribution_packages.get(distribution, 0)
+            + self.promotion_packages.get(promotion, 0)
+            + self.physical_packages.get(physical, 0)
+        )
+
+        # Deduct funds
+        self.economy.withdraw(band_id, cost)
+
+        # Merge vendor terms with clause defaults
+        vendor_terms = vendor_terms or {}
+        final_vendor_terms = {
+            c.key: vendor_terms.get(c.key, c.default) for c in self.vendor_clauses
+        }
+
+        release = IndieRelease(
+            id=self._next_id,
+            band_id=band_id,
+            distribution=distribution,
+            promotion=promotion,
+            physical=physical,
+            cost_cents=cost,
+            vendor_terms=final_vendor_terms,
+        )
+        self.releases[self._next_id] = release
+        self._next_id += 1
+        return release.__dict__
+
+    def list_releases(self, band_id: int) -> List[Dict[str, Any]]:
+        """List all purchased releases for a band."""
+
+        return [r.__dict__ for r in self.releases.values() if r.band_id == band_id]

--- a/frontend/pages/indie_release_form.html
+++ b/frontend/pages/indie_release_form.html
@@ -1,0 +1,21 @@
+<h2>Indie Release Purchase</h2>
+<form id="indieReleaseForm">
+  <input type="number" name="band_id" placeholder="Band ID" required />
+  <select name="distribution">
+    <option value="digital">Digital Distribution</option>
+    <option value="worldwide">Worldwide Distribution</option>
+  </select>
+  <select name="promotion">
+    <option value="none">No Promotion</option>
+    <option value="standard">Standard Promotion</option>
+    <option value="plus">Plus Promotion</option>
+  </select>
+  <select name="physical">
+    <option value="none">Digital Only</option>
+    <option value="cd">CD Production</option>
+    <option value="vinyl">Vinyl Production</option>
+  </select>
+  <input type="text" name="vendor_name" placeholder="PR Vendor (optional)" />
+  <input type="number" name="vendor_fee_cents" placeholder="Vendor Fee (cents)" />
+  <button type="submit">Purchase Release</button>
+</form>


### PR DESCRIPTION
## Summary
- Implement IndieReleaseService handling distribution, promotion, and physical production packages with EconomyService deductions and vendor clauses
- Expose new Flask routes under `/indie/releases` for purchasing and listing indie releases
- Provide frontend form for indie release package selection

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic.fields'; No module named 'boto3')*


------
https://chatgpt.com/codex/tasks/task_e_68b41badc8048325813bcab2b9f86fc4