### PR TITLE
Support cover songs in services and live performances

### DIFF
--- a/backend/migrations/sql/095_add_original_song_id.sql
+++ b/backend/migrations/sql/095_add_original_song_id.sql
@@ -1,0 +1,9 @@
+-- 095_add_original_song_id.sql
+-- Adds original_song_id column to songs for tracking covers.
+-- Safe for SQLite.
+BEGIN TRANSACTION;
+
+ALTER TABLE songs ADD COLUMN original_song_id INTEGER REFERENCES songs(id);
+CREATE INDEX IF NOT EXISTS ix_songs_original_song ON songs(original_song_id);
+
+COMMIT;

--- a/backend/routes/song_routes.py
+++ b/backend/routes/song_routes.py
@@ -18,6 +18,11 @@ def create_song():
 def get_band_songs(band_id):
     return jsonify(song_service.list_songs_by_band(band_id))
 
+
+@song_routes.route('/songs/<int:song_id>/covers', methods=['GET'])
+def get_song_covers(song_id):
+    return jsonify(song_service.list_covers_of_song(song_id))
+
 @song_routes.route('/songs/<int:song_id>', methods=['PUT'])
 def update_song(song_id):
     updates = request.json

--- a/backend/services/live_performance_service.py
+++ b/backend/services/live_performance_service.py
@@ -47,7 +47,25 @@ def simulate_gig(band_id: int, city: str, venue: str, setlist) -> dict:
         a_type = action.get("type")
         if a_type == "song" or a_type == "encore":
             skill_gain += 0.3
-            fame_bonus += 2
+
+            song_bonus = 2
+            ref = action.get("reference")
+            if ref is not None:
+                ref_str = str(ref)
+                if ref_str.isdigit():
+                    song_id = int(ref_str)
+                    cur.execute("SELECT band_id FROM songs WHERE id = ?", (song_id,))
+                    row = cur.fetchone()
+                    if row:
+                        owner_band = row[0]
+                        if owner_band != band_id:
+                            song_bonus = 1
+                        cur.execute(
+                            "UPDATE songs SET play_count = play_count + ? WHERE id = ?",
+                            (2 if owner_band == band_id else 1, song_id),
+                        )
+
+            fame_bonus += song_bonus
         elif a_type == "activity":
             skill_gain += 0.1
             fame_bonus += 1

--- a/backend/services/song_service.py
+++ b/backend/services/song_service.py
@@ -1,67 +1,117 @@
 import sqlite3
+from typing import Dict, List, Optional
+
 from backend.database import DB_PATH
 
 
-def create_song(band_id: int, title: str, duration_sec: int, genre: str, royalties_split: dict) -> dict:
-    if sum(royalties_split.values()) != 100:
-        return {"error": "Royalties must sum to 100%"}
+class SongService:
+    """Service layer for CRUD operations on songs.
 
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
+    Supports creating cover songs via the ``original_song_id`` column and
+    listing covers of a given song.
+    """
 
-    cur.execute("""
-        INSERT INTO songs (band_id, title, duration_sec, genre, play_count)
-        VALUES (?, ?, ?, ?, 0)
-    """, (band_id, title, duration_sec, genre))
-    song_id = cur.lastrowid
+    def __init__(self, db: Optional[str] = None) -> None:
+        self.db = db or DB_PATH
 
-    for user_id, percent in royalties_split.items():
-        cur.execute("""
-            INSERT INTO royalties (song_id, user_id, percent)
-            VALUES (?, ?, ?)
-        """, (song_id, user_id, percent))
+    # ------------------------------------------------------------------
+    # Creation and queries
+    # ------------------------------------------------------------------
+    def create_song(self, data: Dict) -> Dict:
+        """Create a song.
 
-    conn.commit()
-    conn.close()
-    return {"status": "ok", "song_id": song_id}
+        ``data`` should contain ``band_id``, ``title``, ``duration_sec`` and
+        ``genre``.  ``royalties_split`` is optional and defaults to 100%% for the
+        owning band.  ``original_song_id`` can be provided to mark the song as a
+        cover of another song.
+        """
 
+        band_id = data["band_id"]
+        title = data["title"]
+        duration_sec = data["duration_sec"]
+        genre = data["genre"]
+        royalties_split = data.get("royalties_split", {band_id: 100})
+        original_song_id = data.get("original_song_id")
 
-def get_songs_by_band(band_id: int) -> list:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
+        if sum(royalties_split.values()) != 100:
+            raise ValueError("Royalties must sum to 100%")
 
-    cur.execute("""
-        SELECT id, title, duration_sec, genre, play_count
-        FROM songs
-        WHERE band_id = ?
-        ORDER BY id DESC
-    """, (band_id,))
-    songs = cur.fetchall()
-    conn.close()
+        conn = sqlite3.connect(self.db)
+        cur = conn.cursor()
 
-    return [dict(zip(["song_id", "title", "duration", "genre", "plays"], row)) for row in songs]
+        cur.execute(
+            """
+            INSERT INTO songs (band_id, title, duration_sec, genre, play_count, original_song_id)
+            VALUES (?, ?, ?, ?, 0, ?)
+            """,
+            (band_id, title, duration_sec, genre, original_song_id),
+        )
+        song_id = cur.lastrowid
 
