### PR TITLE
Add structured setlist and encore handling to gig simulation

### DIFF
--- a/backend/schemas/live_performance.py
+++ b/backend/schemas/live_performance.py
@@ -1,11 +1,23 @@
+from enum import Enum
 from pydantic import BaseModel
 from typing import List, Optional
 from datetime import date
 
+
+class PerformanceActionType(str, Enum):
+    song = "song"
+    activity = "activity"
+    encore = "encore"
+
+
 class PerformanceActionSchema(BaseModel):
-    type: str
+    type: PerformanceActionType
     reference: Optional[str]
     description: Optional[str]
+    duration: Optional[int] = None
+    position: Optional[int] = None
+    encore: Optional[bool] = False
+
 
 class LivePerformanceCreate(BaseModel):
     band_id: int
@@ -13,7 +25,9 @@ class LivePerformanceCreate(BaseModel):
     performance_type: str
     date: date
     setlist: List[PerformanceActionSchema]
+    encore: Optional[List[PerformanceActionSchema]] = None
     is_solo: bool
+
 
 class LivePerformanceResponse(LivePerformanceCreate):
     id: int
@@ -22,3 +36,4 @@ class LivePerformanceResponse(LivePerformanceCreate):
     fame_gain: float
     skill_gain: float
     revenue: float
+

--- a/backend/tests/city/test_city_trends.py
+++ b/backend/tests/city/test_city_trends.py
@@ -49,7 +49,7 @@ def test_city_trends_affect_merch_sales(monkeypatch):
     monkeypatch.setattr(event_service, "DB_PATH", ":memory:")
     monkeypatch.setattr(event_service.sqlite3, "connect", lambda _: conn)
 
-    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", ["song"])
+    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", [{"type": "song", "reference": "song"}])
     assert result["crowd_size"] == 300  # 200 base * 1.5 modifier
     assert result["merch_sold"] == 90   # 300 * 0.15 * 2.0
 

--- a/backend/tests/live_performance/test_setlist_structure.py
+++ b/backend/tests/live_performance/test_setlist_structure.py
@@ -1,0 +1,36 @@
+import sqlite3
+
+from backend.services import live_performance_service
+from backend.services.city_service import city_service
+from backend.models.city import City
+
+
+def test_simulate_gig_parses_structured_setlist(monkeypatch):
+    city_service.cities.clear()
+    city_service.add_city(City(name="Metro", population=1_000_000, style_preferences={}, event_modifier=1.0, market_index=1.0))
+
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE bands (id INTEGER PRIMARY KEY, fame INTEGER, skill REAL, revenue INTEGER)")
+    cur.execute(
+        "CREATE TABLE live_performances (band_id INTEGER, city TEXT, venue TEXT, date TEXT, setlist TEXT, crowd_size INTEGER, fame_earned INTEGER, revenue_earned INTEGER, skill_gain REAL, merch_sold INTEGER)"
+    )
+    cur.execute("INSERT INTO bands (id, fame, skill, revenue) VALUES (1, 100, 0, 0)")
+
+    monkeypatch.setattr(live_performance_service, "DB_PATH", ":memory:")
+    monkeypatch.setattr(live_performance_service.sqlite3, "connect", lambda _: conn)
+    monkeypatch.setattr(live_performance_service.random, "randint", lambda a, b: a)
+    monkeypatch.setattr(live_performance_service.gear_service, "get_band_bonus", lambda band_id, name: 0)
+    monkeypatch.setattr(live_performance_service, "is_skill_blocked", lambda band_id, skill_id: False)
+
+    setlist = [
+        {"type": "song", "reference": "1"},
+        {"type": "activity", "description": "banter"},
+        {"type": "song", "reference": "2", "encore": True},
+    ]
+
+    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", setlist)
+
+    assert result["fame_earned"] == 28
+    assert result["skill_gain"] == 0.7
+

