### PR TITLE
Add song popularity forecasting

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -228,6 +228,19 @@ def init_db():
         )
         """)
 
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS song_popularity_forecasts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            song_id INTEGER NOT NULL,
+            forecast_date TEXT NOT NULL,
+            predicted_score REAL NOT NULL,
+            lower REAL,
+            upper REAL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(song_id) REFERENCES songs(id)
+        )
+        """)
+
         # Quest definition tables
         cur.execute("""
         CREATE TABLE IF NOT EXISTS quests (

--- a/backend/routes/music_metrics_routes.py
+++ b/backend/routes/music_metrics_routes.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 
 from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
 from backend.services import song_popularity_service
+from backend.services.song_popularity_forecast import forecast_service
 from backend.services.music_metrics import MusicMetricsService
 
 router = APIRouter(prefix="/music/metrics", tags=["Music Metrics"])
@@ -37,3 +38,11 @@ def get_song_popularity(
         ),
         "breakdown": song_popularity_service.get_breakdown(song_id),
     }
+
+
+@router.get("/songs/{song_id}/forecast")
+def get_song_forecast(song_id: int):
+    data = forecast_service.get_forecast(song_id)
+    if not data:
+        data = forecast_service.forecast_song(song_id)
+    return {"song_id": song_id, "forecast": data}

--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 from backend.database import DB_PATH
 from backend.services import chart_service, fan_service, song_popularity_service
+from backend.services.song_popularity_forecast import forecast_service
 from backend.services.skill_service import skill_service
 
 # Map event_type to handler functions
@@ -12,6 +13,7 @@ EVENT_HANDLERS = {
     "weekly_charts": chart_service.calculate_weekly_chart,
     "skill_decay": skill_service.decay_all,
     "aggregate_global_popularity": song_popularity_service.aggregate_global_popularity,
+    "song_popularity_forecast": forecast_service.recompute_all,
     # Add more event handlers here as needed
 }
 

--- a/backend/services/song_popularity_forecast.py
+++ b/backend/services/song_popularity_forecast.py
@@ -1,0 +1,129 @@
+"""Time-series forecasting for song popularity."""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+
+from backend.database import DB_PATH
+
+try:
+    from statsmodels.tsa.arima.model import ARIMA  # type: ignore
+except Exception:  # pragma: no cover - fallback if library missing
+    ARIMA = None  # type: ignore
+
+
+def _ensure_schema(cur: sqlite3.Cursor) -> None:
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS song_popularity_forecasts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            song_id INTEGER NOT NULL,
+            forecast_date TEXT NOT NULL,
+            predicted_score REAL NOT NULL,
+            lower REAL,
+            upper REAL,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+class SongPopularityForecastService:
+    """Generate simple ARIMA-based forecasts for song popularity."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = db_path or DB_PATH
+
+    def forecast_song(self, song_id: int, days: int = 7) -> List[Dict]:
+        """Recompute forecasts for a song and store them."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            _ensure_schema(cur)
+            cur.execute(
+                "SELECT popularity_score, updated_at FROM song_popularity WHERE song_id=? ORDER BY updated_at",
+                (song_id,),
+            )
+            rows = cur.fetchall()
+            if len(rows) < 2:
+                return []
+            scores = [r[0] for r in rows]
+            if ARIMA is not None:
+                try:
+                    model = ARIMA(scores, order=(1, 1, 0))
+                    model_fit = model.fit()
+                    forecast = model_fit.get_forecast(steps=days)
+                    preds = forecast.predicted_mean.tolist()
+                    conf = forecast.conf_int(alpha=0.05).to_numpy().tolist()
+                except Exception:
+                    preds = [scores[-1]] * days
+                    conf = [[scores[-1], scores[-1]] for _ in range(days)]
+            else:  # simple persistence forecast
+                preds = [scores[-1]] * days
+                conf = [[scores[-1], scores[-1]] for _ in range(days)]
+            last_date = datetime.fromisoformat(rows[-1][1])
+            cur.execute(
+                "DELETE FROM song_popularity_forecasts WHERE song_id=?",
+                (song_id,),
+            )
+            results: List[Dict] = []
+            for idx in range(days):
+                date = (last_date + timedelta(days=idx + 1)).isoformat()
+                pred = float(preds[idx])
+                lower = float(conf[idx][0])
+                upper = float(conf[idx][1])
+                now = datetime.utcnow().isoformat()
+                cur.execute(
+                    """
+                    INSERT INTO song_popularity_forecasts
+                        (song_id, forecast_date, predicted_score, lower, upper, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (song_id, date, pred, lower, upper, now),
+                )
+                results.append(
+                    {
+                        "forecast_date": date,
+                        "predicted_score": pred,
+                        "confidence_interval": [lower, upper],
+                    }
+                )
+            conn.commit()
+            return results
+
+    def get_forecast(self, song_id: int) -> List[Dict]:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            _ensure_schema(cur)
+            cur.execute(
+                """
+                SELECT forecast_date, predicted_score, lower, upper
+                FROM song_popularity_forecasts
+                WHERE song_id=? ORDER BY forecast_date
+                """,
+                (song_id,),
+            )
+            rows = cur.fetchall()
+            return [
+                {
+                    "forecast_date": r[0],
+                    "predicted_score": r[1],
+                    "confidence_interval": [r[2], r[3]],
+                }
+                for r in rows
+            ]
+
+    def recompute_all(self) -> int:
+        """Recompute forecasts for all songs with history."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT DISTINCT song_id FROM song_popularity")
+            ids = [r[0] for r in cur.fetchall()]
+        count = 0
+        for sid in ids:
+            if self.forecast_song(sid):
+                count += 1
+        return count
+
+
+forecast_service = SongPopularityForecastService()

--- a/backend/services/song_popularity_service.py
+++ b/backend/services/song_popularity_service.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from backend.database import DB_PATH
+from backend.services.song_popularity_forecast import forecast_service
 
 # Popularity decays by this factor every day
 DECAY_FACTOR = 0.95
@@ -87,6 +88,11 @@ class SongPopularityService:
                 (song_id, region_code, platform, new_score, now),
             )
             conn.commit()
+            # Recompute forecasts whenever a popularity event occurs
+            try:
+                forecast_service.forecast_song(song_id)
+            except Exception:
+                pass
             return {
                 "song_id": song_id,
                 "region_code": region_code,
@@ -180,6 +186,10 @@ def add_event(
             (song_id, region_code, platform, source, amount, now),
         )
         conn.commit()
+        try:
+            forecast_service.forecast_song(song_id)
+        except Exception:
+            pass
         return new_score
 
 

--- a/backend/tests/test_song_popularity.py
+++ b/backend/tests/test_song_popularity.py
@@ -15,6 +15,7 @@ def _reset_db():
         cur = conn.cursor()
         cur.execute("DROP TABLE IF EXISTS song_popularity")
         cur.execute("DROP TABLE IF EXISTS song_popularity_events")
+        cur.execute("DROP TABLE IF EXISTS song_popularity_forecasts")
         conn.commit()
 
 
@@ -58,3 +59,14 @@ def test_regional_breakdown():
     }
     assert data["breakdown"]["US"]["spotify"] == 5
     assert data["breakdown"]["EU"]["apple"] == 2
+
+
+def test_forecast_generation():
+    _reset_db()
+    add_event(4, 10, "stream")
+    add_event(4, 5, "sale")
+    from backend.services.song_popularity_forecast import forecast_service
+
+    forecasts = forecast_service.forecast_song(4, days=3)
+    assert len(forecasts) == 3
+    assert "predicted_score" in forecasts[0]

--- a/frontend/pages/popularity_dashboard.html
+++ b/frontend/pages/popularity_dashboard.html
@@ -13,6 +13,8 @@
 </div>
 
 <ul id="popularityHistory"></ul>
+<h3>Forecast</h3>
+<ul id="forecast"></ul>
 
 <script>
 async function loadPopularity() {
@@ -28,6 +30,15 @@ async function loadPopularity() {
     const li = document.createElement('li');
     li.innerText = `${point.updated_at}: ${point.popularity_score}`;
     list.appendChild(li);
+  });
+  const fRes = await fetch(`/music/metrics/songs/${id}/forecast`);
+  const fData = await fRes.json();
+  const fList = document.getElementById('forecast');
+  fList.innerHTML = '';
+  fData.forecast.forEach(f => {
+    const li = document.createElement('li');
+    li.innerText = `${f.forecast_date}: ${f.predicted_score.toFixed(2)} (${f.confidence_interval[0].toFixed(2)} - ${f.confidence_interval[1].toFixed(2)})`;
+    fList.appendChild(li);
   });
   // Hook for custom chart rendering if available
   if (window.renderPopularityChart) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ fastapi
 httpx
 redis
 alembic
+statsmodels
+pandas
 


### PR DESCRIPTION
## Summary
- add ARIMA-based `song_popularity_forecast` service with fallback when library unavailable
- expose `/music/metrics/songs/{song_id}/forecast` endpoint and update dashboard to display forecasts
- recompute forecasts after events and schedule nightly jobs

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement statsmodels)*
- `pytest backend/tests/test_song_popularity.py`

------
https://chatgpt.com/codex/tasks/task_e_68b497ee72608325b7299341c21d6ffb