### PR TITLE
Add daily game loop design documentation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -91,6 +91,7 @@ This document outlines the current state of implemented features, the roadmap fo
 - Advanced NPC simulation with seasonal and random events.
 - Community-driven festivals and genre trends.
 - Player-submitted cosmetic moderation workflows.
+- Daily game loop with login streaks, rotating challenges, weekly item drops, and tiered rewards (see docs/daily_game_loop.md).
 
 ---
 

--- a/docs/daily_game_loop.md
+++ b/docs/daily_game_loop.md
@@ -1,0 +1,26 @@
+# Daily Game Loop Enhancements
+
+To encourage players to spend more time in RockMundo and reward them for consistent engagement, the following mechanics are proposed:
+
+1. **Daily Logins & Streak Bonuses**  
+   Provide small rewards for logging in each day with increasing value for maintaining streaks.
+2. **Rotating Daily Challenges**  
+   Offer a mix of quick and extended tasks that change daily to keep gameplay fresh.
+3. **Weekly Hour Milestones**  
+   Track play time and grant a rotating weekly item when players hit set hour thresholds.
+4. **Timed Event Tracks**  
+   Run limited-duration events with progress bars and milestone rewards.
+5. **Tiered Reward Levels**  
+   Introduce reward ladders where higher engagement unlocks better items.
+6. **Social & Community Goals**  
+   Include cooperative challenges and leaderboards to foster friendly competition.
+7. **Session-Based Bonuses**  
+   Drop small bonus items after continuous play sessions (e.g., every two hours).
+8. **Surprise Bonus Drops**  
+   Occasionally grant unexpected rewards at the end of sessions to keep players excited.
+9. **Provide Choice and Variety**  
+   Let players choose among multiple reward tracks tailored to different play styles.
+10. **Ethical Considerations**  
+    Keep time requirements reasonable and offer catch-up mechanics so players avoid burnout.
+
+These ideas can be combined into a cohesive daily loop that balances motivation, variety, and player well-being.


### PR DESCRIPTION
## Summary
- document proposed daily game loop engagement features
- reference new design doc in README

## Testing
- `pytest` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b59874b1c483259bacb78d3bb3cfa1