### PR TITLE
Add song popularity half-life analytics

### DIFF
--- a/backend/routes/music_metrics_routes.py
+++ b/backend/routes/music_metrics_routes.py
@@ -17,8 +17,11 @@ def get_totals(album_id: Optional[int] = None, song_id: Optional[int] = None):
 
 @router.get("/songs/{song_id}/popularity")
 def get_song_popularity(song_id: int):
-    """Return popularity history for a song."""
+    """Return popularity analytics for a song."""
     return {
         "song_id": song_id,
+        "current_popularity": song_popularity_service.get_current_popularity(song_id),
+        "half_life_days": song_popularity_service.HALF_LIFE_DAYS,
+        "last_boost_source": song_popularity_service.get_last_boost_source(song_id),
         "history": song_popularity_service.get_history(song_id),
     }

--- a/backend/services/song_popularity_service.py
+++ b/backend/services/song_popularity_service.py
@@ -1,88 +1,19 @@
+import math
 import sqlite3
-from typing import Optional, List, Dict
-
-from backend.database import DB_PATH
-
-
-class SongPopularityService:
-    """Track song popularity boosts from various media events."""
-
-    def __init__(self, db_path: Optional[str] = None):
-        self.db_path = db_path or DB_PATH
-
-    def add_event(self, song_id: int, source: str, boost: int) -> Dict[str, int]:
-        """Apply a popularity boost and log the event.
-
-        Returns the new popularity score for the song.
-        """
-        conn = sqlite3.connect(self.db_path)
-        cur = conn.cursor()
-        cur.execute(
-            """
-            INSERT INTO song_popularity_events (song_id, source, boost)
-            VALUES (?, ?, ?)
-            """,
-            (song_id, source, boost),
-        )
-        cur.execute(
-            """
-            INSERT INTO song_popularity (song_id, score)
-            VALUES (?, ?)
-            ON CONFLICT(song_id) DO UPDATE SET score = score + excluded.score
-            """,
-            (song_id, boost),
-        )
-        cur.execute(
-            "SELECT score FROM song_popularity WHERE song_id = ?",
-            (song_id,),
-        )
-        row = cur.fetchone()
-        conn.commit()
-        conn.close()
-        return {"song_id": song_id, "score": int(row[0] if row else 0)}
-
-    def list_events(self, song_id: Optional[int] = None) -> List[Dict]:
-        conn = sqlite3.connect(self.db_path)
-        cur = conn.cursor()
-        if song_id is None:
-            cur.execute(
-                "SELECT id, song_id, source, boost, created_at FROM song_popularity_events ORDER BY id DESC"
-            )
-        else:
-            cur.execute(
-                """
-                SELECT id, song_id, source, boost, created_at
-                FROM song_popularity_events
-                WHERE song_id = ?
-                ORDER BY id DESC
-                """,
-                (song_id,),
-            )
-        rows = cur.fetchall()
-        conn.close()
-        return [
-            {
-                "id": r[0],
-                "song_id": r[1],
-                "source": r[2],
-                "boost": r[3],
-                "created_at": r[4],
-            }
-            for r in rows
-        ]
-
-
-# Singleton used across the app
-song_popularity_service = SongPopularityService()
 from datetime import datetime
-from typing import List, Dict
+from typing import Dict, List, Optional
 
 from backend.database import DB_PATH
 
+
+# Popularity decays by this factor every day
 DECAY_FACTOR = 0.95
+# Derived half-life in days for the current decay factor
+HALF_LIFE_DAYS = math.log(0.5) / math.log(DECAY_FACTOR)
 
 
 def _ensure_schema(cur: sqlite3.Cursor) -> None:
