### PR TITLE
Add admin name dataset management endpoints

### DIFF
--- a/backend/routes/admin_name_routes.py
+++ b/backend/routes/admin_name_routes.py
@@ -1,0 +1,41 @@
+"""Administrative routes for managing name datasets."""
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services import name_dataset_service as dataset_service
+from backend.services.admin_audit_service import audit_dependency
+from pydantic import BaseModel
+
+router = APIRouter(
+    prefix="/names", tags=["AdminNames"], dependencies=[Depends(audit_dependency)]
+)
+
+
+class FirstNameIn(BaseModel):
+    name: str
+    gender: Literal["male", "female"]
+
+
+class SurnameIn(BaseModel):
+    name: str
+
+
+@router.post("/first")
+async def add_first_name(payload: FirstNameIn, req: Request) -> dict[str, str]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    if not dataset_service.add_first_name(payload.name, payload.gender):
+        raise HTTPException(status_code=409, detail="Name already exists")
+    return {"status": "ok"}
+
+
+@router.post("/surname")
+async def add_surname(payload: SurnameIn, req: Request) -> dict[str, str]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    if not dataset_service.add_surname(payload.name):
+        raise HTTPException(status_code=409, detail="Name already exists")
+    return {"status": "ok"}

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -12,6 +12,7 @@ from .admin_media_moderation_routes import router as media_router
 from .admin_modding_routes import router as modding_router
 from .admin_monitoring_routes import router as monitoring_router
 from .admin_music_routes import router as music_router
+from .admin_name_routes import router as name_router
 from .admin_npc_dialogue_routes import router as npc_dialogue_router
 from .admin_npc_routes import router as npc_router
 from .admin_quest_routes import router as quest_router
@@ -41,4 +42,5 @@ router.include_router(song_popularity_router)
 router.include_router(item_router)
 router.include_router(venue_router)
 router.include_router(music_router)
+router.include_router(name_router)
 

--- a/backend/services/name_dataset_service.py
+++ b/backend/services/name_dataset_service.py
@@ -1,0 +1,81 @@
+"""Utility service for maintaining simple name datasets.
+
+This module exposes helpers used by administrative endpoints to append new
+first names or surnames to CSV files under ``backend/utils/data``.  The files
+are created on demand and values are only appended when they do not already
+exist in the corresponding dataset.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+# Base directory containing the CSV datasets
+_DATA_DIR = Path(__file__).resolve().parents[1] / "utils" / "data"
+
+
+def _append_unique(file_path: Path, name: str) -> bool:
+    """Append ``name`` to ``file_path`` if it is not already present.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the CSV file.
+    name:
+        The name to append.
+
+    Returns
+    -------
+    bool
+        ``True`` if the name was appended, ``False`` if it was already present.
+    """
+
+    # Ensure the data directory exists
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    normalised = name.strip()
+    if not normalised:
+        return False
+
+    # Gather existing entries, if any
+    existing: set[str] = set()
+    if file_path.exists():
+        with file_path.open("r", encoding="utf-8") as fh:
+            existing = {line.strip().lower() for line in fh if line.strip()}
+
+    if normalised.lower() in existing:
+        return False
+
+    with file_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"{normalised}\n")
+    return True
+
+
+def add_first_name(name: str, gender: Literal["male", "female"]) -> bool:
+    """Add a first name to the gender specific dataset.
+
+    Parameters
+    ----------
+    name:
+        The first name to append.
+    gender:
+        ``"male"`` or ``"female"`` specifying which dataset to target.
+    """
+
+    file_map = {
+        "male": _DATA_DIR / "male_names.csv",
+        "female": _DATA_DIR / "female_names.csv",
+    }
+    return _append_unique(file_map[gender], name)
+
+
+def add_surname(name: str) -> bool:
+    """Add a surname to the dataset.
+
+    Parameters
+    ----------
+    name:
+        The surname to append.
+    """
+
+    return _append_unique(_DATA_DIR / "surnames.csv", name)


### PR DESCRIPTION
## Summary
- add service for appending unique first names and surnames to CSV datasets
- expose admin-only routes for adding first and last names
- register the new router in the aggregated admin router

## Testing
- `ruff check backend/services/name_dataset_service.py backend/routes/admin_name_routes.py backend/routes/admin_routes.py`
- `pytest` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a61d1e3c8325957ea2e5a67a774c