### PR TITLE
Add song popularity tracking and decay

### DIFF
--- a/backend/models/song_popularity.py
+++ b/backend/models/song_popularity.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class SongPopularity:
+    """Represents the popularity score of a song at a point in time."""
+
+    song_id: int
+    popularity_score: float
+    updated_at: datetime

--- a/backend/routes/music_metrics_routes.py
+++ b/backend/routes/music_metrics_routes.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
 from backend.services.music_metrics import MusicMetricsService
+from backend.services import song_popularity_service
 from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 
 router = APIRouter(prefix="/music/metrics", tags=["Music Metrics"])
@@ -12,3 +13,12 @@ svc = MusicMetricsService()
 @router.get("/totals")
 def get_totals(album_id: Optional[int] = None, song_id: Optional[int] = None):
     return svc.totals(album_id=album_id, song_id=song_id)
+
+
+@router.get("/songs/{song_id}/popularity")
+def get_song_popularity(song_id: int):
+    """Return popularity history for a song."""
+    return {
+        "song_id": song_id,
+        "history": song_popularity_service.get_history(song_id),
+    }

--- a/backend/services/cover_service.py
+++ b/backend/services/cover_service.py
@@ -1,0 +1,8 @@
+"""Service for handling song covers by other artists."""
+
+from backend.services.song_popularity_service import add_event
+
+
+def record_cover(song_id: int, artist_id: int) -> None:
+    """Record a cover performance or release and boost popularity."""
+    add_event(song_id, 5.0, f"cover:{artist_id}")

--- a/backend/services/jobs_world_pulse.py
+++ b/backend/services/jobs_world_pulse.py
@@ -329,6 +329,14 @@ class WorldPulseService:
         return None
 
     def run_all(self, date: str) -> Dict[str, Any]:
+        # Apply daily decay to song popularity scores before computing pulses
+        try:
+            from backend.services.song_popularity_service import apply_decay
+
+            apply_decay()
+        except Exception:
+            pass
+
         res = {"daily": self.run_daily(date)}
         wk = self.run_weekly_if_sunday(date)
         if wk: res["weekly"] = wk

--- a/backend/services/media_service.py
+++ b/backend/services/media_service.py
@@ -1,2 +1,14 @@
-# File: backend/services/media_service.py
-# Full code provided in assistant response above
+"""Media placement service for film/TV and other exposure channels."""
+
+from backend.services.song_popularity_service import add_event
+
+
+def record_media_placement(song_id: int, placement_type: str) -> None:
+    """Record that a song was placed in some media and boost its popularity.
+
+    Args:
+        song_id: The song receiving placement.
+        placement_type: e.g. "film", "tv", "ad".
+    """
+    boost = 20.0 if placement_type.lower() == "film" else 10.0
+    add_event(song_id, boost, placement_type)

--- a/backend/services/sales_service.py
+++ b/backend/services/sales_service.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
+from backend.services.song_popularity_service import add_event
+
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 
 @dataclass
