### PR TITLE
Add cover licensing and royalty tracking

### DIFF
--- a/backend/migrations/sql/100_add_song_licensing.sql
+++ b/backend/migrations/sql/100_add_song_licensing.sql
@@ -1,0 +1,21 @@
+-- 100_add_song_licensing.sql
+-- Adds licensing fields to songs and creates cover_royalties table.
+-- Safe for SQLite.
+BEGIN TRANSACTION;
+
+ALTER TABLE songs ADD COLUMN license_fee INTEGER DEFAULT 0;
+ALTER TABLE songs ADD COLUMN royalty_rate REAL DEFAULT 0.0;
+
+CREATE TABLE IF NOT EXISTS cover_royalties (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    song_id INTEGER NOT NULL,
+    cover_band_id INTEGER NOT NULL,
+    amount_owed INTEGER NOT NULL,
+    amount_paid INTEGER DEFAULT 0,
+    license_proof_url TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY(song_id) REFERENCES songs(id)
+);
+CREATE INDEX IF NOT EXISTS ix_cover_royalties_song ON cover_royalties(song_id);
+
+COMMIT;

--- a/backend/models/song.py
+++ b/backend/models/song.py
@@ -22,6 +22,8 @@ class Song:
         royalties_split: Optional[dict] = None,
         plagiarism_warning: Optional[str] = None,
         arrangement: Optional[List[ArrangementTrack]] = None,
+        license_fee: int = 0,
+        royalty_rate: float = 0.0,
     ) -> None:
         self.id = id
         self.title = title
@@ -37,6 +39,8 @@ class Song:
         self.royalties_split = royalties_split or {owner_band_id: 100}
         self.plagiarism_warning = plagiarism_warning
         self.arrangement = arrangement or []
+        self.license_fee = license_fee
+        self.royalty_rate = royalty_rate
 
     def to_dict(self):
         data = self.__dict__.copy()

--- a/backend/services/cover_service.py
+++ b/backend/services/cover_service.py
@@ -1,8 +1,19 @@
 """Service for handling song covers by other artists."""
 
 from backend.services.song_popularity_service import add_event
+from backend.services.song_service import SongService
+
+song_service = SongService()
 
 
-def record_cover(song_id: int, artist_id: int) -> None:
-    """Record a cover performance or release and boost popularity."""
+def record_cover(song_id: int, artist_id: int, revenue_cents: int = 0) -> None:
+    """Record a cover performance or release and boost popularity.
+
+    Alerts if the band does not have an active license for the song.
+    """
+    try:
+        song_service.record_cover_usage(song_id, artist_id, revenue_cents)
+    except PermissionError as exc:
+        print(f"ALERT: {exc}")
+        raise
     add_event(song_id, 5.0, f"cover:{artist_id}")

--- a/backend/tests/services/test_song_service.py
+++ b/backend/tests/services/test_song_service.py
@@ -7,10 +7,13 @@ def setup_db(path):
     conn = sqlite3.connect(path)
     cur = conn.cursor()
     cur.execute(
-        "CREATE TABLE songs (id INTEGER PRIMARY KEY AUTOINCREMENT, band_id INTEGER, title TEXT, duration_sec INTEGER, genre TEXT, play_count INTEGER, original_song_id INTEGER)"
+        "CREATE TABLE songs (id INTEGER PRIMARY KEY AUTOINCREMENT, band_id INTEGER, title TEXT, duration_sec INTEGER, genre TEXT, play_count INTEGER, original_song_id INTEGER, license_fee INTEGER DEFAULT 0, royalty_rate REAL DEFAULT 0.0)"
     )
     cur.execute(
         "CREATE TABLE royalties (id INTEGER PRIMARY KEY AUTOINCREMENT, song_id INTEGER, user_id INTEGER, percent INTEGER)"
+    )
+    cur.execute(
+        "CREATE TABLE cover_royalties (id INTEGER PRIMARY KEY AUTOINCREMENT, song_id INTEGER, cover_band_id INTEGER, amount_owed INTEGER, amount_paid INTEGER, license_proof_url TEXT)"
     )
     conn.commit()
     conn.close()
@@ -44,3 +47,34 @@ def test_create_cover_and_list(tmp_path):
     covers = service.list_covers_of_song(orig_id)
     assert len(covers) == 1
     assert covers[0]["band_id"] == 2
+
+
+def test_cover_royalties_and_license(tmp_path):
+    db_path = tmp_path / "songs.db"
+    setup_db(db_path)
+    service = SongService(db=str(db_path))
+
+    original = {
+        "band_id": 1,
+        "title": "Original",
+        "duration_sec": 120,
+        "genre": "rock",
+        "royalties_split": {1: 100},
+        "license_fee": 1000,
+        "royalty_rate": 0.1,
+    }
+    song_id = service.create_song(original)["song_id"]
+
+    band_id = 2
+
+    # Performing a cover without license should alert
+    try:
+        service.record_cover_usage(song_id, band_id, revenue_cents=1000)
+        assert False, "expected PermissionError"
+    except PermissionError:
+        pass
+
+    # Purchase license and record usage
+    service.purchase_cover_license(song_id, band_id, "proof.png")
+    res = service.record_cover_usage(song_id, band_id, revenue_cents=1000)
+    assert res["amount_owed"] == 100

--- a/frontend/pages/cover_licensing.html
+++ b/frontend/pages/cover_licensing.html
@@ -1,0 +1,12 @@
+<h2>Cover Licensing</h2>
+<table id="royalties">
+  <thead>
+    <tr><th>Song ID</th><th>Owed (¢)</th><th>Paid (¢)</th><th>License Proof</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<form id="licenseUpload">
+  <input type="number" name="song_id" placeholder="Song ID" required />
+  <input type="file" name="license_proof" required />
+  <button type="submit">Upload Proof</button>
+</form>


### PR DESCRIPTION
## Summary
- track license fees and royalty rates on songs
- log cover royalties and validate licenses when covers occur
- add cover licensing admin page

## Testing
- `pytest backend/tests/services/test_song_service.py -q`
- `ruff check backend/services/song_service.py backend/services/cover_service.py backend/tests/services/test_song_service.py backend/models/song.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4944fa580832583864bb1341e564c