+        for user_id, percent in royalties_split.items():
+            cur.execute(
+                """INSERT INTO royalties (song_id, user_id, percent) VALUES (?, ?, ?)""",
+                (song_id, user_id, percent),
+            )
 
-def update_song(song_id: int, updates: dict) -> dict:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
+        conn.commit()
+        conn.close()
+        return {"status": "ok", "song_id": song_id}
 
-    for field, value in updates.items():
-        cur.execute(f"UPDATE songs SET {field} = ? WHERE id = ?", (value, song_id))
+    def list_songs_by_band(self, band_id: int) -> List[Dict]:
+        conn = sqlite3.connect(self.db)
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT id, title, duration_sec, genre, play_count, original_song_id
+            FROM songs
+            WHERE band_id = ?
+            ORDER BY id DESC
+            """,
+            (band_id,),
+        )
+        rows = cur.fetchall()
+        conn.close()
+        return [
+            dict(
+                zip(
+                    ["song_id", "title", "duration", "genre", "plays", "original_song_id"],
+                    row,
+                )
+            )
+            for row in rows
+        ]
 
-    conn.commit()
-    conn.close()
-    return {"status": "ok", "message": "Song updated"}
+    def list_covers_of_song(self, song_id: int) -> List[Dict]:
+        """Return cover versions referencing ``song_id`` as original."""
+        conn = sqlite3.connect(self.db)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT id, band_id, title FROM songs WHERE original_song_id = ?",
+            (song_id,),
+        )
+        rows = cur.fetchall()
+        conn.close()
+        return [dict(zip(["song_id", "band_id", "title"], row)) for row in rows]
 
+    # ------------------------------------------------------------------
+    # Updates and deletion
+    # ------------------------------------------------------------------
+    def update_song(self, song_id: int, updates: Dict) -> Dict:
+        conn = sqlite3.connect(self.db)
+        cur = conn.cursor()
+        for field, value in updates.items():
+            cur.execute(f"UPDATE songs SET {field} = ? WHERE id = ?", (value, song_id))
+        conn.commit()
+        conn.close()
+        return {"status": "ok", "message": "Song updated"}
 
-def delete_song(song_id: int) -> dict:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-
-    cur.execute("DELETE FROM royalties WHERE song_id = ?", (song_id,))
-    cur.execute("DELETE FROM album_songs WHERE song_id = ?", (song_id,))
-    cur.execute("DELETE FROM songs WHERE id = ?", (song_id,))
-
-    conn.commit()
-    conn.close()
-    return {"status": "ok", "message": "Song deleted"}
+    def delete_song(self, song_id: int) -> Dict:
+        conn = sqlite3.connect(self.db)
+        cur = conn.cursor()
+        cur.execute("DELETE FROM royalties WHERE song_id = ?", (song_id,))
+        cur.execute("DELETE FROM album_songs WHERE song_id = ?", (song_id,))
+        cur.execute("DELETE FROM songs WHERE id = ?", (song_id,))
+        conn.commit()
+        conn.close()
+        return {"status": "ok", "message": "Song deleted"}

--- a/backend/tests/live_performance/test_setlist_structure.py
+++ b/backend/tests/live_performance/test_setlist_structure.py
@@ -5,20 +5,32 @@ from backend.services.city_service import city_service
 from backend.models.city import City
 
 
-def test_simulate_gig_parses_structured_setlist(monkeypatch):
+def test_simulate_gig_parses_structured_setlist(monkeypatch, tmp_path):
     city_service.cities.clear()
     city_service.add_city(City(name="Metro", population=1_000_000, style_preferences={}, event_modifier=1.0, market_index=1.0))
 
-    conn = sqlite3.connect(":memory:")
+    db_file = tmp_path / "gig.db"
+    conn = sqlite3.connect(db_file)
     cur = conn.cursor()
     cur.execute("CREATE TABLE bands (id INTEGER PRIMARY KEY, fame INTEGER, skill REAL, revenue INTEGER)")
     cur.execute(
         "CREATE TABLE live_performances (band_id INTEGER, city TEXT, venue TEXT, date TEXT, setlist TEXT, crowd_size INTEGER, fame_earned INTEGER, revenue_earned INTEGER, skill_gain REAL, merch_sold INTEGER)"
     )
+    cur.execute(
+        "CREATE TABLE songs (id INTEGER PRIMARY KEY, band_id INTEGER, title TEXT, duration_sec INTEGER, genre TEXT, play_count INTEGER, original_song_id INTEGER)"
+    )
     cur.execute("INSERT INTO bands (id, fame, skill, revenue) VALUES (1, 100, 0, 0)")
+    cur.executemany(
+        "INSERT INTO songs (id, band_id, title, duration_sec, genre, play_count, original_song_id) VALUES (?, ?, ?, 0, '', 0, NULL)",
+        [
+            (1, 1, 'Song A'),
+            (2, 1, 'Song B'),
+        ],
+    )
+    conn.commit()
+    conn.close()
 
-    monkeypatch.setattr(live_performance_service, "DB_PATH", ":memory:")
-    monkeypatch.setattr(live_performance_service.sqlite3, "connect", lambda _: conn)
+    monkeypatch.setattr(live_performance_service, "DB_PATH", db_file)
     monkeypatch.setattr(live_performance_service.random, "randint", lambda a, b: a)
     monkeypatch.setattr(live_performance_service.gear_service, "get_band_bonus", lambda band_id, name: 0)
     monkeypatch.setattr(live_performance_service, "is_skill_blocked", lambda band_id, skill_id: False)
@@ -34,3 +46,52 @@ def test_simulate_gig_parses_structured_setlist(monkeypatch):
     assert result["fame_earned"] == 28
     assert result["skill_gain"] == 0.7
 
+
+def test_cover_song_reduces_fame_and_boosts_original(monkeypatch, tmp_path):
+    city_service.cities.clear()
+    city_service.add_city(City(name="Metro", population=1_000_000, style_preferences={}, event_modifier=1.0, market_index=1.0))
+
+    db_file = tmp_path / "gig.db"
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE bands (id INTEGER PRIMARY KEY, fame INTEGER, skill REAL, revenue INTEGER)")
+    cur.execute(
+        "CREATE TABLE live_performances (band_id INTEGER, city TEXT, venue TEXT, date TEXT, setlist TEXT, crowd_size INTEGER, fame_earned INTEGER, revenue_earned INTEGER, skill_gain REAL, merch_sold INTEGER)"
+    )
+    cur.execute(
+        "CREATE TABLE songs (id INTEGER PRIMARY KEY, band_id INTEGER, title TEXT, duration_sec INTEGER, genre TEXT, play_count INTEGER, original_song_id INTEGER)"
+    )
+    cur.executemany(
+        "INSERT INTO bands (id, fame, skill, revenue) VALUES (?, ?, 0, 0)",
+        [(1, 100), (2, 50)],
+    )
+    cur.executemany(
+        "INSERT INTO songs (id, band_id, title, duration_sec, genre, play_count, original_song_id) VALUES (?, ?, ?, 0, '', 0, NULL)",
+        [
+            (1, 1, 'Song A'),
+            (2, 2, 'Song B'),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(live_performance_service, "DB_PATH", db_file)
+    monkeypatch.setattr(live_performance_service.random, "randint", lambda a, b: a)
+    monkeypatch.setattr(live_performance_service.gear_service, "get_band_bonus", lambda band_id, name: 0)
+    monkeypatch.setattr(live_performance_service, "is_skill_blocked", lambda band_id, skill_id: False)
+
+    setlist = [
+        {"type": "song", "reference": "1"},  # own song
+        {"type": "song", "reference": "2"},  # cover
+    ]
+
+    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", setlist)
+
+    assert result["fame_earned"] == 23
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute("SELECT play_count FROM songs WHERE id = 1")
+    assert cur.fetchone()[0] == 2
+    cur.execute("SELECT play_count FROM songs WHERE id = 2")
+    assert cur.fetchone()[0] == 1
+    conn.close()

--- a/backend/tests/services/test_song_service.py
+++ b/backend/tests/services/test_song_service.py
@@ -1,0 +1,46 @@
+import sqlite3
+
+from backend.services.song_service import SongService
+
+
+def setup_db(path):
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE songs (id INTEGER PRIMARY KEY AUTOINCREMENT, band_id INTEGER, title TEXT, duration_sec INTEGER, genre TEXT, play_count INTEGER, original_song_id INTEGER)"
+    )
+    cur.execute(
+        "CREATE TABLE royalties (id INTEGER PRIMARY KEY AUTOINCREMENT, song_id INTEGER, user_id INTEGER, percent INTEGER)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_create_cover_and_list(tmp_path):
+    db_path = tmp_path / "songs.db"
+    setup_db(db_path)
+    service = SongService(db=str(db_path))
+
+    original = {
+        "band_id": 1,
+        "title": "Original",
+        "duration_sec": 120,
+        "genre": "rock",
+        "royalties_split": {1: 100},
+    }
+    res = service.create_song(original)
+    orig_id = res["song_id"]
+
+    cover = {
+        "band_id": 2,
+        "title": "Cover",
+        "duration_sec": 120,
+        "genre": "rock",
+        "royalties_split": {2: 100},
+        "original_song_id": orig_id,
+    }
+    service.create_song(cover)
+
+    covers = service.list_covers_of_song(orig_id)
+    assert len(covers) == 1
+    assert covers[0]["band_id"] == 2


### PR DESCRIPTION
## Summary
- track original songs with `original_song_id` column
- allow creating/listing cover songs via `SongService` and REST endpoint
- adjust live gig simulation to award reduced fame for covers and bump original song popularity

## Testing
- `pytest backend/tests/services/test_song_service.py backend/tests/live_performance/test_setlist_structure.py backend/tests/city/test_city_trends.py::test_city_trends_affect_merch_sales -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4878f2cc8832598c6ec25ad29cb09