### PR TITLE
feat: track and analyze live crowd reactions

### DIFF
--- a/backend/services/live_performance_analysis.py
+++ b/backend/services/live_performance_analysis.py
@@ -1,0 +1,41 @@
+import json
+import sqlite3
+from datetime import datetime
+
+from backend.database import DB_PATH
+
+
+def store_setlist_summary(summary: dict) -> None:
+    """Persist a setlist summary for later review."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS setlist_summaries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            performance_id INTEGER,
+            summary TEXT,
+            created_at TEXT
+        )
+        """
+    )
+    cur.execute(
+        "INSERT INTO setlist_summaries (performance_id, summary, created_at) VALUES (?, ?, ?)",
+        (summary.get("performance_id"), json.dumps(summary), datetime.utcnow().isoformat()),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_setlist_summary(performance_id: int):
+    """Retrieve a stored setlist summary."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT summary FROM setlist_summaries WHERE performance_id = ?",
+        (performance_id,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    return json.loads(row[0]) if row else None
+

--- a/backend/services/live_performance_service.py
+++ b/backend/services/live_performance_service.py
@@ -3,17 +3,46 @@ import sqlite3
 import json
 from datetime import datetime
 
+from typing import Generator, Iterable, Optional
+
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
 from backend.database import DB_PATH
 from backend.services.city_service import city_service
 from backend.services.event_service import is_skill_blocked
 from backend.services.gear_service import gear_service
+from backend.services import live_performance_analysis
 
 
-def simulate_gig(band_id: int, city: str, venue: str, setlist) -> dict:
+def crowd_reaction_stream() -> Generator[float, None, None]:
+    """Endless stream of crowd reaction scores between 0 and 1."""
+    while True:
+        yield random.uniform(0.0, 1.0)
+
+
+def simulate_gig(
+    band_id: int,
+    city: str,
+    venue: str,
+    setlist,
+    reaction_stream: Optional[Iterable[float]] = None,
+) -> dict:
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
+
+    # ensure performance_events table exists
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS performance_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            performance_id INTEGER,
+            action TEXT,
+            crowd_reaction REAL,
+            fame_modifier INTEGER,
+            created_at TEXT
+        )
+        """
+    )
 
     # Get band fame
     cur.execute("SELECT fame FROM bands WHERE id = ?", (band_id,))
@@ -30,6 +59,10 @@ def simulate_gig(band_id: int, city: str, venue: str, setlist) -> dict:
 
     fame_bonus = 0
     skill_gain = 0.0
+    event_log = []
+    recent_reactions: list[float] = []
+
+    stream = iter(reaction_stream) if reaction_stream is not None else crowd_reaction_stream()
 
     main_actions: list = []
     encore_actions: list = []
@@ -45,6 +78,8 @@ def simulate_gig(band_id: int, city: str, venue: str, setlist) -> dict:
 
     for action in main_actions + encore_actions:
         a_type = action.get("type")
+        action_bonus = 0
+        fame_modifier = 0
         if a_type == "song" or a_type == "encore":
             skill_gain += 0.3
 
@@ -65,12 +100,31 @@ def simulate_gig(band_id: int, city: str, venue: str, setlist) -> dict:
                             (2 if owner_band == band_id else 1, song_id),
                         )
 
-            fame_bonus += song_bonus
+            action_bonus += song_bonus
         elif a_type == "activity":
             skill_gain += 0.1
-            fame_bonus += 1
+            action_bonus += 1
         if action.get("encore") or a_type == "encore":
-            fame_bonus += 3
+            action_bonus += 3
+
+        if recent_reactions:
+            avg_recent = sum(recent_reactions[-3:]) / len(recent_reactions[-3:])
+            if avg_recent > 0.7:
+                fame_modifier = 1
+            elif avg_recent < 0.3:
+                fame_modifier = -1
+
+        fame_bonus += action_bonus + fame_modifier
+
+        reaction = next(stream)
+        recent_reactions.append(reaction)
+        event_log.append(
+            {
+                "action": a_type,
+                "crowd_reaction": reaction,
+                "fame_modifier": fame_modifier,
+            }
+        )
 
     fame_earned = crowd_size // 10 + fame_bonus
     revenue_earned = crowd_size * 5
@@ -101,6 +155,34 @@ def simulate_gig(band_id: int, city: str, venue: str, setlist) -> dict:
             merch_sold,
         ),
     )
