### PR TITLE
feat(modding): add plugin activation management

### DIFF
--- a/backend/routes/admin_modding_routes.py
+++ b/backend/routes/admin_modding_routes.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from backend.modding.loader import PluginLoader
+
+router = APIRouter(prefix="/modding", tags=["AdminModding"])
+
+# In-memory loader instance for managing plugins
+plugin_loader = PluginLoader()
+
+
+@router.get("/plugins")
+def list_plugins() -> list[dict[str, str | bool | None]]:
+    """Return metadata for all registered plugins."""
+
+    return plugin_loader.list_plugins()
+
+
+@router.post("/plugins/{name}/enable")
+def enable_plugin(name: str) -> dict[str, str]:
+    """Enable a plugin by name."""
+
+    try:
+        plugin_loader.enable(name)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Plugin not found")
+    return {"status": "enabled"}
+
+
+@router.post("/plugins/{name}/disable")
+def disable_plugin(name: str) -> dict[str, str]:
+    """Disable a plugin by name."""
+
+    try:
+        plugin_loader.disable(name)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Plugin not found")
+    return {"status": "disabled"}

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -8,6 +8,7 @@ from .admin_business_routes import router as business_router
 from .admin_economy_routes import router as economy_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
+from .admin_modding_routes import router as modding_router
 from .admin_monitoring_routes import router as monitoring_router
 from .admin_music_routes import router as music_router
 from .admin_npc_routes import router as npc_router
@@ -28,6 +29,7 @@ router.include_router(xp_event_router)
 router.include_router(jobs_router)
 router.include_router(media_router)
 router.include_router(monitoring_router)
+router.include_router(modding_router)
 router.include_router(npc_router)
 router.include_router(quest_router)
 router.include_router(schema_router)

--- a/backend/tests/modding/test_plugin_loader.py
+++ b/backend/tests/modding/test_plugin_loader.py
@@ -1,24 +1,44 @@
-import sys
-
 from backend.modding.loader import PluginLoader
-from backend.modding.interfaces import PluginMeta
 
 
-def test_plugin_registration(tmp_path, monkeypatch):
+def _create_plugin(tmp_path, monkeypatch, extra_code: str = ""):
     plugin_code = (
         "from backend.modding.interfaces import PluginMeta\n"
         "class Sample:\n"
         "    meta = PluginMeta(name='sample', version='1.0', author='tester')\n"
         "    activated = False\n"
+        "    deactivated = False\n"
         "    def activate(self):\n"
         "        self.activated = True\n"
+        "    def deactivate(self):\n"
+        "        self.deactivated = True\n"
+        f"{extra_code}\n"
         "plugin = Sample()\n"
     )
     mod = tmp_path / "myplugin.py"
     mod.write_text(plugin_code)
     monkeypatch.syspath_prepend(str(tmp_path))
 
+
+def test_plugin_registration_and_enable(tmp_path, monkeypatch):
+    _create_plugin(tmp_path, monkeypatch)
+
     loader = PluginLoader()
     loader.load_from_modules(["myplugin"])
     assert "sample" in loader.plugins
+    # plugin should not be enabled until explicitly enabled
+    assert loader.registry["sample"].enabled is False
+    loader.enable("sample")
+    assert loader.registry["sample"].enabled is True
     assert loader.plugins["sample"].activated is True
+
+
+def test_plugin_disable(tmp_path, monkeypatch):
+    _create_plugin(tmp_path, monkeypatch)
+
+    loader = PluginLoader()
+    loader.load_from_modules(["myplugin"])
+    loader.enable("sample")
+    loader.disable("sample")
+    assert loader.registry["sample"].enabled is False
+    assert loader.plugins["sample"].deactivated is True

--- a/frontend/src/admin/App.tsx
+++ b/frontend/src/admin/App.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Sidebar from './components/Sidebar';
 import { AuditTable } from './audit';
 import { MonitoringWidget } from './monitoring';
+import { PluginManager } from './modding';
 import XPEventForm from './components/XPEventForm';
 import XPItemForm from './components/XPItemForm';
 
@@ -23,6 +24,8 @@ const App: React.FC = () => {
     content = <XPEventForm />;
   } else if (path.includes('/admin/xp-items')) {
     content = <XPItemForm />;
+  } else if (path.includes('/admin/modding')) {
+    content = <PluginManager />;
   }
 
   return (

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -14,6 +14,7 @@ const navItems: NavItem[] = [
   { label: 'XP Items', href: '/admin/xp-items' },
   { label: 'Venues', href: '/admin/venues' },
   { label: 'Audit Logs', href: '/admin/audit' },
+  { label: 'Modding', href: '/admin/modding' },
 ];
 
 const Sidebar: React.FC = () => (

--- a/frontend/src/admin/modding/PluginManager.tsx
+++ b/frontend/src/admin/modding/PluginManager.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+
+interface PluginInfo {
+  name: string;
+  version: string;
+  author?: string | null;
+  enabled: boolean;
+}
+
+const PluginManager: React.FC = () => {
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+
+  const load = async () => {
+    try {
+      const res = await fetch('/admin/modding/plugins');
+      const data = await res.json();
+      setPlugins(data);
+    } catch {
+      // swallow errors for now
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const toggle = async (name: string, enabled: boolean) => {
+    const action = enabled ? 'disable' : 'enable';
+    await fetch(`/admin/modding/plugins/${name}/${action}`, { method: 'POST' });
+    load();
+  };
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-xl font-semibold mb-4">Plugins</h2>
+      <ul>
+        {plugins.map((p) => (
+          <li key={p.name} className="flex items-center justify-between mb-2">
+            <span>
+              {p.name} v{p.version}
+              {p.author ? ` by ${p.author}` : ''}
+            </span>
+            <button
+              className="px-2 py-1 bg-blue-500 text-white rounded"
+              onClick={() => toggle(p.name, p.enabled)}
+            >
+              {p.enabled ? 'Disable' : 'Enable'}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default PluginManager;

--- a/frontend/src/admin/modding/index.ts
+++ b/frontend/src/admin/modding/index.ts
@@ -1,0 +1,1 @@
+export { default as PluginManager } from './PluginManager';


### PR DESCRIPTION
## Summary
- track plugin metadata and activation state
- expose admin APIs for listing and toggling plugins
- add admin UI for managing plugins

## Testing
- `ruff check backend/modding/loader.py backend/routes/admin_modding_routes.py backend/routes/admin_routes.py backend/tests/modding/test_plugin_loader.py`
- `pytest backend/tests/modding/test_plugin_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47e7177348325beae1548d8bff2c8