### PR TITLE
Add social sentiment analytics to song popularity

### DIFF
--- a/backend/routes/music_metrics_routes.py
+++ b/backend/routes/music_metrics_routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
 from backend.services import song_popularity_service
 from backend.services.music_metrics import MusicMetricsService
+from backend.services.social_sentiment_service import social_sentiment_service
 
 router = APIRouter(prefix="/music/metrics", tags=["Music Metrics"])
 svc = MusicMetricsService()
@@ -37,3 +38,11 @@ def get_song_popularity(
         ),
         "breakdown": song_popularity_service.get_breakdown(song_id),
     }
+
+
+@router.get("/songs/{song_id}/sentiment")
+def get_song_sentiment(song_id: int):
+    """Return sentiment analytics for a song."""
+    history = social_sentiment_service.history(song_id)
+    current = history[-1]["sentiment"] if history else 0.0
+    return {"song_id": song_id, "current_sentiment": current, "history": history}

--- a/backend/services/social_sentiment_service.py
+++ b/backend/services/social_sentiment_service.py
@@ -1,0 +1,83 @@
+import sqlite3
+from datetime import datetime
+from typing import Callable, Dict, List, Optional
+
+from backend.database import DB_PATH
+from backend.services.song_popularity_service import add_event
+
+
+def _ensure_schema(cur: sqlite3.Cursor) -> None:
+    """Ensure sentiment history table exists."""
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS song_sentiment_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            song_id INTEGER NOT NULL,
+            sentiment REAL NOT NULL,
+            captured_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+class SocialSentimentService:
+    """Fetch social sentiment scores and map them to popularity boosts."""
+
+    def __init__(
+        self,
+        db_path: Optional[str] = None,
+        fetcher: Optional[Callable[[int], float]] = None,
+    ) -> None:
+        self.db_path = db_path or DB_PATH
+        # Fetcher returns a sentiment score (e.g., -1.0..1.0 or 0..1).
+        # Default fetcher returns neutral sentiment.
+        self.fetcher = fetcher or (lambda song_id: 0.0)
+
+    def fetch_sentiment(self, song_id: int) -> float:
+        """Fetch sentiment score for a song from the configured fetcher."""
+        return float(self.fetcher(song_id))
+
+    def process_song(self, song_id: int) -> Dict[str, float]:
+        """Fetch sentiment, log it, and convert to popularity boost."""
+        score = self.fetch_sentiment(song_id)
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            _ensure_schema(cur)
+            now = datetime.utcnow().isoformat()
+            cur.execute(
+                """
+                INSERT INTO song_sentiment_history (song_id, sentiment, captured_at)
+                VALUES (?, ?, ?)
+                """,
+                (song_id, score, now),
+            )
+            conn.commit()
+        # Translate sentiment score to a boost (simple linear mapping)
+        boost = int(round(score * 10))
+        if boost:
+            add_event(song_id, boost, source="social_sentiment")
+        return {"song_id": song_id, "sentiment": score, "boost": boost}
+
+    def history(self, song_id: int, limit: int = 100) -> List[Dict[str, float]]:
+        """Return sentiment history for a song."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            _ensure_schema(cur)
+            cur.execute(
+                """
+                SELECT sentiment, captured_at
+                FROM song_sentiment_history
+                WHERE song_id=?
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (song_id, limit),
+            )
+            rows = cur.fetchall()
+        # Return in chronological order
+        return [dict(r) for r in reversed(rows)]
+
+
+# Singleton instance used elsewhere
+social_sentiment_service = SocialSentimentService()

--- a/backend/tests/test_social_sentiment.py
+++ b/backend/tests/test_social_sentiment.py
@@ -1,0 +1,25 @@
+import sqlite3
+
+from backend.database import DB_PATH
+from backend.services.social_sentiment_service import SocialSentimentService
+from backend.services.song_popularity_service import get_current_popularity
+
+
+def _reset_db():
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS song_sentiment_history")
+        cur.execute("DROP TABLE IF EXISTS song_popularity")
+        cur.execute("DROP TABLE IF EXISTS song_popularity_events")
+        conn.commit()
+
+
+def test_sentiment_processing_updates_popularity():
+    _reset_db()
+    svc = SocialSentimentService(fetcher=lambda song_id: 0.8)
+    result = svc.process_song(1)
+    assert result["boost"] == 8
+    assert get_current_popularity(1) == 8
+    history = svc.history(1)
+    assert len(history) == 1
+    assert history[0]["sentiment"] == 0.8

--- a/frontend/pages/popularity_dashboard.html
+++ b/frontend/pages/popularity_dashboard.html
@@ -9,10 +9,13 @@
 <div>
   Current Popularity: <span id="currentPopularity">-</span><br />
   Half-life (days): <span id="halfLife">-</span><br />
-  Last Boost Source: <span id="lastBoost">-</span>
+  Last Boost Source: <span id="lastBoost">-</span><br />
+  Current Sentiment: <span id="currentSentiment">-</span>
 </div>
 
 <ul id="popularityHistory"></ul>
+<h3>Sentiment History</h3>
+<ul id="sentimentHistory"></ul>
 
 <script>
 async function loadPopularity() {
@@ -29,9 +32,23 @@ async function loadPopularity() {
     li.innerText = `${point.updated_at}: ${point.popularity_score}`;
     list.appendChild(li);
   });
-  // Hook for custom chart rendering if available
+
+  const sRes = await fetch(`/music/metrics/songs/${id}/sentiment`);
+  const sData = await sRes.json();
+  document.getElementById('currentSentiment').innerText = sData.current_sentiment.toFixed(2);
+  const sList = document.getElementById('sentimentHistory');
+  sList.innerHTML = '';
+  sData.history.forEach(point => {
+    const li = document.createElement('li');
+    li.innerText = `${point.captured_at}: ${point.sentiment}`;
+    sList.appendChild(li);
+  });
+  // Hooks for custom chart rendering if available
   if (window.renderPopularityChart) {
     window.renderPopularityChart(data.history);
+  }
+  if (window.renderSentimentChart) {
+    window.renderSentimentChart(sData.history);
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- Create `SocialSentimentService` to fetch song sentiment, log history, and convert scores to popularity boosts
- Expose `/music/metrics/songs/{song_id}/sentiment` endpoint for sentiment analytics
- Display current sentiment and trend history alongside popularity in dashboard

## Testing
- `pytest backend/tests/test_social_sentiment.py backend/tests/test_song_popularity.py::test_add_event_and_decay -q`

------
https://chatgpt.com/codex/tasks/task_e_68b49942f08c8325893c168feb6b9213