### PR TITLE
Add setlist revision approvals for live performances

### DIFF
--- a/backend/routes/live_performance.py
+++ b/backend/routes/live_performance.py
@@ -1,21 +1,22 @@
 from auth.dependencies import get_current_user_id, require_role
 
 from flask import Blueprint, request, jsonify
-from services.live_performance_service import LivePerformanceService
+from backend.services import live_performance_service
 
 live_routes = Blueprint('live_routes', __name__)
-live_service = LivePerformanceService(db=None)
 
 @live_routes.route('/gigs/simulate', methods=['POST'])
 def simulate_gig():
     data = request.json
     try:
-        setlist_source = data.get('revision_id', data.get('setlist'))
-        gig = live_service.simulate_gig(
+        revision_id = data.get('revision_id')
+        if revision_id is None:
+            return jsonify({'error': 'revision_id required'}), 400
+        gig = live_performance_service.simulate_gig(
             band_id=data['band_id'],
             city=data['city'],
             venue=data['venue'],
-            setlist=setlist_source
+            setlist_revision_id=revision_id
         )
         return jsonify(gig), 201
     except Exception as e:
@@ -23,4 +24,4 @@ def simulate_gig():
 
 @live_routes.route('/gigs/band/<int:band_id>', methods=['GET'])
 def get_band_gigs(band_id):
-    return jsonify(live_service.get_band_performances(band_id))
+    return jsonify(live_performance_service.get_band_performances(band_id))

--- a/backend/services/live_performance_service.py
+++ b/backend/services/live_performance_service.py
@@ -24,19 +24,17 @@ def simulate_gig(
     band_id: int,
     city: str,
     venue: str,
-    setlist,
+    setlist_revision_id: int,
     reaction_stream: Optional[Iterable[float]] = None,
 ) -> dict:
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
 
-
-    if isinstance(setlist, int):
-        approved = get_approved_setlist(setlist)
-        if not approved:
-            conn.close()
-            return {"error": "Setlist revision must be approved"}
-        setlist = approved
+    approved = get_approved_setlist(setlist_revision_id)
+    if not approved:
+        conn.close()
+        return {"error": "Setlist revision must be approved"}
+    setlist = approved
     # ensure performance_events table exists
     cur.execute(
         """

--- a/backend/services/tournament_service.py
+++ b/backend/services/tournament_service.py
@@ -78,7 +78,10 @@ class TournamentService:
     # Helpers ---------------------------------------------------------------
     def _calculate_score(self, band_id: int) -> Score:
         result = self.performance.simulate_gig(
-            band_id=band_id, city="Arena City", venue="Grand Arena", setlist=["song"]
+            band_id=band_id,
+            city="Arena City",
+            venue="Grand Arena",
+            setlist_revision_id=0,
         )
         return Score(
             band_id=band_id,

--- a/backend/tests/live_performance/test_crowd_reaction.py
+++ b/backend/tests/live_performance/test_crowd_reaction.py
@@ -1,7 +1,7 @@
 import json
 import sqlite3
 
-from backend.services import live_performance_service, live_performance_analysis
+from backend.services import live_performance_service, live_performance_analysis, setlist_service
 from backend.services.city_service import city_service
 from backend.models.city import City
 
@@ -34,6 +34,9 @@ def test_crowd_reaction_adjusts_and_logs(monkeypatch, tmp_path):
     cur.execute(
         "CREATE TABLE setlist_summaries (id INTEGER PRIMARY KEY AUTOINCREMENT, performance_id INTEGER, summary TEXT, created_at TEXT)"
     )
+    cur.execute(
+        "CREATE TABLE setlist_revisions (id INTEGER PRIMARY KEY AUTOINCREMENT, setlist_id INTEGER NOT NULL, setlist TEXT NOT NULL, author TEXT NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, approved INTEGER DEFAULT 0)"
+    )
     cur.execute("INSERT INTO bands (id, fame, skill, revenue) VALUES (1, 100, 0, 0)")
     cur.execute("INSERT INTO songs (id, band_id, title, duration_sec, genre, play_count, original_song_id) VALUES (1, 1, 'Song A', 0, '', 0, NULL)")
     conn.commit()
@@ -41,6 +44,7 @@ def test_crowd_reaction_adjusts_and_logs(monkeypatch, tmp_path):
 
     monkeypatch.setattr(live_performance_service, "DB_PATH", db_file)
     monkeypatch.setattr(live_performance_analysis, "DB_PATH", db_file)
+    monkeypatch.setattr(setlist_service, "DB_PATH", db_file)
     monkeypatch.setattr(live_performance_service.random, "randint", lambda a, b: a)
     monkeypatch.setattr(live_performance_service.gear_service, "get_band_bonus", lambda band_id, name: 0)
     monkeypatch.setattr(live_performance_service, "is_skill_blocked", lambda band_id, skill_id: False)
@@ -49,9 +53,11 @@ def test_crowd_reaction_adjusts_and_logs(monkeypatch, tmp_path):
         {"type": "song", "reference": "1"},
         {"type": "song", "reference": "1"},
     ]
+    revision_id = setlist_service.create_revision(1, setlist, "tester")
+    setlist_service.approve_revision(1, revision_id)
 
     reaction = iter([0.9, 0.9])
-    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", setlist, reaction_stream=reaction)
+    result = live_performance_service.simulate_gig(1, "Metro", "The Spot", revision_id, reaction_stream=reaction)
 
     assert result["fame_earned"] == 25
 

--- a/backend/tests/tournament/test_tournament_service.py
+++ b/backend/tests/tournament/test_tournament_service.py
@@ -17,7 +17,7 @@ class DummyPerformance:
     def __init__(self, scores):
         self.scores = scores
 
-    def simulate_gig(self, band_id, city, venue, setlist):
+    def simulate_gig(self, band_id, city, venue, setlist_revision_id=None, **_):
         value = self.scores[band_id]
         return {
             "status": "ok",

--- a/frontend/components/setlist_editor.vue
+++ b/frontend/components/setlist_editor.vue
@@ -36,11 +36,16 @@ export default {
       currentSetlist: '',
       revisions: [],
       comment: '',
-      comments: []
+      comments: [],
+      poller: null
     }
   },
   created() {
     this.fetchRevisions()
+    this.poller = setInterval(this.fetchRevisions, 5000)
+  },
+  beforeUnmount() {
+    clearInterval(this.poller)
   },
   methods: {
     async fetchRevisions() {


### PR DESCRIPTION
## Summary
- ensure setlists use revision workflow and create/approve/list endpoints
- lock live performances to approved setlist revisions
- add polling setlist editor with comments and approval actions

## Testing
- `pytest backend/tests/live_performance/test_setlist_structure.py backend/tests/live_performance/test_crowd_reaction.py backend/tests/city/test_city_trends.py backend/tests/tournament/test_tournament_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68b57c482400832594b02511dc3bea43