+    performance_record_id = cur.lastrowid
+
+    for event in event_log:
+        cur.execute(
+            """
+            INSERT INTO performance_events (
+                performance_id, action, crowd_reaction, fame_modifier, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                performance_record_id,
+                event["action"],
+                event["crowd_reaction"],
+                event["fame_modifier"],
+                datetime.utcnow().isoformat(),
+            ),
+        )
+
+    conn.commit()
+
+    summary = {
+        "performance_id": performance_record_id,
+        "actions": event_log,
+        "average_reaction": sum(r["crowd_reaction"] for r in event_log) / len(event_log)
+        if event_log
+        else 0,
+    }
+    live_performance_analysis.store_setlist_summary(summary)
 
     # Update band stats
     cur.execute("UPDATE bands SET fame = fame + ? WHERE id = ?", (fame_earned, band_id))
@@ -119,7 +201,7 @@ def simulate_gig(band_id: int, city: str, venue: str, setlist) -> dict:
         "fame_earned": fame_earned,
         "revenue_earned": revenue_earned,
         "skill_gain": applied_skill,
-        "merch_sold": merch_sold
+        "merch_sold": merch_sold,
     }
 
 

--- a/backend/tests/live_performance/test_crowd_reaction.py
+++ b/backend/tests/live_performance/test_crowd_reaction.py
@@ -1,0 +1,67 @@
+import json
+import sqlite3
+
+from backend.services import live_performance_service, live_performance_analysis
+from backend.services.city_service import city_service
+from backend.models.city import City
+
+
+def test_crowd_reaction_adjusts_and_logs(monkeypatch, tmp_path):
+    city_service.cities.clear()
+    city_service.add_city(
+        City(
+            name="Metro",
+            population=1_000_000,
+            style_preferences={},
+            event_modifier=1.0,
+            market_index=1.0,
+        )
+    )
+
+    db_file = tmp_path / "gig.db"
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE bands (id INTEGER PRIMARY KEY, fame INTEGER, skill REAL, revenue INTEGER)")
+    cur.execute(
+        "CREATE TABLE live_performances (band_id INTEGER, city TEXT, venue TEXT, date TEXT, setlist TEXT, crowd_size INTEGER, fame_earned INTEGER, revenue_earned INTEGER, skill_gain REAL, merch_sold INTEGER)"
+    )
+    cur.execute(
+        "CREATE TABLE songs (id INTEGER PRIMARY KEY, band_id INTEGER, title TEXT, duration_sec INTEGER, genre TEXT, play_count INTEGER, original_song_id INTEGER)"
+    )
+    cur.execute(
+        "CREATE TABLE performance_events (id INTEGER PRIMARY KEY AUTOINCREMENT, performance_id INTEGER, action TEXT, crowd_reaction REAL, fame_modifier INTEGER, created_at TEXT)"
+    )
+    cur.execute(
+        "CREATE TABLE setlist_summaries (id INTEGER PRIMARY KEY AUTOINCREMENT, performance_id INTEGER, summary TEXT, created_at TEXT)"
+    )
+    cur.execute("INSERT INTO bands (id, fame, skill, revenue) VALUES (1, 100, 0, 0)")
+    cur.execute("INSERT INTO songs (id, band_id, title, duration_sec, genre, play_count, original_song_id) VALUES (1, 1, 'Song A', 0, '', 0, NULL)")
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(live_performance_service, "DB_PATH", db_file)
+    monkeypatch.setattr(live_performance_analysis, "DB_PATH", db_file)
+    monkeypatch.setattr(live_performance_service.random, "randint", lambda a, b: a)
+    monkeypatch.setattr(live_performance_service.gear_service, "get_band_bonus", lambda band_id, name: 0)
+    monkeypatch.setattr(live_performance_service, "is_skill_blocked", lambda band_id, skill_id: False)
+
+    setlist = [
+        {"type": "song", "reference": "1"},
+        {"type": "song", "reference": "1"},
+    ]
+
+    reaction = iter([0.9, 0.9])
+    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", setlist, reaction_stream=reaction)
+
+    assert result["fame_earned"] == 25
+
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute("SELECT action, crowd_reaction, fame_modifier FROM performance_events ORDER BY id")
+    rows = cur.fetchall()
+    assert rows == [("song", 0.9, 0), ("song", 0.9, 1)]
+    cur.execute("SELECT summary FROM setlist_summaries")
+    summary = json.loads(cur.fetchone()[0])
+    assert summary["average_reaction"] == 0.9
+    conn.close()
+

--- a/backend/tests/live_performance/test_setlist_structure.py
+++ b/backend/tests/live_performance/test_setlist_structure.py
@@ -1,6 +1,7 @@
 import sqlite3
 
 from backend.services import live_performance_service
+from backend.services import live_performance_analysis
 from backend.services.city_service import city_service
 from backend.models.city import City
 
@@ -19,6 +20,12 @@ def test_simulate_gig_parses_structured_setlist(monkeypatch, tmp_path):
     cur.execute(
         "CREATE TABLE songs (id INTEGER PRIMARY KEY, band_id INTEGER, title TEXT, duration_sec INTEGER, genre TEXT, play_count INTEGER, original_song_id INTEGER)"
     )
+    cur.execute(
+        "CREATE TABLE performance_events (id INTEGER PRIMARY KEY AUTOINCREMENT, performance_id INTEGER, action TEXT, crowd_reaction REAL, fame_modifier INTEGER, created_at TEXT)"
+    )
+    cur.execute(
+        "CREATE TABLE setlist_summaries (id INTEGER PRIMARY KEY AUTOINCREMENT, performance_id INTEGER, summary TEXT, created_at TEXT)"
+    )
     cur.execute("INSERT INTO bands (id, fame, skill, revenue) VALUES (1, 100, 0, 0)")
     cur.executemany(
         "INSERT INTO songs (id, band_id, title, duration_sec, genre, play_count, original_song_id) VALUES (?, ?, ?, 0, '', 0, NULL)",
@@ -31,6 +38,7 @@ def test_simulate_gig_parses_structured_setlist(monkeypatch, tmp_path):
     conn.close()
 
     monkeypatch.setattr(live_performance_service, "DB_PATH", db_file)
+    monkeypatch.setattr(live_performance_analysis, "DB_PATH", db_file)
     monkeypatch.setattr(live_performance_service.random, "randint", lambda a, b: a)
     monkeypatch.setattr(live_performance_service.gear_service, "get_band_bonus", lambda band_id, name: 0)
     monkeypatch.setattr(live_performance_service, "is_skill_blocked", lambda band_id, skill_id: False)
@@ -41,7 +49,8 @@ def test_simulate_gig_parses_structured_setlist(monkeypatch, tmp_path):
         {"type": "song", "reference": "2", "encore": True},
     ]
 
-    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", setlist)
+    reaction = iter([0.5, 0.5, 0.5])
+    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", setlist, reaction_stream=reaction)
 
     assert result["fame_earned"] == 28
     assert result["skill_gain"] == 0.7
@@ -61,6 +70,12 @@ def test_cover_song_reduces_fame_and_boosts_original(monkeypatch, tmp_path):
     cur.execute(
         "CREATE TABLE songs (id INTEGER PRIMARY KEY, band_id INTEGER, title TEXT, duration_sec INTEGER, genre TEXT, play_count INTEGER, original_song_id INTEGER)"
     )
+    cur.execute(
+        "CREATE TABLE performance_events (id INTEGER PRIMARY KEY AUTOINCREMENT, performance_id INTEGER, action TEXT, crowd_reaction REAL, fame_modifier INTEGER, created_at TEXT)"
+    )
+    cur.execute(
+        "CREATE TABLE setlist_summaries (id INTEGER PRIMARY KEY AUTOINCREMENT, performance_id INTEGER, summary TEXT, created_at TEXT)"
+    )
     cur.executemany(
         "INSERT INTO bands (id, fame, skill, revenue) VALUES (?, ?, 0, 0)",
         [(1, 100), (2, 50)],
@@ -76,6 +91,7 @@ def test_cover_song_reduces_fame_and_boosts_original(monkeypatch, tmp_path):
     conn.close()
 
     monkeypatch.setattr(live_performance_service, "DB_PATH", db_file)
+    monkeypatch.setattr(live_performance_analysis, "DB_PATH", db_file)
     monkeypatch.setattr(live_performance_service.random, "randint", lambda a, b: a)
     monkeypatch.setattr(live_performance_service.gear_service, "get_band_bonus", lambda band_id, name: 0)
     monkeypatch.setattr(live_performance_service, "is_skill_blocked", lambda band_id, skill_id: False)
@@ -85,7 +101,8 @@ def test_cover_song_reduces_fame_and_boosts_original(monkeypatch, tmp_path):
         {"type": "song", "reference": "2"},  # cover
     ]
 
-    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", setlist)
+    reaction = iter([0.5, 0.5])
+    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", setlist, reaction_stream=reaction)
 
     assert result["fame_earned"] == 23
     conn = sqlite3.connect(db_file)

--- a/frontend/pages/setlist_review.html
+++ b/frontend/pages/setlist_review.html
@@ -1,0 +1,40 @@
+<h2>Setlist Review</h2>
+
+<input type="number" id="performanceId" placeholder="Performance ID" />
+<button id="loadBtn">Load Summary</button>
+
+<table border="1">
+  <thead>
+    <tr>
+      <th>Action</th>
+      <th>Crowd Reaction</th>
+      <th>Fame Modifier</th>
+    </tr>
+  </thead>
+  <tbody id="summaryBody"></tbody>
+</table>
+
+<div id="suggestion"></div>
+
+<script>
+document.getElementById('loadBtn').onclick = async () => {
+  const id = document.getElementById('performanceId').value;
+  if (!id) return;
+  const res = await fetch(`/analysis/setlist/${id}`);
+  const data = await res.json();
+  const body = document.getElementById('summaryBody');
+  body.innerHTML = '';
+  data.actions.forEach(a => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${a.action}</td><td>${a.crowd_reaction.toFixed(2)}</td><td>${a.fame_modifier}</td>`;
+    body.appendChild(tr);
+  });
+  const suggestion = document.getElementById('suggestion');
+  if (data.average_reaction < 0.5) {
+    suggestion.textContent = 'Consider adding more engaging songs earlier in the set.';
+  } else {
+    suggestion.textContent = 'Crowd engagement was strong. Keep up the good work!';
+  }
+};
+</script>
+


### PR DESCRIPTION
## Summary
- add crowd_reaction stream to gig simulation and log performance events
- record setlist summaries for later analysis
- provide basic UI to review setlist engagement

## Testing
- `pytest backend/tests/live_performance/test_setlist_structure.py backend/tests/live_performance/test_crowd_reaction.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic.schema')*


------
https://chatgpt.com/codex/tasks/task_e_68b49206cdb48325ad13009876872e1b