### PR TITLE
Add generic item model and admin endpoints

### DIFF
--- a/backend/models/item.py
+++ b/backend/models/item.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+
+@dataclass
+class ItemCategory:
+    """Simple item category descriptor."""
+
+    name: str
+    description: str = ""
+
+
+@dataclass
+class Item:
+    """Generic inventory item with arbitrary stats."""
+
+    id: Optional[int]
+    name: str
+    category: str
+    stats: Dict[str, float] = field(default_factory=dict)
+
+
+__all__ = ["ItemCategory", "Item"]

--- a/backend/routes/admin_item_routes.py
+++ b/backend/routes/admin_item_routes.py
@@ -1,0 +1,74 @@
+"""Admin routes for managing generic items."""
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.models.item import Item
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.item_service import ItemService, item_service
+from pydantic import BaseModel
+
+router = APIRouter(
+    prefix="/items", tags=["AdminItems"], dependencies=[Depends(audit_dependency)]
+)
+svc: ItemService = item_service
+
+
+class ItemIn(BaseModel):
+    name: str
+    category: str
+    stats: dict[str, float] = {}
+
+
+@router.get("/")
+async def list_items(req: Request) -> list[Item]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    return svc.list_items()
+
+
+@router.post("/")
+async def create_item(payload: ItemIn, req: Request) -> Item:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    item = Item(id=None, **payload.dict())
+    return svc.create_item(item)
+
+
+@router.put("/{item_id}")
+async def update_item(item_id: int, payload: ItemIn, req: Request) -> Item:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    try:
+        return svc.update_item(item_id, **payload.dict())
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.delete("/{item_id}")
+async def delete_item(item_id: int, req: Request) -> dict[str, str]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    svc.delete_item(item_id)
+    return {"status": "deleted"}
+
+
+class InventoryIn(BaseModel):
+    quantity: int = 1
+
+
+@router.post("/{item_id}/give/{user_id}")
+async def give_item(item_id: int, user_id: int, payload: InventoryIn, req: Request) -> dict[str, str]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    try:
+        svc.add_to_inventory(user_id, item_id, payload.quantity)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return {"status": "ok"}
+
+
+@router.get("/inventory/{user_id}")
+async def get_inventory(user_id: int, req: Request) -> dict[int, int]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    return svc.get_inventory(user_id)

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -6,6 +6,7 @@ from .admin_analytics_routes import router as analytics_router
 from .admin_audit_routes import router as audit_router
 from .admin_business_routes import router as business_router
 from .admin_economy_routes import router as economy_router
+from .admin_item_routes import router as item_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
 from .admin_modding_routes import router as modding_router
@@ -33,6 +34,7 @@ router.include_router(modding_router)
 router.include_router(npc_router)
 router.include_router(quest_router)
 router.include_router(schema_router)
+router.include_router(item_router)
 router.include_router(venue_router)
 router.include_router(music_router)
 

--- a/backend/routes/admin_schema_routes.py
+++ b/backend/routes/admin_schema_routes.py
@@ -2,8 +2,8 @@ from datetime import datetime
 from typing import Any, Dict, List, Literal
 
 from auth.dependencies import get_current_user_id, require_role
-
 from fastapi import APIRouter, Request
+
 from pydantic import BaseModel
 
 
@@ -54,6 +54,12 @@ class XPItemSchema(BaseModel):
     duration: int
 
 
+class ItemSchema(BaseModel):
+    name: str
+    category: str
+    stats: Dict[str, float] = {}
+
+
 router = APIRouter(prefix="/schema", tags=["AdminSchema"])
 
 
@@ -96,3 +102,9 @@ async def xp_event_schema(req: Request) -> Dict[str, Any]:
 async def xp_item_schema(req: Request) -> Dict[str, Any]:
     await _ensure_admin(req)
     return XPItemSchema.model_json_schema()
+
+
+@router.get("/item")
+async def item_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return ItemSchema.model_json_schema()

--- a/backend/services/item_service.py
+++ b/backend/services/item_service.py
@@ -1,0 +1,85 @@
+"""Service layer for generic items and inventories."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Dict, List
+
+from backend.models.item import Item, ItemCategory
+
+
+class ItemService:
+    """In-memory management of items and inventories."""
+
+    def __init__(self) -> None:
+        self._items: Dict[int, Item] = {}
+        self._categories: Dict[str, ItemCategory] = {}
+        self._inventories: Dict[int, Dict[int, int]] = {}
+        self._id_seq = 1
+
+    # ------------------------------------------------------------------
+    # Category operations
+    # ------------------------------------------------------------------
+    def list_categories(self) -> List[ItemCategory]:
+        return list(self._categories.values())
+
+    def create_category(self, category: ItemCategory) -> ItemCategory:
+        self._categories[category.name] = category
+        return category
+
+    def delete_category(self, name: str) -> None:
+        self._categories.pop(name, None)
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def list_items(self) -> List[Item]:
+        return list(self._items.values())
+
+    def create_item(self, item: Item) -> Item:
+        item.id = self._id_seq
+        self._items[item.id] = item
+        self._id_seq += 1
+        return item
+
+    def update_item(self, item_id: int, **changes) -> Item:
+        itm = self._items.get(item_id)
+        if not itm:
+            raise ValueError("Item not found")
+        for k, v in changes.items():
+            if hasattr(itm, k) and v is not None:
+                setattr(itm, k, v)
+        return itm
+
+    def delete_item(self, item_id: int) -> None:
+        self._items.pop(item_id, None)
+        for inv in self._inventories.values():
+            inv.pop(item_id, None)
+
+    # ------------------------------------------------------------------
+    # Inventory management
+    # ------------------------------------------------------------------
+    def add_to_inventory(self, user_id: int, item_id: int, quantity: int = 1) -> None:
+        if item_id not in self._items:
+            raise ValueError("invalid item")
+        inv = self._inventories.setdefault(user_id, {})
+        inv[item_id] = inv.get(item_id, 0) + quantity
+
+    def remove_from_inventory(self, user_id: int, item_id: int, quantity: int = 1) -> None:
+        inv = self._inventories.get(user_id, {})
+        if inv.get(item_id, 0) < quantity:
+            raise ValueError("not enough items")
+        inv[item_id] -= quantity
+        if inv[item_id] <= 0:
+            del inv[item_id]
+
+    def get_inventory(self, user_id: int) -> Dict[int, int]:
+        return dict(self._inventories.get(user_id, {}))
+
+    # helper for routes
+    def asdict(self, item: Item) -> Dict:
+        return asdict(item)
+
+
+item_service = ItemService()
+
+__all__ = ["ItemService", "item_service"]

--- a/frontend/src/admin/components/ItemForm.tsx
+++ b/frontend/src/admin/components/ItemForm.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import SchemaForm from './SchemaForm';
+
+const ItemForm: React.FC = () => (
+  <SchemaForm schemaUrl="/admin/schema/item" submitUrl="/admin/items" />
+);
+
+export default ItemForm;


### PR DESCRIPTION
## Summary
- add Item and ItemCategory dataclasses to support categories and stats
- implement ItemService for CRUD and inventory management
- expose admin item routes and schema, plus UI form

## Testing
- `ruff check backend/routes/admin_item_routes.py backend/services/item_service.py backend/models/item.py backend/routes/admin_schema_routes.py backend/routes/admin_routes.py`
- `mypy backend/models/item.py backend/services/item_service.py backend/routes/admin_item_routes.py backend/routes/admin_schema_routes.py backend/routes/admin_routes.py --follow-imports=skip`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic.fields'; missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b47fa50ac08325af197fe268fbaa91