### PR TITLE
Add regional and platform popularity tracking with scheduled aggregation

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -206,8 +206,12 @@ def init_db():
         # Song popularity tracking
         cur.execute("""
         CREATE TABLE IF NOT EXISTS song_popularity (
-            song_id INTEGER PRIMARY KEY,
-            score INTEGER NOT NULL DEFAULT 0,
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            song_id INTEGER NOT NULL,
+            region_code TEXT NOT NULL DEFAULT 'global',
+            platform TEXT NOT NULL DEFAULT 'any',
+            popularity_score REAL NOT NULL,
+            updated_at TEXT NOT NULL,
             FOREIGN KEY(song_id) REFERENCES songs(id)
         )
         """)
@@ -215,6 +219,8 @@ def init_db():
         CREATE TABLE IF NOT EXISTS song_popularity_events (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             song_id INTEGER NOT NULL,
+            region_code TEXT NOT NULL DEFAULT 'global',
+            platform TEXT NOT NULL DEFAULT 'any',
             source TEXT NOT NULL,
             boost INTEGER NOT NULL,
             created_at TEXT DEFAULT (datetime('now')),

--- a/backend/routes/admin_song_popularity_routes.py
+++ b/backend/routes/admin_song_popularity_routes.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
-from fastapi import APIRouter, Depends
-from pydantic import BaseModel
-
 from auth.dependencies import require_role
+from fastapi import APIRouter, Depends
 from services.media_event_service import media_event_service
 from services.song_popularity_service import song_popularity_service
+
+from pydantic import BaseModel
 
 router = APIRouter(prefix="/song-popularity", tags=["Song Popularity"])
 
@@ -13,21 +13,29 @@ router = APIRouter(prefix="/song-popularity", tags=["Song Popularity"])
 class MediaEvent(BaseModel):
     song_id: int
     boost: int = 10
+    region_code: str = "global"
+    platform: str = "any"
 
 
 @router.post("/film", dependencies=[Depends(require_role(["admin"]))])
 async def film(evt: MediaEvent):
-    return media_event_service.film_placement(evt.song_id, evt.boost)
+    return media_event_service.film_placement(
+        evt.song_id, evt.boost, evt.region_code, evt.platform
+    )
 
 
 @router.post("/tv", dependencies=[Depends(require_role(["admin"]))])
 async def tv(evt: MediaEvent):
-    return media_event_service.tv_placement(evt.song_id, evt.boost)
+    return media_event_service.tv_placement(
+        evt.song_id, evt.boost, evt.region_code, evt.platform
+    )
 
 
 @router.post("/tiktok", dependencies=[Depends(require_role(["admin"]))])
 async def tiktok(evt: MediaEvent):
-    return media_event_service.tiktok_trend(evt.song_id, evt.boost)
+    return media_event_service.tiktok_trend(
+        evt.song_id, evt.boost, evt.region_code, evt.platform
+    )
 
 
 @router.get("/events", dependencies=[Depends(require_role(["admin"]))])

--- a/backend/routes/music_metrics_routes.py
+++ b/backend/routes/music_metrics_routes.py
@@ -1,10 +1,11 @@
 # File: backend/routes/music_metrics_routes.py
 from typing import Optional
 
-from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
-from backend.services.music_metrics import MusicMetricsService
-from backend.services import song_popularity_service
 from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
+
+from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.services import song_popularity_service
+from backend.services.music_metrics import MusicMetricsService
 
 router = APIRouter(prefix="/music/metrics", tags=["Music Metrics"])
 svc = MusicMetricsService()
@@ -16,12 +17,23 @@ def get_totals(album_id: Optional[int] = None, song_id: Optional[int] = None):
 
 
 @router.get("/songs/{song_id}/popularity")
-def get_song_popularity(song_id: int):
+def get_song_popularity(
+    song_id: int,
+    region_code: str = "global",
+    platform: str = "any",
+):
     """Return popularity analytics for a song."""
     return {
         "song_id": song_id,
-        "current_popularity": song_popularity_service.get_current_popularity(song_id),
+        "current_popularity": song_popularity_service.get_current_popularity(
+            song_id, region_code, platform
+        ),
         "half_life_days": song_popularity_service.HALF_LIFE_DAYS,
-        "last_boost_source": song_popularity_service.get_last_boost_source(song_id),
-        "history": song_popularity_service.get_history(song_id),
+        "last_boost_source": song_popularity_service.get_last_boost_source(
+            song_id, region_code, platform
+        ),
+        "history": song_popularity_service.get_history(
+            song_id, region_code, platform
+        ),
+        "breakdown": song_popularity_service.get_breakdown(song_id),
     }

--- a/backend/services/media_event_service.py
+++ b/backend/services/media_event_service.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from backend.services.song_popularity_service import song_popularity_service, SongPopularityService
+from backend.services.song_popularity_service import SongPopularityService, song_popularity_service
 
 
 class MediaEventService:
@@ -9,17 +9,37 @@ class MediaEventService:
     def __init__(self, popularity_svc: Optional[SongPopularityService] = None):
         self.popularity_svc = popularity_svc or song_popularity_service
 
-    def film_placement(self, song_id: int, boost: int = 20):
-        return self._register(song_id, "film", boost)
+    def film_placement(
+        self,
+        song_id: int,
+        boost: int = 20,
+        region_code: str = "global",
+        platform: str = "any",
+    ):
+        return self._register(song_id, "film", boost, region_code, platform)
 
-    def tv_placement(self, song_id: int, boost: int = 15):
-        return self._register(song_id, "tv", boost)
+    def tv_placement(
+        self,
+        song_id: int,
+        boost: int = 15,
+        region_code: str = "global",
+        platform: str = "any",
+    ):
+        return self._register(song_id, "tv", boost, region_code, platform)
 
-    def tiktok_trend(self, song_id: int, boost: int = 30):
-        return self._register(song_id, "tiktok", boost)
+    def tiktok_trend(
+        self,
+        song_id: int,
+        boost: int = 30,
+        region_code: str = "global",
+        platform: str = "any",
+    ):
+        return self._register(song_id, "tiktok", boost, region_code, platform)
 
-    def _register(self, song_id: int, source: str, boost: int):
-        return self.popularity_svc.add_event(song_id, source, boost)
+    def _register(
+        self, song_id: int, source: str, boost: int, region_code: str, platform: str
+    ):
+        return self.popularity_svc.add_event(song_id, source, boost, region_code, platform)
 
 
 media_event_service = MediaEventService()

--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -3,7 +3,7 @@ import sqlite3
 from datetime import datetime, timedelta
 
 from backend.database import DB_PATH
-from backend.services import chart_service, fan_service
+from backend.services import chart_service, fan_service, song_popularity_service
 from backend.services.skill_service import skill_service
 
 # Map event_type to handler functions
@@ -11,6 +11,7 @@ EVENT_HANDLERS = {
     "fan_decay": fan_service.decay_fan_loyalty,
     "weekly_charts": chart_service.calculate_weekly_chart,
     "skill_decay": skill_service.decay_all,
+    "aggregate_global_popularity": song_popularity_service.aggregate_global_popularity,
     # Add more event handlers here as needed
 }
 

--- a/backend/services/song_popularity_service.py
+++ b/backend/services/song_popularity_service.py
@@ -5,7 +5,6 @@ from typing import Dict, List, Optional
 
 from backend.database import DB_PATH
 
-
 # Popularity decays by this factor every day
 DECAY_FACTOR = 0.95
 # Derived half-life in days for the current decay factor
@@ -19,6 +18,8 @@ def _ensure_schema(cur: sqlite3.Cursor) -> None:
         CREATE TABLE IF NOT EXISTS song_popularity (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             song_id INTEGER NOT NULL,
+            region_code TEXT NOT NULL DEFAULT 'global',
+            platform TEXT NOT NULL DEFAULT 'any',
             popularity_score REAL NOT NULL,
             updated_at TEXT NOT NULL
         )
@@ -29,6 +30,8 @@ def _ensure_schema(cur: sqlite3.Cursor) -> None:
         CREATE TABLE IF NOT EXISTS song_popularity_events (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             song_id INTEGER NOT NULL,
+            region_code TEXT NOT NULL DEFAULT 'global',
+            platform TEXT NOT NULL DEFAULT 'any',
             source TEXT NOT NULL,
             boost INTEGER NOT NULL,
             created_at TEXT NOT NULL
@@ -43,50 +46,91 @@ class SongPopularityService:
     def __init__(self, db_path: Optional[str] = None) -> None:
         self.db_path = db_path or DB_PATH
 
-    def add_event(self, song_id: int, source: str, boost: int) -> Dict[str, int]:
+    def add_event(
+        self,
+        song_id: int,
+        source: str,
+        boost: int,
+        region_code: str = "global",
+        platform: str = "any",
+    ) -> Dict[str, int]:
         """Apply a popularity boost and log the event."""
         with sqlite3.connect(self.db_path) as conn:
             cur = conn.cursor()
             _ensure_schema(cur)
             now = datetime.utcnow().isoformat()
             cur.execute(
-                "INSERT INTO song_popularity_events (song_id, source, boost, created_at) VALUES (?, ?, ?, ?)",
-                (song_id, source, boost, now),
+                """
+                INSERT INTO song_popularity_events
+                    (song_id, region_code, platform, source, boost, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (song_id, region_code, platform, source, boost, now),
             )
             cur.execute(
-                "INSERT INTO song_popularity (song_id, score) VALUES (?, ?) "
-                "ON CONFLICT(song_id) DO UPDATE SET score = score + excluded.score",
-                (song_id, boost),
-            )
-            cur.execute(
-                "SELECT score FROM song_popularity WHERE song_id = ?",
-                (song_id,),
+                """
+                SELECT popularity_score FROM song_popularity
+                WHERE song_id=? AND region_code=? AND platform=?
+                ORDER BY updated_at DESC LIMIT 1
+                """,
+                (song_id, region_code, platform),
             )
             row = cur.fetchone()
-            return {"song_id": song_id, "score": int(row[0] if row else 0)}
+            current = float(row[0]) if row else 0.0
+            new_score = current + float(boost)
+            cur.execute(
+                """
+                INSERT INTO song_popularity
+                    (song_id, region_code, platform, popularity_score, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (song_id, region_code, platform, new_score, now),
+            )
+            conn.commit()
+            return {
+                "song_id": song_id,
+                "region_code": region_code,
+                "platform": platform,
+                "score": int(new_score),
+            }
 
-    def list_events(self, song_id: Optional[int] = None) -> List[Dict]:
+    def list_events(
+        self,
+        song_id: Optional[int] = None,
+        region_code: Optional[str] = None,
+        platform: Optional[str] = None,
+    ) -> List[Dict]:
         with sqlite3.connect(self.db_path) as conn:
             cur = conn.cursor()
             _ensure_schema(cur)
-            if song_id is None:
-                cur.execute(
-                    "SELECT id, song_id, source, boost, created_at FROM song_popularity_events ORDER BY id DESC"
-                )
-            else:
-                cur.execute(
-                    "SELECT id, song_id, source, boost, created_at FROM song_popularity_events "
-                    "WHERE song_id = ? ORDER BY id DESC",
-                    (song_id,),
-                )
+            query = (
+                "SELECT id, song_id, region_code, platform, source, boost, created_at FROM song_popularity_events"
+            )
+            params: List = []
+            conditions = []
+            if song_id is not None:
+                conditions.append("song_id = ?")
+                params.append(song_id)
+            if region_code is not None:
+                conditions.append("region_code = ?")
+                params.append(region_code)
+            if platform is not None:
+                conditions.append("platform = ?")
+                params.append(platform)
+            if conditions:
+                query += " WHERE " + " AND ".join(conditions)
+            query += " ORDER BY id DESC"
+            cur.execute(query, params)
             rows = cur.fetchall()
             return [
                 {
                     "id": r[0],
                     "song_id": r[1],
-                    "source": r[2],
-                    "boost": r[3],
-                    "created_at": r[4],
+                    "region_code": r[2],
+                    "platform": r[3],
+                    "source": r[4],
+                    "boost": r[5],
+                    "created_at": r[6],
                 }
                 for r in rows
             ]
@@ -96,26 +140,44 @@ class SongPopularityService:
 song_popularity_service = SongPopularityService()
 
 
-def add_event(song_id: int, amount: float, source: str) -> float:
+def add_event(
+    song_id: int,
+    amount: float,
+    source: str,
+    region_code: str = "global",
+    platform: str = "any",
+) -> float:
     """Boost a song's popularity by a given amount from some source."""
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         _ensure_schema(cur)
         cur.execute(
-            "SELECT popularity_score FROM song_popularity WHERE song_id=? ORDER BY updated_at DESC LIMIT 1",
-            (song_id,),
+            """
+            SELECT popularity_score FROM song_popularity
+            WHERE song_id=? AND region_code=? AND platform=?
+            ORDER BY updated_at DESC LIMIT 1
+            """,
+            (song_id, region_code, platform),
         )
         row = cur.fetchone()
         current = float(row[0]) if row else 0.0
         new_score = current + float(amount)
         now = datetime.utcnow().isoformat()
         cur.execute(
-            "INSERT INTO song_popularity (song_id, popularity_score, updated_at) VALUES (?, ?, ?)",
-            (song_id, new_score, now),
+            """
+            INSERT INTO song_popularity
+                (song_id, region_code, platform, popularity_score, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (song_id, region_code, platform, new_score, now),
         )
         cur.execute(
-            "INSERT INTO song_popularity_events (song_id, source, boost, created_at) VALUES (?, ?, ?, ?)",
-            (song_id, source, amount, now),
+            """
+            INSERT INTO song_popularity_events
+                (song_id, region_code, platform, source, boost, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (song_id, region_code, platform, source, amount, now),
         )
         conn.commit()
         return new_score
@@ -128,62 +190,174 @@ def apply_decay() -> int:
         _ensure_schema(cur)
         cur.execute(
             """
-            SELECT song_id, popularity_score FROM song_popularity
-            WHERE (song_id, updated_at) IN (
-                SELECT song_id, MAX(updated_at) FROM song_popularity GROUP BY song_id
+            SELECT song_id, region_code, platform, popularity_score FROM song_popularity
+            WHERE (song_id, region_code, platform, updated_at) IN (
+                SELECT song_id, region_code, platform, MAX(updated_at)
+                FROM song_popularity GROUP BY song_id, region_code, platform
             )
             """
         )
         rows = cur.fetchall()
         now = datetime.utcnow().isoformat()
         decayed = [
-            (song_id, score * DECAY_FACTOR, now)
-            for song_id, score in rows
+            (song_id, region_code, platform, score * DECAY_FACTOR, now)
+            for song_id, region_code, platform, score in rows
         ]
         if decayed:
             cur.executemany(
-                "INSERT INTO song_popularity (song_id, popularity_score, updated_at) VALUES (?, ?, ?)",
+                """
+                INSERT INTO song_popularity
+                    (song_id, region_code, platform, popularity_score, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
                 decayed,
             )
         conn.commit()
         return len(decayed)
 
 
-def get_history(song_id: int) -> List[Dict[str, float]]:
+def get_history(
+    song_id: int,
+    region_code: str = "global",
+    platform: str = "any",
+) -> List[Dict[str, float]]:
     """Return the popularity history for a song."""
     with sqlite3.connect(DB_PATH) as conn:
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
         _ensure_schema(cur)
         cur.execute(
-            "SELECT popularity_score, updated_at FROM song_popularity WHERE song_id=? ORDER BY updated_at",
-            (song_id,),
+            """
+            SELECT popularity_score, updated_at FROM song_popularity
+            WHERE song_id=? AND region_code=? AND platform=?
+            ORDER BY updated_at
+            """,
+            (song_id, region_code, platform),
         )
         return [dict(r) for r in cur.fetchall()]
 
 
-def get_current_popularity(song_id: int) -> float:
+def get_current_popularity(
+    song_id: int,
+    region_code: str = "global",
+    platform: str = "any",
+) -> float:
     """Return the latest popularity score for a song."""
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         _ensure_schema(cur)
         cur.execute(
-            "SELECT popularity_score FROM song_popularity WHERE song_id=? ORDER BY updated_at DESC LIMIT 1",
-            (song_id,),
+            """
+            SELECT popularity_score FROM song_popularity
+            WHERE song_id=? AND region_code=? AND platform=?
+            ORDER BY updated_at DESC LIMIT 1
+            """,
+            (song_id, region_code, platform),
         )
         row = cur.fetchone()
         return float(row[0]) if row else 0.0
 
 
-def get_last_boost_source(song_id: int) -> Optional[str]:
+def get_last_boost_source(
+    song_id: int,
+    region_code: str = "global",
+    platform: str = "any",
+) -> Optional[str]:
     """Return the source of the most recent popularity boost."""
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         _ensure_schema(cur)
         cur.execute(
-            "SELECT source FROM song_popularity_events WHERE song_id=? ORDER BY id DESC LIMIT 1",
-            (song_id,),
+            """
+            SELECT source FROM song_popularity_events
+            WHERE song_id=? AND region_code=? AND platform=?
+            ORDER BY id DESC LIMIT 1
+            """,
+            (song_id, region_code, platform),
         )
         row = cur.fetchone()
         return row[0] if row else None
+
+
+def get_breakdown(song_id: int) -> Dict[str, Dict[str, float]]:
+    """Return latest popularity scores grouped by region and platform."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+        _ensure_schema(cur)
+        cur.execute(
+            "SELECT region_code, platform, popularity_score, updated_at FROM song_popularity WHERE song_id=? ORDER BY updated_at DESC",
+            (song_id,),
+        )
+        rows = cur.fetchall()
+    breakdown: Dict[str, Dict[str, float]] = {}
+    seen = set()
+    for r in rows:
+        key = (r["region_code"], r["platform"])
+        if key in seen:
+            continue
+        seen.add(key)
+        breakdown.setdefault(r["region_code"], {})[r["platform"]] = r["popularity_score"]
+    return breakdown
+
+
+def aggregate_global_popularity() -> int:
+    """Aggregate regional popularity into global totals."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        _ensure_schema(cur)
+        cur.execute(
+            """
+            SELECT song_id, region_code, platform, popularity_score FROM song_popularity
+            WHERE (song_id, region_code, platform, updated_at) IN (
+                SELECT song_id, region_code, platform, MAX(updated_at)
+                FROM song_popularity GROUP BY song_id, region_code, platform
+            )
+            """
+        )
+        rows = cur.fetchall()
+        totals: Dict[int, float] = {}
+        for song_id, region_code, platform, score in rows:
+            if region_code == "global" and platform == "any":
+                continue
+            totals[song_id] = totals.get(song_id, 0.0) + float(score)
+        now = datetime.utcnow().isoformat()
+        inserts = [
+            (sid, "global", "any", total, now) for sid, total in totals.items()
+        ]
+        if inserts:
+            cur.executemany(
+                """
+                INSERT INTO song_popularity
+                    (song_id, region_code, platform, popularity_score, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                inserts,
+            )
+        conn.commit()
+        return len(inserts)
+
+
+def schedule_global_aggregation() -> None:
+    """Schedule daily aggregation of regional popularity into global totals."""
+    try:
+        from datetime import timedelta
+
+        from backend.services.scheduler_service import schedule_task
+
+        run_at = (datetime.utcnow() + timedelta(days=1)).isoformat()
+        schedule_task(
+            "aggregate_global_popularity",
+            {},
+            run_at,
+            recurring=True,
+            interval_days=1,
+        )
+    except Exception:
+        # Scheduling is best effort; ignore failures if scheduler tables don't exist
+        pass
+
+
+# Attempt to schedule aggregation on import
+schedule_global_aggregation()
 

--- a/frontend/components/popularity_map.vue
+++ b/frontend/components/popularity_map.vue
@@ -1,0 +1,35 @@
+<template>
+  <canvas ref="canvas"></canvas>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import Chart from 'chart.js/auto'
+
+const props = defineProps<{ songId: number }>()
+const canvas = ref<HTMLCanvasElement | null>(null)
+
+onMounted(async () => {
+  const resp = await fetch(`/music/metrics/songs/${props.songId}/popularity`)
+  const data = await resp.json()
+  const breakdown = data.breakdown || {}
+  const labels: string[] = []
+  const values: number[] = []
+  for (const [region, platforms] of Object.entries(breakdown)) {
+    const total = Object.values(platforms as Record<string, number>)
+      .map(v => Number(v))
+      .reduce((a, b) => a + b, 0)
+    labels.push(region)
+    values.push(total)
+  }
+  if (canvas.value) {
+    new Chart(canvas.value, {
+      type: 'bar',
+      data: {
+        labels,
+        datasets: [{ label: 'Popularity', data: values }],
+      },
+    })
+  }
+})
+</script>


### PR DESCRIPTION
## Summary
- track song popularity per region and platform
- expose popularity breakdowns via analytics API
- add Vue popularity map component and schedule daily global aggregation

## Testing
- `ruff check backend/services/song_popularity_service.py backend/routes/music_metrics_routes.py backend/services/media_event_service.py backend/routes/admin_song_popularity_routes.py backend/services/scheduler_service.py backend/tests/test_song_popularity.py`
- `pytest backend/tests/test_song_popularity.py::test_add_event_and_decay backend/tests/test_song_popularity.py::test_popularity_endpoint backend/tests/test_song_popularity.py::test_regional_breakdown -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4951942c8832580c31345f35fc9e8