### PR TITLE
Refactor album service to SQLAlchemy and add tests

### DIFF
--- a/backend/routes/album_routes.py
+++ b/backend/routes/album_routes.py
@@ -1,10 +1,8 @@
-from auth.dependencies import get_current_user_id, require_role
-
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, jsonify, request
 from services.album_service import AlbumService
 
-album_routes = Blueprint('album_routes', __name__)
-album_service = AlbumService(db=None)
+album_routes = Blueprint("album_routes", __name__)
+album_service = AlbumService()
 
 @album_routes.route('/albums', methods=['POST'])
 def create_release():
@@ -18,13 +16,15 @@ def create_release():
 def get_band_releases(band_id):
     return jsonify(album_service.list_releases_by_band(band_id))
 
-@album_routes.route('/albums/<int:release_id>', methods=['PUT'])
+@album_routes.route("/albums/<int:release_id>", methods=["PUT"])
 def update_release(release_id):
     updates = request.json
-    album_service.update_release(release_id, updates)
-    return '', 204
+    result = album_service.update_release(release_id, updates)
+    status = 404 if "error" in result else 200
+    return jsonify(result), status
 
-@album_routes.route('/albums/<int:release_id>/publish', methods=['POST'])
+@album_routes.route("/albums/<int:release_id>/publish", methods=["POST"])
 def publish_release(release_id):
-    album_service.publish_release(release_id)
-    return '', 200
+    result = album_service.publish_release(release_id)
+    status = 404 if "error" in result else 200
+    return jsonify(result), status

--- a/backend/services/album_service.py
+++ b/backend/services/album_service.py
@@ -1,118 +1,194 @@
-import sqlite3
+"""Album service using SQLAlchemy sessions.
+
+This module replaces the previous ``sqlite3`` implementation with a session
+based approach similar to :mod:`services.band_service`.  The service exposes
+helpers to create, list, update and publish music releases.  Earnings are
+delegated to :class:`services.band_service.BandService` so tests may share the
+same in-memory database by providing a custom ``session_factory``.
+"""
+
+from __future__ import annotations
+
 from datetime import datetime
-from backend.database import DB_PATH
-from backend.services import band_service
+from pathlib import Path
+from typing import Callable, Iterable
+
+from sqlalchemy import create_engine, or_
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.music import Base as MusicBase, Release, Track
+from services.band_service import (
+    BandCollaboration,
+    BandService,
+    Base as BandBase,
+)
+
+
+# ---------------------------------------------------------------------------
+# Database setup
+# ---------------------------------------------------------------------------
+
+DB_PATH = Path(__file__).resolve().parents[1] / "database" / "rockmundo.db"
+DATABASE_URL = f"sqlite:///{DB_PATH}"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+# Tables are created by the application or tests.  Creating them here would
+# require resolving cross-metadata foreign keys (``Release`` references tables
+# from ``BandBase``), so we leave schema creation to the caller.
+
+
+# ---------------------------------------------------------------------------
+# Service implementation
+# ---------------------------------------------------------------------------
 
 
 class AlbumService:
-    def __init__(self, db: str | None = DB_PATH):
-        self.db = db or DB_PATH
+    """Encapsulates release CRUD operations and publishing logic."""
 
+    def __init__(
+        self,
+        session_factory: Callable[[], Session] | sessionmaker = SessionLocal,
+        band_service: BandService | None = None,
+    ) -> None:
+        self.session_factory = session_factory
+        self.band_service = band_service or BandService(session_factory)
+
+    # ------------------------------------------------------------------
     def create_release(self, data: dict) -> dict:
-        band_id = data.get("band_id")
-        title = data.get("title")
-        release_format = data.get("format")
-        tracks = data.get("tracks", [])
-        distribution_channels = ",".join(data.get("distribution_channels", []))
+        """Create a new music release along with its tracks."""
 
+        release_format = data.get("format")
+        tracks: Iterable[dict] = data.get("tracks", [])
+
+        # ``tracks`` may be provided as an iterator; materialize it once so we
+        # can validate length and reuse the data.
+        tracks = list(tracks)
         if release_format == "ep" and len(tracks) > 4:
             raise ValueError("EPs cannot contain more than 4 tracks")
 
         total_runtime = sum(t.get("duration", 0) for t in tracks)
+        distribution_channels = ",".join(data.get("distribution_channels", []))
 
