### PR TITLE
Add cover licensing marketplace and royalty settlement job

### DIFF
--- a/backend/jobs/royalty_clearing_job.py
+++ b/backend/jobs/royalty_clearing_job.py
@@ -1,0 +1,53 @@
+"""Periodic job for settling cover royalties.
+
+This job aggregates outstanding cover royalty transactions and marks them as
+paid.  Earnings are distributed to rights holders based on the ``royalties``
+split of the original song.  For simplicity the job only updates the
+``cover_royalties`` table and prints distributions; integrating with a real
+payment system is outside the scope of this module.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterable, Tuple
+
+from backend.database import DB_PATH
+
+
+def _fetch_outstanding(cur: sqlite3.Cursor) -> Iterable[Tuple[int, int, int, int]]:
+    """Yield outstanding cover royalty rows as ``(id, song_id, cover_band_id, owed)``."""
+
+    cur.execute(
+        """
+        SELECT id, song_id, cover_band_id, amount_owed
+        FROM cover_royalties
+        WHERE amount_owed > amount_paid
+        """
+    )
+    return cur.fetchall()
+
+
+def run(db: str = DB_PATH) -> None:
+    """Run the royalty clearing process for the given database."""
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    rows = _fetch_outstanding(cur)
+    for row in rows:
+        rid, song_id, cover_band_id, owed = row
+        cur.execute(
+            "SELECT user_id, percent FROM royalties WHERE song_id = ?", (song_id,)
+        )
+        splits = cur.fetchall()
+        for user_id, percent in splits:
+            amount = owed * percent // 100
+            print(
+                f"Settled {amount}¢ to rights holder {user_id} from band {cover_band_id} cover of song {song_id}"
+            )
+        cur.execute(
+            "UPDATE cover_royalties SET amount_paid = amount_owed WHERE id = ?",
+            (rid,),
+        )
+    conn.commit()
+    conn.close()

--- a/backend/services/licensing_marketplace_service.py
+++ b/backend/services/licensing_marketplace_service.py
@@ -1,0 +1,39 @@
+"""Service for retrieving songs available for cover licensing.
+
+This service fetches song catalogs from partner APIs.  The partner client is
+injected so it can be easily mocked in tests."""
+
+from typing import List, Dict, Protocol
+
+
+class PartnerClient(Protocol):
+    """Protocol for partner API clients."""
+
+    def fetch_catalog(self) -> List[Dict]:
+        """Return a list of songs with licensing terms.
+
+        Each song dictionary should contain at minimum ``song_id``, ``title`` and
+        ``license_fee`` keys.  Additional fields from the partner API are passed
+        through as-is.
+        """
+        ...
+
+
+class DefaultPartnerClient:
+    """Fallback client used when no external integration is provided."""
+
+    def fetch_catalog(self) -> List[Dict]:
+        # In production this would call out to the partner's HTTP API.  To keep
+        # this module fully offline-friendly we simply return an empty catalog.
+        return []
+
+
+class LicensingMarketplaceService:
+    """Expose a catalog of songs bands can license for covers."""
+
+    def __init__(self, partner_client: PartnerClient | None = None) -> None:
+        self.partner_client = partner_client or DefaultPartnerClient()
+
+    def list_available_songs(self) -> List[Dict]:
+        """Return songs available for cover along with fees and terms."""
+        return self.partner_client.fetch_catalog()

--- a/backend/tests/services/test_song_service.py
+++ b/backend/tests/services/test_song_service.py
@@ -1,6 +1,7 @@
 import sqlite3
 
 from backend.services.song_service import SongService
+from backend.jobs.royalty_clearing_job import run as royalty_run
 
 
 def setup_db(path):
@@ -13,7 +14,10 @@ def setup_db(path):
         "CREATE TABLE royalties (id INTEGER PRIMARY KEY AUTOINCREMENT, song_id INTEGER, user_id INTEGER, percent INTEGER)"
     )
     cur.execute(
-        "CREATE TABLE cover_royalties (id INTEGER PRIMARY KEY AUTOINCREMENT, song_id INTEGER, cover_band_id INTEGER, amount_owed INTEGER, amount_paid INTEGER, license_proof_url TEXT)"
+        "CREATE TABLE cover_royalties (id INTEGER PRIMARY KEY AUTOINCREMENT, song_id INTEGER, cover_band_id INTEGER, amount_owed INTEGER, amount_paid INTEGER)"
+    )
+    cur.execute(
+        "CREATE TABLE cover_license_transactions (id INTEGER PRIMARY KEY AUTOINCREMENT, song_id INTEGER, cover_band_id INTEGER, license_fee INTEGER, license_proof_url TEXT, purchased_at TEXT, expires_at TEXT)"
     )
     conn.commit()
     conn.close()
@@ -34,19 +38,29 @@ def test_create_cover_and_list(tmp_path):
     res = service.create_song(original)
     orig_id = res["song_id"]
 
+    cover_band = 2
     cover = {
-        "band_id": 2,
+        "band_id": cover_band,
         "title": "Cover",
         "duration_sec": 120,
         "genre": "rock",
-        "royalties_split": {2: 100},
+        "royalties_split": {cover_band: 100},
         "original_song_id": orig_id,
     }
-    service.create_song(cover)
+
+    # creating a cover without a license should fail
+    try:
+        service.create_cover(cover, license_transaction_id=999)
+        assert False, "expected PermissionError"
+    except PermissionError:
+        pass
+
+    tx = service.purchase_cover_license(orig_id, cover_band, "proof.png")
+    service.create_cover(cover, tx["transaction_id"])
 
     covers = service.list_covers_of_song(orig_id)
     assert len(covers) == 1
-    assert covers[0]["band_id"] == 2
+    assert covers[0]["band_id"] == cover_band
 
 
 def test_cover_royalties_and_license(tmp_path):
@@ -74,10 +88,25 @@ def test_cover_royalties_and_license(tmp_path):
     except PermissionError:
         pass
 
-    # Purchase license and record usage
-    service.purchase_cover_license(song_id, band_id, "proof.png")
+    # Purchase license and create cover
+    tx = service.purchase_cover_license(song_id, band_id, "proof.png")
+    cover_data = {
+        "band_id": band_id,
+        "title": "Cover",
+        "duration_sec": 120,
+        "genre": "rock",
+        "royalties_split": {band_id: 100},
+        "original_song_id": song_id,
+    }
+    service.create_cover(cover_data, tx["transaction_id"])
+
+    # Record usage and check royalties
     res = service.record_cover_usage(song_id, band_id, revenue_cents=1000)
     assert res["amount_owed"] == 100
     royalties = service.list_cover_royalties(band_id)
-    assert len(royalties) == 2
-    assert any(r["license_proof_url"] == "proof.png" for r in royalties)
+    assert len(royalties) == 1
+
+    # Run royalty clearing job and ensure amount_paid updated
+    royalty_run(db=str(db_path))
+    royalties_after = service.list_cover_royalties(band_id)
+    assert royalties_after[0]["amount_paid"] == royalties_after[0]["amount_owed"]

--- a/frontend/pages/cover_marketplace.html
+++ b/frontend/pages/cover_marketplace.html
@@ -1,0 +1,31 @@
+<h2>Cover Marketplace</h2>
+<div id="catalog"></div>
+
+<script>
+  async function loadCatalog() {
+    // In a real application this would call an API endpoint which in turn
+    // uses ``LicensingMarketplaceService``.  Here we just expect JSON of the
+    // form [{song_id, title, license_fee}].
+    const resp = await fetch('/licensing_marketplace');
+    const songs = await resp.json();
+    const container = document.getElementById('catalog');
+    container.innerHTML = '';
+    songs.forEach(s => {
+      const div = document.createElement('div');
+      div.className = 'song';
+      div.innerHTML = `<strong>${s.title}</strong> - Fee: ${s.license_fee}¢ ` +
+        `<button data-id="${s.song_id}">Purchase</button>`;
+      container.appendChild(div);
+    });
+  }
+
+  // placeholder purchase handler
+  document.addEventListener('click', async e => {
+    if (e.target.tagName === 'BUTTON' && e.target.dataset.id) {
+      const songId = e.target.dataset.id;
+      alert('Purchase flow for song ' + songId + ' would start here.');
+    }
+  });
+
+  loadCatalog();
+</script>


### PR DESCRIPTION
## Summary
- add mockable `LicensingMarketplaceService` for partner cover catalogs
- require active license transactions when creating covers and track royalties
- settle cover royalties via `royalty_clearing_job`
- basic frontend page to browse and purchase cover licenses

## Testing
- `pytest backend/tests/services/test_song_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b590731bdc8325af471c48cd9b294e