--- a/frontend/pages/gig_simulator.html
+++ b/frontend/pages/gig_simulator.html
@@ -1,17 +1,84 @@
-
 <h2>Live Gig Simulator</h2>
 
 <form id="gigForm">
   <input type="text" name="band_id" placeholder="Band ID" required />
   <input type="text" name="city" placeholder="City" required />
   <input type="text" name="venue" placeholder="Venue" required />
-  <input type="text" name="setlist" placeholder="Song IDs (comma-separated)" required />
+
+  <div id="setlistSection">
+    <h3>Setlist</h3>
+    <ul id="setlist"></ul>
+    <button type="button" id="addSong">Add Song</button>
+    <button type="button" id="addActivity">Add Activity</button>
+  </div>
+
   <button type="submit">Simulate Gig</button>
 </form>
 
 <pre id="resultBox"></pre>
 
 <script>
+const actions = [];
+
+function renderSetlist() {
+  const list = document.getElementById('setlist');
+  list.innerHTML = '';
+  actions.forEach((a, idx) => {
+    const li = document.createElement('li');
+    li.textContent = `${a.type}: ${a.reference || a.description || ''}`;
+    if (a.encore) li.textContent += ' (Encore)';
+
+    const up = document.createElement('button');
+    up.textContent = '↑';
+    up.type = 'button';
+    up.onclick = () => {
+      if (idx > 0) {
+        [actions[idx - 1], actions[idx]] = [actions[idx], actions[idx - 1]];
+        renderSetlist();
+      }
+    };
+
+    const down = document.createElement('button');
+    down.textContent = '↓';
+    down.type = 'button';
+    down.onclick = () => {
+      if (idx < actions.length - 1) {
+        [actions[idx + 1], actions[idx]] = [actions[idx], actions[idx + 1]];
+        renderSetlist();
+      }
+    };
+
+    const encore = document.createElement('input');
+    encore.type = 'checkbox';
+    encore.checked = a.encore;
+    encore.onchange = (e) => { a.encore = e.target.checked; };
+    const label = document.createElement('label');
+    label.appendChild(encore);
+    label.appendChild(document.createTextNode('Encore'));
+
+    li.appendChild(up);
+    li.appendChild(down);
+    li.appendChild(label);
+    list.appendChild(li);
+  });
+}
+
+document.getElementById('addSong').addEventListener('click', () => {
+  const ref = prompt('Song ID or name?');
+  if (ref) {
+    actions.push({ type: 'song', reference: ref, encore: false });
+    renderSetlist();
+  }
+});
+
+document.getElementById('addActivity').addEventListener('click', () => {
+  const desc = prompt('Activity description?');
+  if (desc) {
+    actions.push({ type: 'activity', description: desc, encore: false });
+    renderSetlist();
+  }
+});
+
 document.getElementById('gigForm').addEventListener('submit', async (e) => {
   e.preventDefault();
   const formData = new FormData(e.target);
@@ -19,7 +86,7 @@ document.getElementById('gigForm').addEventListener('submit', async (e) => {
     band_id: parseInt(formData.get('band_id')),
     city: formData.get('city'),
     venue: formData.get('venue'),
-    setlist: formData.get('setlist').split(',').map(s => parseInt(s.trim()))
+    setlist: actions.map((a, i) => ({ ...a, position: i + 1 }))
   };
 
   const res = await fetch('/gigs/simulate', {
@@ -31,4 +98,7 @@ document.getElementById('gigForm').addEventListener('submit', async (e) => {
   const data = await res.json();
   document.getElementById('resultBox').innerText = JSON.stringify(data, null, 2);
 });
+
+renderSetlist();
 </script>
+


### PR DESCRIPTION
## Summary
- Expand live performance schemas with typed actions, optional metadata, and encore support
- Parse structured setlists in gig simulator with different bonuses and JSON persistence
- Add UI for building ordered setlists with activities and encore segments

## Testing
- `pytest` *(fails: Interrupted: 33 errors during collection)*
- `pytest backend/tests/live_performance/test_setlist_structure.py backend/tests/city/test_city_trends.py`


------
https://chatgpt.com/codex/tasks/task_e_68b486797ad08325a9aab3c422855c41