### PR TITLE
Add lyric originality checks and copyright registration

### DIFF
--- a/backend/models/lyric_hash.py
+++ b/backend/models/lyric_hash.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class LyricHash:
+    """Persisted hash of song lyrics for originality checks."""
+
+    id: int
+    song_id: int
+    hash: str
+    created_at: datetime = field(default_factory=datetime.utcnow)

--- a/backend/models/song.py
+++ b/backend/models/song.py
@@ -18,6 +18,7 @@ class Song:
         release_date: Optional[str] = None,
         format: str = "digital",
         royalties_split: Optional[dict] = None,
+        plagiarism_warning: Optional[str] = None,
     ) -> None:
         self.id = id
         self.title = title
@@ -31,6 +32,7 @@ class Song:
         self.release_date = release_date or datetime.utcnow().isoformat()
         self.format = format
         self.royalties_split = royalties_split or {owner_band_id: 100}
+        self.plagiarism_warning = plagiarism_warning
 
     def to_dict(self):
         return self.__dict__

--- a/backend/models/songwriting.py
+++ b/backend/models/songwriting.py
@@ -26,5 +26,6 @@ class LyricDraft:
     lyrics: str
     chord_progression: str
     album_art_url: Optional[str] = None
+    plagiarism_warning: Optional[str] = None
     created_at: datetime = field(default_factory=datetime.utcnow)
     metadata: GenerationMetadata = field(default_factory=GenerationMetadata)

--- a/backend/services/originality_service.py
+++ b/backend/services/originality_service.py
@@ -1,0 +1,30 @@
+"""Simple in-memory originality checker for lyrics."""
+from __future__ import annotations
+
+import hashlib
+from typing import Dict, Tuple
+
+from backend.models.lyric_hash import LyricHash
+
+
+class OriginalityService:
+    """Hashes lyrics and detects duplicates."""
+
+    def __init__(self) -> None:
+        self._hashes: Dict[str, LyricHash] = {}
+        self._counter = 1
+
+    def register_lyrics(self, lyrics: str, song_id: int) -> Tuple[LyricHash, bool]:
+        """Store hash for lyrics and indicate if it already existed."""
+
+        digest = hashlib.sha256(lyrics.encode("utf-8")).hexdigest()
+        existing = self._hashes.get(digest)
+        if existing:
+            return existing, True
+        record = LyricHash(id=self._counter, song_id=song_id, hash=digest)
+        self._hashes[digest] = record
+        self._counter += 1
+        return record, False
+
+
+originality_service = OriginalityService()

--- a/backend/services/songwriting_service.py
+++ b/backend/services/songwriting_service.py
@@ -8,6 +8,14 @@ from typing import Protocol
 from backend.models.song import Song
 from backend.models.songwriting import LyricDraft
 from backend.services.ai_art_service import AIArtService, ai_art_service
+from backend.services.originality_service import (
+    OriginalityService,
+    originality_service,
+)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from backend.services.legal_service import LegalService
 
 
 class _Message:
@@ -36,15 +44,25 @@ class SongwritingService:
         self,
         llm_client: Optional[LLMProvider] = None,
         art_service: Optional[AIArtService] = None,
+        originality: Optional[OriginalityService] = None,
+        legal: Optional[LegalService] = None,
     ) -> None:
         self.llm = llm_client or EchoLLM()
         self.art_service = art_service or ai_art_service
+        self.originality = originality or originality_service
+        self.legal = legal
         self._drafts: Dict[int, LyricDraft] = {}
         self._songs: Dict[int, Song] = {}
         self._counter = 1
 
     async def generate_draft(
-        self, creator_id: int, title: str, genre: str, themes: List[str]
+        self,
+        creator_id: int,
+        title: str,
+        genre: str,
+        themes: List[str],
+        *,
+        register_copyright: bool = False,
     ) -> LyricDraft:
         """Generate lyrics, chords and album art for a song idea."""
 
@@ -68,6 +86,12 @@ class SongwritingService:
         except Exception:
             art_url = None
 
+        record, duplicate = self.originality.register_lyrics(lyrics, self._counter)
+        warning = "possible_plagiarism" if duplicate else None
+        if duplicate and self.legal:
+            # log dispute for record keeping
+            self.legal.create_case(0, creator_id, f"duplicate_lyrics:{record.hash}")
+
         draft = LyricDraft(
             id=self._counter,
             creator_id=creator_id,
@@ -77,6 +101,7 @@ class SongwritingService:
             lyrics=lyrics,
             chord_progression=chord_progression,
             album_art_url=art_url,
+            plagiarism_warning=warning,
         )
         self._drafts[draft.id] = draft
         song = Song(
@@ -89,8 +114,13 @@ class SongwritingService:
             chord_progression=chord_progression,
             album_art_url=art_url,
             owner_band_id=creator_id,
+            plagiarism_warning=warning,
         )
         self._songs[draft.id] = song
+
+        if register_copyright and self.legal:
+            self.legal.register_copyright(song.id, lyrics)
+
         self._counter += 1
         return draft
 


### PR DESCRIPTION
## Summary
- Add lyric hash model and in-memory originality service
- Flag duplicate lyrics with plagiarism warnings and register copyrights via legal service
- Cover originality and registration behaviors with tests

## Testing
- `pytest backend/tests/songwriting/test_songwriting_service.py -q`
- `pytest -q` *(fails: No module named 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_68b42011f5b08325ad7558b00406f7bc