@@ -101,6 +103,11 @@ class SalesService:
                 VALUES (?, ?, ?, ?, ?, ?)
             """, (buyer_user_id, work_type, work_id, price_cents, currency, source))
             conn.commit()
+
+            # Boost popularity for song sales
+            if work_type == "song":
+                add_event(work_id, price_cents / 100.0, "sale")
+
             return cur.lastrowid
 
     def list_digital_sales_for_work(self, work_type: str, work_id: int) -> List[Dict[str, Any]]:

--- a/backend/services/song_popularity_service.py
+++ b/backend/services/song_popularity_service.py
@@ -1,0 +1,81 @@
+import sqlite3
+from datetime import datetime
+from typing import List, Dict
+
+from backend.database import DB_PATH
+
+DECAY_FACTOR = 0.95
+
+
+def _ensure_schema(cur: sqlite3.Cursor) -> None:
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS song_popularity (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            song_id INTEGER NOT NULL,
+            popularity_score REAL NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+def add_event(song_id: int, amount: float, source: str) -> float:
+    """Boost a song's popularity by a given amount from some source."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        _ensure_schema(cur)
+        cur.execute(
+            "SELECT popularity_score FROM song_popularity WHERE song_id=? ORDER BY updated_at DESC LIMIT 1",
+            (song_id,),
+        )
+        row = cur.fetchone()
+        current = float(row[0]) if row else 0.0
+        new_score = current + float(amount)
+        cur.execute(
+            "INSERT INTO song_popularity (song_id, popularity_score, updated_at) VALUES (?, ?, ?)",
+            (song_id, new_score, datetime.utcnow().isoformat()),
+        )
+        conn.commit()
+        return new_score
+
+
+def apply_decay() -> int:
+    """Apply exponential decay to all songs' popularity scores."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        _ensure_schema(cur)
+        cur.execute(
+            """
+            SELECT song_id, popularity_score FROM song_popularity
+            WHERE (song_id, updated_at) IN (
+                SELECT song_id, MAX(updated_at) FROM song_popularity GROUP BY song_id
+            )
+            """
+        )
+        rows = cur.fetchall()
+        now = datetime.utcnow().isoformat()
+        decayed = [
+            (song_id, score * DECAY_FACTOR, now)
+            for song_id, score in rows
+        ]
+        if decayed:
+            cur.executemany(
+                "INSERT INTO song_popularity (song_id, popularity_score, updated_at) VALUES (?, ?, ?)",
+                decayed,
+            )
+        conn.commit()
+        return len(decayed)
+
+
+def get_history(song_id: int) -> List[Dict[str, float]]:
+    """Return the popularity history for a song."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+        _ensure_schema(cur)
+        cur.execute(
+            "SELECT popularity_score, updated_at FROM song_popularity WHERE song_id=? ORDER BY updated_at",
+            (song_id,),
+        )
+        return [dict(r) for r in cur.fetchall()]

--- a/backend/services/streaming_service.py
+++ b/backend/services/streaming_service.py
@@ -1,6 +1,7 @@
 import sqlite3
 from datetime import datetime
 from backend.database import DB_PATH
+from backend.services.song_popularity_service import add_event
 
 
 def stream_song(user_id: int, song_id: int) -> dict:
@@ -37,6 +38,9 @@ def stream_song(user_id: int, song_id: int) -> dict:
 
     conn.commit()
     conn.close()
+
+    # Boost popularity for the streamed song
+    add_event(song_id, 1.0, "stream")
 
     return {"status": "ok", "revenue": round(revenue, 4)}
 

--- a/backend/tests/test_song_popularity.py
+++ b/backend/tests/test_song_popularity.py
@@ -1,0 +1,39 @@
+import sqlite3
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.database import DB_PATH
+from backend.routes.music_metrics_routes import router as metrics_router
+from backend.services.song_popularity_service import add_event, apply_decay, get_history
+
+
+def _reset_db():
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS song_popularity")
+        conn.commit()
+
+
+def test_add_event_and_decay():
+    _reset_db()
+    add_event(1, 10, "stream")
+    add_event(1, 5, "sale")
+    hist = get_history(1)
+    assert hist[-1]["popularity_score"] == 15
+    apply_decay()
+    hist2 = get_history(1)
+    assert len(hist2) == 3
+    assert hist2[-1]["popularity_score"] < 15
+
+
+def test_popularity_endpoint():
+    _reset_db()
+    add_event(2, 3, "stream")
+    app = FastAPI()
+    app.include_router(metrics_router)
+    client = TestClient(app)
+    resp = client.get("/music/metrics/songs/2/popularity")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["song_id"] == 2
+    assert len(data["history"]) == 1


### PR DESCRIPTION
## Summary
- add SongPopularity model and service to track song popularity with decay
- hook streaming and sales events into popularity scoring; include cover/media helpers
- expose popularity history endpoint and schedule daily decay job

## Testing
- `python3 - <<'PY'
from backend.services.song_popularity_service import add_event, get_history, apply_decay
from backend.database import DB_PATH
import sqlite3
with sqlite3.connect(DB_PATH) as conn:
    cur=conn.cursor(); cur.execute('DROP TABLE IF EXISTS song_popularity'); conn.commit()
add_event(1, 10, 'stream'); add_event(1, 5, 'sale'); apply_decay(); print(get_history(1))
PY`
- `pytest -q` *(fails: command not found)*
- `pip install pytest --break-system-packages -q` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b489358b8483258b4cee252ce1da7c