+    """Ensure required tables exist."""
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS song_popularity (
@@ -93,6 +24,76 @@ def _ensure_schema(cur: sqlite3.Cursor) -> None:
         )
         """
     )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS song_popularity_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            song_id INTEGER NOT NULL,
+            source TEXT NOT NULL,
+            boost INTEGER NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+class SongPopularityService:
+    """Track song popularity boosts from various media events."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = db_path or DB_PATH
+
+    def add_event(self, song_id: int, source: str, boost: int) -> Dict[str, int]:
+        """Apply a popularity boost and log the event."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            _ensure_schema(cur)
+            now = datetime.utcnow().isoformat()
+            cur.execute(
+                "INSERT INTO song_popularity_events (song_id, source, boost, created_at) VALUES (?, ?, ?, ?)",
+                (song_id, source, boost, now),
+            )
+            cur.execute(
+                "INSERT INTO song_popularity (song_id, score) VALUES (?, ?) "
+                "ON CONFLICT(song_id) DO UPDATE SET score = score + excluded.score",
+                (song_id, boost),
+            )
+            cur.execute(
+                "SELECT score FROM song_popularity WHERE song_id = ?",
+                (song_id,),
+            )
+            row = cur.fetchone()
+            return {"song_id": song_id, "score": int(row[0] if row else 0)}
+
+    def list_events(self, song_id: Optional[int] = None) -> List[Dict]:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            _ensure_schema(cur)
+            if song_id is None:
+                cur.execute(
+                    "SELECT id, song_id, source, boost, created_at FROM song_popularity_events ORDER BY id DESC"
+                )
+            else:
+                cur.execute(
+                    "SELECT id, song_id, source, boost, created_at FROM song_popularity_events "
+                    "WHERE song_id = ? ORDER BY id DESC",
+                    (song_id,),
+                )
+            rows = cur.fetchall()
+            return [
+                {
+                    "id": r[0],
+                    "song_id": r[1],
+                    "source": r[2],
+                    "boost": r[3],
+                    "created_at": r[4],
+                }
+                for r in rows
+            ]
+
+
+# Singleton used across the app
+song_popularity_service = SongPopularityService()
 
 
 def add_event(song_id: int, amount: float, source: str) -> float:
@@ -107,9 +108,14 @@ def add_event(song_id: int, amount: float, source: str) -> float:
         row = cur.fetchone()
         current = float(row[0]) if row else 0.0
         new_score = current + float(amount)
+        now = datetime.utcnow().isoformat()
         cur.execute(
             "INSERT INTO song_popularity (song_id, popularity_score, updated_at) VALUES (?, ?, ?)",
-            (song_id, new_score, datetime.utcnow().isoformat()),
+            (song_id, new_score, now),
+        )
+        cur.execute(
+            "INSERT INTO song_popularity_events (song_id, source, boost, created_at) VALUES (?, ?, ?, ?)",
+            (song_id, source, amount, now),
         )
         conn.commit()
         return new_score
@@ -154,3 +160,30 @@ def get_history(song_id: int) -> List[Dict[str, float]]:
             (song_id,),
         )
         return [dict(r) for r in cur.fetchall()]
+
+
+def get_current_popularity(song_id: int) -> float:
+    """Return the latest popularity score for a song."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        _ensure_schema(cur)
+        cur.execute(
+            "SELECT popularity_score FROM song_popularity WHERE song_id=? ORDER BY updated_at DESC LIMIT 1",
+            (song_id,),
+        )
+        row = cur.fetchone()
+        return float(row[0]) if row else 0.0
+
+
+def get_last_boost_source(song_id: int) -> Optional[str]:
+    """Return the source of the most recent popularity boost."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        _ensure_schema(cur)
+        cur.execute(
+            "SELECT source FROM song_popularity_events WHERE song_id=? ORDER BY id DESC LIMIT 1",
+            (song_id,),
+        )
+        row = cur.fetchone()
+        return row[0] if row else None
+

--- a/backend/tests/test_song_popularity.py
+++ b/backend/tests/test_song_popularity.py
@@ -4,13 +4,19 @@ from fastapi.testclient import TestClient
 
 from backend.database import DB_PATH
 from backend.routes.music_metrics_routes import router as metrics_router
-from backend.services.song_popularity_service import add_event, apply_decay, get_history
+from backend.services.song_popularity_service import (
+    add_event,
+    apply_decay,
+    get_history,
+    HALF_LIFE_DAYS,
+)
 
 
 def _reset_db():
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute("DROP TABLE IF EXISTS song_popularity")
+        cur.execute("DROP TABLE IF EXISTS song_popularity_events")
         conn.commit()
 
 
@@ -36,4 +42,7 @@ def test_popularity_endpoint():
     assert resp.status_code == 200
     data = resp.json()
     assert data["song_id"] == 2
+    assert data["current_popularity"] == 3
+    assert data["half_life_days"] == HALF_LIFE_DAYS
+    assert data["last_boost_source"] == "stream"
     assert len(data["history"]) == 1

--- a/frontend/pages/popularity_dashboard.html
+++ b/frontend/pages/popularity_dashboard.html
@@ -1,0 +1,38 @@
+<h2>Song Popularity Dashboard</h2>
+
+<div>
+  <label for="songId">Song ID:</label>
+  <input type="text" id="songId" />
+  <button onclick="loadPopularity()">Load</button>
+</div>
+
+<div>
+  Current Popularity: <span id="currentPopularity">-</span><br />
+  Half-life (days): <span id="halfLife">-</span><br />
+  Last Boost Source: <span id="lastBoost">-</span>
+</div>
+
+<ul id="popularityHistory"></ul>
+
+<script>
+async function loadPopularity() {
+  const id = document.getElementById('songId').value;
+  const res = await fetch(`/music/metrics/songs/${id}/popularity`);
+  const data = await res.json();
+  document.getElementById('currentPopularity').innerText = data.current_popularity;
+  document.getElementById('halfLife').innerText = data.half_life_days.toFixed(2);
+  document.getElementById('lastBoost').innerText = data.last_boost_source || '-';
+  const list = document.getElementById('popularityHistory');
+  list.innerHTML = '';
+  data.history.forEach(point => {
+    const li = document.createElement('li');
+    li.innerText = `${point.updated_at}: ${point.popularity_score}`;
+    list.appendChild(li);
+  });
+  // Hook for custom chart rendering if available
+  if (window.renderPopularityChart) {
+    window.renderPopularityChart(data.history);
+  }
+}
+</script>
+


### PR DESCRIPTION
## Summary
- calculate and expose `half_life_days` for song popularity decay
- extend music metrics API to include current popularity, half-life, and last boost source
- add dashboard page with hooks to visualize popularity decay

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic.schema')*


------
https://chatgpt.com/codex/tasks/task_e_68b48caa60008325a5b77b957e4a2f75