### PR TITLE
Add arrangement track management and planning UI

### DIFF
--- a/backend/models/arrangement.py
+++ b/backend/models/arrangement.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ArrangementTrack:
+    id: int
+    song_id: int
+    track_type: str
+    performer: Optional[str] = None
+    notes: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "song_id": self.song_id,
+            "track_type": self.track_type,
+            "performer": self.performer,
+            "notes": self.notes,
+        }
+
+
+__all__ = ["ArrangementTrack"]

--- a/backend/models/song.py
+++ b/backend/models/song.py
@@ -2,6 +2,8 @@
 from datetime import datetime
 from typing import List, Optional
 
+from backend.models.arrangement import ArrangementTrack
+
 
 class Song:
     def __init__(
@@ -18,6 +20,7 @@ class Song:
         release_date: Optional[str] = None,
         format: str = "digital",
         royalties_split: Optional[dict] = None,
+        arrangement: Optional[List[ArrangementTrack]] = None,
     ) -> None:
         self.id = id
         self.title = title
@@ -31,6 +34,10 @@ class Song:
         self.release_date = release_date or datetime.utcnow().isoformat()
         self.format = format
         self.royalties_split = royalties_split or {owner_band_id: 100}
+        self.arrangement = arrangement or []
 
     def to_dict(self):
-        return self.__dict__
+        data = self.__dict__.copy()
+        if self.arrangement:
+            data["arrangement"] = [a.__dict__ for a in self.arrangement]
+        return data

--- a/backend/services/arrangement_service.py
+++ b/backend/services/arrangement_service.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from backend.models.arrangement import ArrangementTrack
+from backend.models.song import Song
+from backend.services.recording_service import RecordingService, recording_service
+
+
+class ArrangementService:
+    """Manage arrangement tracks for songs and integrate with recording sessions."""
+
+    def __init__(self, recording: Optional[RecordingService] = None) -> None:
+        self.recording = recording or recording_service
+        self._tracks: Dict[int, ArrangementTrack] = {}
+        self._songs: Dict[int, Song] = {}
+        self._id_seq = 1
+
+    # CRUD operations -------------------------------------------------
+    def add_track(
+        self,
+        song: Song,
+        track_type: str,
+        performer: Optional[str] = None,
+        notes: str = "",
+    ) -> ArrangementTrack:
+        """Add a new arrangement track to a song."""
+
+        track = ArrangementTrack(
+            id=self._id_seq,
+            song_id=song.id,
+            track_type=track_type,
+            performer=performer,
+            notes=notes,
+        )
+        self._tracks[track.id] = track
+        self._songs.setdefault(song.id, song).arrangement.append(track)
+        self._id_seq += 1
+        return track
+
+    def get_track(self, track_id: int) -> Optional[ArrangementTrack]:
+        return self._tracks.get(track_id)
+
+    def list_tracks(self, song_id: int) -> List[ArrangementTrack]:
+        song = self._songs.get(song_id)
+        return list(song.arrangement) if song else []
+
+    def update_track(
+        self,
+        track_id: int,
+        *,
+        track_type: Optional[str] = None,
+        performer: Optional[str] = None,
+        notes: Optional[str] = None,
+    ) -> ArrangementTrack:
+        track = self._tracks.get(track_id)
+        if not track:
+            raise KeyError("track_not_found")
+        if track_type is not None:
+            track.track_type = track_type
+        if performer is not None:
+            track.performer = performer
+        if notes is not None:
+            track.notes = notes
+        return track
+
+    def delete_track(self, track_id: int) -> None:
+        track = self._tracks.pop(track_id, None)
+        if not track:
+            return
+        song = self._songs.get(track.song_id)
+        if song:
+            song.arrangement = [t for t in song.arrangement if t.id != track_id]
+
+    # Integration with recording sessions -----------------------------
+    def schedule_recording_session(
+        self,
+        song_id: int,
+        band_id: int,
+        studio: str,
+        start: str,
+        end: str,
+        cost_cents: int,
+    ):
+        """Schedule a recording session using a song's arrangement tracks."""
+
+        tracks = [t.id for t in self.list_tracks(song_id)]
+        return self.recording.schedule_session(
+            band_id=band_id,
+            studio=studio,
+            start=start,
+            end=end,
+            tracks=tracks,
+            cost_cents=cost_cents,
+        )
+
+
+arrangement_service = ArrangementService()
+
+__all__ = ["ArrangementService", "arrangement_service"]

--- a/backend/tests/services/test_arrangement_service.py
+++ b/backend/tests/services/test_arrangement_service.py
@@ -1,0 +1,37 @@
+from backend.models.song import Song
+from backend.services.arrangement_service import ArrangementService
+from backend.services.recording_service import RecordingService
+from backend.services.economy_service import EconomyService
+
+
+def test_arrangement_tracks_feed_recording(tmp_path):
+    econ = EconomyService(db_path=tmp_path / "econ.db")
+    econ.ensure_schema()
+    econ.deposit(1, 10_000)
+    recording = RecordingService(economy=econ)
+    service = ArrangementService(recording=recording)
+
+    song = Song(
+        id=10,
+        title="Test",
+        duration_sec=180,
+        genre_id=None,
+        lyrics="",
+        owner_band_id=1,
+    )
+
+    t1 = service.add_track(song, "guitar", "Alice")
+    t2 = service.add_track(song, "drums", "Bob")
+
+    tracks = service.list_tracks(song.id)
+    assert [t.id for t in tracks] == [t1.id, t2.id]
+
+    session = service.schedule_recording_session(
+        song_id=song.id,
+        band_id=1,
+        studio="Studio A",
+        start="2024-01-01T00:00",
+        end="2024-01-01T02:00",
+        cost_cents=5_000,
+    )
+    assert set(session.track_statuses.keys()) == {t1.id, t2.id}

--- a/frontend/pages/arrangement_form.html
+++ b/frontend/pages/arrangement_form.html
@@ -1,0 +1,21 @@
+<h2>Plan Arrangement</h2>
+<form id="arrangementForm">
+  <input type="number" name="song_id" placeholder="Song ID" required />
+  <input type="text" name="track_type" placeholder="Instrument" required />
+  <input type="text" name="performer" placeholder="Performer" />
+  <textarea name="notes" placeholder="Notes"></textarea>
+  <button type="submit">Add Track</button>
+</form>
+
+<div id="trackList"></div>
+<script>
+  document.getElementById('arrangementForm').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const data = new FormData(e.target);
+    const div = document.getElementById('trackList');
+    const item = document.createElement('div');
+    item.textContent = `${data.get('track_type')} - ${data.get('performer')}`;
+    div.appendChild(item);
+    e.target.reset();
+  });
+</script>


### PR DESCRIPTION
## Summary
- add `ArrangementTrack` model and track list on `Song`
- implement arrangement service with CRUD and recording session integration
- add arrangement planning form to frontend
- cover arrangement workflow with tests

## Testing
- `pytest backend/tests/services/test_arrangement_service.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic.fields'; ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68b42010401883259ef20d309dfe4519