### PR TITLE
Add song popularity forecast endpoint and scheduling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,8 @@ from routes import (
     sponsorship,
     video_routes,
     setlist_routes,
+    music_metrics_routes,
+    song_forecast_routes,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -78,6 +80,8 @@ app.include_router(
     tags=["Onboarding"],
 )
 app.include_router(setlist_routes.router, prefix="/api", tags=["Setlists"])
+app.include_router(music_metrics_routes.router)
+app.include_router(song_forecast_routes.router)
 
 
 @app.get("/metrics")

--- a/backend/routes/song_forecast_routes.py
+++ b/backend/routes/song_forecast_routes.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+from backend.services.song_popularity_forecast import forecast_service
+
+router = APIRouter(prefix="/songs", tags=["Song Forecast"])
+
+
+@router.get("/{song_id}/forecast")
+def get_song_forecast(song_id: int):
+    """Return forecasted popularity for a song."""
+    data = forecast_service.get_forecast(song_id)
+    if not data:
+        data = forecast_service.forecast_song(song_id)
+    return {"song_id": song_id, "forecast": data}

--- a/backend/services/song_popularity_forecast.py
+++ b/backend/services/song_popularity_forecast.py
@@ -127,3 +127,24 @@ class SongPopularityForecastService:
 
 
 forecast_service = SongPopularityForecastService()
+
+
+def _schedule_forecast_recompute() -> None:
+    """Schedule nightly recomputation of all song forecasts."""
+    try:  # best effort; scheduler may not be set up in all environments
+        from backend.services.scheduler_service import schedule_task
+
+        run_at = (datetime.utcnow() + timedelta(days=1)).isoformat()
+        schedule_task(
+            "song_popularity_forecast",
+            {},
+            run_at,
+            recurring=True,
+            interval_days=1,
+        )
+    except Exception:
+        pass
+
+
+# Attempt to schedule on import
+_schedule_forecast_recompute()

--- a/backend/tests/test_song_popularity.py
+++ b/backend/tests/test_song_popularity.py
@@ -79,6 +79,25 @@ def test_forecast_generation():
     assert "predicted_score" in forecasts[0]
 
 
+def test_forecast_endpoint(client_factory):
+    if FastAPI is None:
+        pytest.skip("FastAPI not installed")
+    _reset_db()
+    app = FastAPI()
+    from backend.routes.song_forecast_routes import router as forecast_router
+
+    app.include_router(forecast_router)
+    add_event(6, 5, "stream")
+    add_event(6, 3, "sale")
+    client = client_factory(app)
+    resp = client.get("/songs/6/forecast")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["song_id"] == 6
+    assert len(data["forecast"]) > 0
+    assert "predicted_score" in data["forecast"][0]
+
+
 def test_add_event_invalid_inputs():
     _reset_db()
     with pytest.raises(ValueError):

--- a/frontend/pages/popularity_dashboard.html
+++ b/frontend/pages/popularity_dashboard.html
@@ -46,8 +46,7 @@ async function loadPopularity() {
     sList.appendChild(li);
   });
   // Hooks for custom chart rendering if available
-=======
-  const fRes = await fetch(`/music/metrics/songs/${id}/forecast`);
+  const fRes = await fetch(`/songs/${id}/forecast`);
   const fData = await fRes.json();
   const fList = document.getElementById('forecast');
   fList.innerHTML = '';


### PR DESCRIPTION
## Summary
- add `/songs/{song_id}/forecast` API and wire it into main app
- schedule nightly recomputation of song popularity forecasts
- update popularity dashboard to display forecasts via new endpoint
- add regression test for forecast endpoint

## Testing
- `pytest backend/tests/test_song_popularity.py -q`
- `pytest backend/tests/achievements/test_achievements.py -q` *(fails: No module named 'pydantic.schema')*


------
https://chatgpt.com/codex/tasks/task_e_68b584e0d134832580cd88e79b24f6ac