### PR TITLE
feat: expand negotiation clauses

### DIFF
--- a/backend/models/label_management_models.py
+++ b/backend/models/label_management_models.py
@@ -54,6 +54,10 @@ class ClauseTemplate:
 DEFAULT_CLAUSES = [
     ClauseTemplate("advance_cents", "Upfront payment to the band", 0),
     ClauseTemplate("royalty_rate", "Revenue percentage for the band", 0.0),
+    ClauseTemplate("marketing_budget_cents", "Label-funded marketing spend", 0),
+    ClauseTemplate("distribution_fee_rate", "Percentage fee for distribution services", 0.0),
+    ClauseTemplate("rights_reversion_months", "Months until rights revert to the band", 0),
+    ClauseTemplate("release_commitment", "Minimum releases label commits to", 0),
 ]
 
 

--- a/backend/models/record_contract.py
+++ b/backend/models/record_contract.py
@@ -23,3 +23,7 @@ class RecordContract:
     recoupable_budgets_cents: int = 0
     options: List[str] = field(default_factory=list)
     obligations: List[str] = field(default_factory=list)
+    marketing_budget_cents: int = 0
+    distribution_fee_rate: float = 0.0
+    rights_reversion_months: int = 0
+    release_commitment: int = 0

--- a/backend/routes/contract_routes.py
+++ b/backend/routes/contract_routes.py
@@ -1,9 +1,9 @@
 # Routes for contract negotiations.
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
 
 from backend.services.contract_negotiation_service import ContractNegotiationService
+from pydantic import BaseModel, Field
 
 router = APIRouter(prefix="/contracts", tags=["Contracts"])
 
@@ -11,26 +11,37 @@ svc = ContractNegotiationService()
 svc.economy.ensure_schema()
 
 
+class ContractTerms(BaseModel):
+    """Supported negotiable clauses."""
+
+    advance_cents: int = Field(0, description="Upfront payment to the band")
+    royalty_rate: float = Field(0.0, description="Revenue percentage for the band")
+    marketing_budget_cents: int = Field(0, description="Label-funded marketing spend")
+    distribution_fee_rate: float = Field(0.0, description="Percentage fee for distribution services")
+    rights_reversion_months: int = Field(0, description="Months until rights revert to the band")
+    release_commitment: int = Field(0, description="Minimum releases label commits to")
+
+
 class OfferIn(BaseModel):
     label_id: int
     band_id: int
-    terms: dict
+    terms: ContractTerms
 
 
 class CounterIn(BaseModel):
-    terms: dict
+    terms: ContractTerms
 
 
 @router.post("/offer")
 def create_offer(payload: OfferIn):
-    negotiation = svc.create_offer(payload.label_id, payload.band_id, payload.terms)
+    negotiation = svc.create_offer(payload.label_id, payload.band_id, payload.terms.dict())
     return negotiation.__dict__
 
 
 @router.post("/{negotiation_id}/counter")
 def counter_offer(negotiation_id: int, payload: CounterIn):
     try:
-        negotiation = svc.counter_offer(negotiation_id, payload.terms)
+        negotiation = svc.counter_offer(negotiation_id, payload.terms.dict())
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     return negotiation.__dict__


### PR DESCRIPTION
## Summary
- add marketing, distribution, reversion, and release clauses with defaults
- validate new clauses in contract negotiation service
- expose clause fields via API models for docs

## Testing
- `pytest` *(fails: 31 errors)*
- `ruff check backend/routes/contract_routes.py backend/services/contract_negotiation_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68b41dca32d88325a21970243d5cf9fc