### PR TITLE
Add date filtering for song popularity data

### DIFF
--- a/backend/routes/music_metrics_routes.py
+++ b/backend/routes/music_metrics_routes.py
@@ -27,6 +27,8 @@ def get_song_popularity(
     song_id: int,
     region_code: str = "global",
     platform: str = "any",
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
 ):
     """Return popularity analytics for a song."""
     if region_code not in ALLOWED_REGION_CODES:
@@ -43,9 +45,11 @@ def get_song_popularity(
             song_id, region_code, platform
         ),
         "history": song_popularity_service.get_history(
-            song_id, region_code, platform
+            song_id, region_code, platform, start_date, end_date
         ),
-        "breakdown": song_popularity_service.get_breakdown(song_id),
+        "breakdown": song_popularity_service.get_breakdown(
+            song_id, start_date, end_date
+        ),
     }
 
 @router.get("/songs/{song_id}/sentiment")


### PR DESCRIPTION
## Summary
- allow music metrics popularity endpoint to filter by date range
- handle start/end dates in song popularity service history and breakdown
- send date params from popularity map component and update chart

## Testing
- `ruff check backend/routes/music_metrics_routes.py backend/services/song_popularity_service.py backend/tests/test_song_popularity.py`
- `pytest backend/tests/test_song_popularity.py::test_date_filters -q`
- `pytest` *(fails: 37 errors during collection)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b583066db083258b93b1f8b6c4a6fb