-        conn = sqlite3.connect(self.db)
-        cur = conn.cursor()
-        cur.execute(
-            """
-            INSERT INTO releases (band_id, title, format, release_date, total_runtime, distribution_channels)
-            VALUES (?, ?, ?, NULL, ?, ?)
-            """,
-            (band_id, title, release_format, total_runtime, distribution_channels),
-        )
-        release_id = cur.lastrowid
-
-        for i, track in enumerate(tracks, start=1):
-            cur.execute(
-                """
-                INSERT INTO tracks (release_id, title, duration, track_number)
-                VALUES (?, ?, ?, ?)
-                """,
-                (release_id, track["title"], track["duration"], i),
-            )
-
-        conn.commit()
-        conn.close()
-        return {"status": "ok", "release_id": release_id}
-
-    def list_releases_by_band(self, band_id: int) -> list:
-        conn = sqlite3.connect(self.db)
-        cur = conn.cursor()
-        cur.execute(
-            """
-            SELECT id, title, format, release_date, total_runtime, distribution_channels
-            FROM releases
-            WHERE band_id = ?
-            ORDER BY release_date DESC NULLS LAST
-            """,
-            (band_id,),
-        )
-        releases = cur.fetchall()
-        conn.close()
-        return [
-            dict(
-                zip(
-                    [
-                        "release_id",
-                        "title",
-                        "format",
-                        "release_date",
-                        "total_runtime",
-                        "distribution_channels",
-                    ],
-                    row,
+        with self.session_factory() as session:
+            with session.begin():
+                release = Release(
+                    band_id=data.get("band_id"),
+                    collaboration_id=data.get("collaboration_id"),
+                    title=data.get("title"),
+                    format=release_format,
+                    total_runtime=total_runtime,
+                    distribution_channels=distribution_channels,
                 )
+                session.add(release)
+                session.flush()  # populate ``release.id``
+
+                for i, track in enumerate(tracks, start=1):
+                    session.add(
+                        Track(
+                            release_id=release.id,
+                            title=track["title"],
+                            duration=track.get("duration", 0),
+                            track_number=i,
+                        )
+                    )
+
+            session.refresh(release)
+            return {"status": "ok", "release_id": release.id}
+
+    # ------------------------------------------------------------------
+    def list_releases_by_band(self, band_id: int) -> list[dict]:
+        """List releases belonging to the band or its collaborations."""
+
+        with self.session_factory() as session:
+            releases = (
+                session.query(Release)
+                .outerjoin(
+                    BandCollaboration,
+                    Release.collaboration_id == BandCollaboration.id,
+                )
+                .filter(
+                    or_(
+                        Release.band_id == band_id,
+                        BandCollaboration.band_1_id == band_id,
+                        BandCollaboration.band_2_id == band_id,
+                    )
+                )
+                .order_by(Release.release_date.desc())
+                .all()
             )
-            for row in releases
-        ]
 
+            result: list[dict] = []
+            for r in releases:
+                result.append(
+                    {
+                        "release_id": r.id,
+                        "title": r.title,
+                        "format": r.format,
+                        "release_date": r.release_date.isoformat()
+                        if r.release_date
+                        else None,
+                        "total_runtime": r.total_runtime,
+                        "distribution_channels": r.distribution_channels,
+                    }
+                )
+            return result
+
+    # ------------------------------------------------------------------
     def update_release(self, release_id: int, updates: dict) -> dict:
-        conn = sqlite3.connect(self.db)
-        cur = conn.cursor()
-        for field, value in updates.items():
-            cur.execute(f"UPDATE releases SET {field} = ? WHERE id = ?", (value, release_id))
-        conn.commit()
-        conn.close()
-        return {"status": "ok", "message": "Release updated"}
+        """Update fields on a release."""
 
+        with self.session_factory() as session:
+            with session.begin():
+                release = session.get(Release, release_id)
+                if not release:
+                    return {"error": "Release not found"}
+                for field, value in updates.items():
+                    setattr(release, field, value)
+            return {"status": "ok", "message": "Release updated"}
+
+    # ------------------------------------------------------------------
     def publish_release(self, release_id: int) -> dict:
-        conn = sqlite3.connect(self.db)
-        cur = conn.cursor()
+        """Mark a release as published and compute earnings."""
 
-        release_date = datetime.now().date()
-        cur.execute("UPDATE releases SET release_date = ? WHERE id = ?", (release_date, release_id))
+        with self.session_factory() as session:
+            with session.begin():
+                release = session.get(Release, release_id)
+                if not release:
+                    return {"error": "Release not found"}
 
-        cur.execute(
-            "SELECT band_id FROM releases WHERE id = ?",
-            (release_id,),
-        )
-        row = cur.fetchone()
-        if not row:
-            conn.close()
-            return {"error": "Release not found"}
+                release_date = datetime.utcnow()
+                release.release_date = release_date
 
-        band_id = row[0]
+                band_id = release.band_id
+                collab_band_id = None
+                if release.collaboration_id:
+                    collab = session.get(
+                        BandCollaboration, release.collaboration_id
+                    )
+                    if collab:
+                        # Determine the partner band for revenue splitting
+                        if band_id == collab.band_1_id or band_id is None:
+                            band_id = collab.band_1_id
+                            collab_band_id = collab.band_2_id
+                        else:
+                            collab_band_id = collab.band_1_id
+
         fame_gain = 50
         revenue = 1000
-
-        earnings = band_service.split_earnings(band_id, revenue, None)
-
-        conn.commit()
-        conn.close()
+        earnings = self.band_service.split_earnings(
+            band_id, revenue, collab_band_id
+        )
 
         return {
             "status": "ok",
-            "release_date": str(release_date),
+            "release_date": release_date.isoformat(),
             "fame_gain": fame_gain,
             "revenue": revenue,
             "earnings": earnings,
         }
+
+
+__all__ = ["AlbumService"]
+

--- a/backend/tests/albums/test_album_service.py
+++ b/backend/tests/albums/test_album_service.py
@@ -1,0 +1,73 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.music import Base as MusicBase, Release
+from services.album_service import AlbumService
+from services.band_service import Base as BandBase, BandService, Band, BandCollaboration
+
+
+def get_services():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    BandBase.metadata.create_all(bind=engine)
+    # Make band tables visible in the music metadata so foreign keys resolve
+    # when creating release/track tables.
+    Band.__table__.tometadata(MusicBase.metadata)
+    BandCollaboration.__table__.tometadata(MusicBase.metadata)
+    MusicBase.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    band_svc = BandService(SessionLocal)
+    album_svc = AlbumService(SessionLocal, band_svc)
+    return album_svc, band_svc, SessionLocal
+
+
+def test_ep_track_limit():
+    album_svc, band_svc, _ = get_services()
+    band = band_svc.create_band(user_id=1, band_name="Band", genre="rock")
+    data = {
+        "band_id": band.id,
+        "title": "Too Many Tracks",
+        "format": "ep",
+        "tracks": [{"title": f"T{i}", "duration": 120} for i in range(5)],
+    }
+    with pytest.raises(ValueError):
+        album_svc.create_release(data)
+
+
+def test_publish_release_sets_date_and_returns_earnings():
+    album_svc, band_svc, SessionLocal = get_services()
+    band = band_svc.create_band(user_id=1, band_name="Band", genre="rock")
+    data = {
+        "band_id": band.id,
+        "title": "LP1",
+        "format": "lp",
+        "tracks": [{"title": "Song1", "duration": 120}],
+    }
+    res = album_svc.create_release(data)
+    result = album_svc.publish_release(res["release_id"])
+    assert result["status"] == "ok"
+    assert result["revenue"] == 1000
+    with SessionLocal() as session:
+        release = session.get(Release, res["release_id"])
+        assert release.release_date is not None
+
+
+def test_collaboration_publish_split():
+    album_svc, band_svc, _ = get_services()
+    band1 = band_svc.create_band(user_id=1, band_name="Band1", genre="rock")
+    band2 = band_svc.create_band(user_id=2, band_name="Band2", genre="jazz")
+    collab = band_svc.create_collaboration(band1.id, band2.id, "album", "Collab")
+    data = {
+        "band_id": band1.id,
+        "title": "Collab Album",
+        "format": "lp",
+        "tracks": [{"title": "Song", "duration": 120}],
+        "collaboration_id": collab.id,
+    }
+    res = album_svc.create_release(data)
+    result = album_svc.publish_release(res["release_id"])
+    assert result["earnings"]["band_1_share"] == 500
+    assert result["earnings"]["band_2_share"] == 500
+


### PR DESCRIPTION
## Summary
- refactor album service to SQLAlchemy with publish logic and EP validation
- expose album endpoints using the new service
- add album service unit tests for EP limits, publishing, and collaborations

## Testing
- `pytest backend/tests/albums -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41c6227ac8325be8779c2fcefa699