### PR TITLE
Enable dynamic name pool updates

### DIFF
--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Optional
 
 from backend.models.admin_action import AdminAction
 from backend.utils.db import get_conn
+from backend.utils import name_generator
 
 
 class AdminActionRepository:
@@ -133,4 +134,10 @@ class AdminService:
         if hasattr(self.repo, "update_game_balance"):
             self.repo.update_game_balance(setting_name, value)  # type: ignore[attr-defined]
         return {"status": f"{setting_name} updated to {value}."}
+
+    def add_name_to_pool(self, gender: str | None, name: str) -> Dict[str, str]:
+        """Append a name to the appropriate generator pool and refresh lists."""
+
+        name_generator.append_name(gender, name)
+        return {"status": "name added"}
 

--- a/backend/tests/admin/test_name_pools_reload.py
+++ b/backend/tests/admin/test_name_pools_reload.py
@@ -1,0 +1,33 @@
+from backend.services.admin_service import AdminService, AdminActionRepository
+from backend.utils import name_generator
+
+
+def test_add_name_updates_pools(tmp_path, monkeypatch):
+    # Preserve originals to restore after test
+    orig_dir = name_generator.DATA_DIR
+    orig_male = name_generator.MALE_FIRST_NAMES.copy()
+    orig_female = name_generator.FEMALE_FIRST_NAMES.copy()
+    orig_last = name_generator.LAST_NAMES.copy()
+
+    try:
+        # Setup temporary data files
+        (tmp_path / "male_names.csv").write_text("John\n")
+        (tmp_path / "female_names.csv").write_text("Jane\n")
+        (tmp_path / "surnames.csv").write_text("Doe\n")
+
+        monkeypatch.setattr(name_generator, "DATA_DIR", tmp_path)
+        name_generator.reload_name_pools()
+
+        svc = AdminService(AdminActionRepository(db_path=":memory:"))
+
+        svc.add_name_to_pool("male", "Alex")
+        assert "Alex" in name_generator.MALE_FIRST_NAMES
+
+        svc.add_name_to_pool(None, "Smith")
+        assert "Smith" in name_generator.LAST_NAMES
+    finally:
+        # Restore global state
+        name_generator.DATA_DIR = orig_dir
+        name_generator.MALE_FIRST_NAMES = orig_male
+        name_generator.FEMALE_FIRST_NAMES = orig_female
+        name_generator.LAST_NAMES = orig_last

--- a/backend/utils/name_generator.py
+++ b/backend/utils/name_generator.py
@@ -40,6 +40,44 @@ FEMALE_FIRST_NAMES = _load_names("female_names.csv")
 LAST_NAMES = _load_names("surnames.csv")
 
 
+def reload_name_pools() -> None:
+    """Reload name pools from CSV files into module-level lists."""
+
+    global MALE_FIRST_NAMES, FEMALE_FIRST_NAMES, LAST_NAMES
+    MALE_FIRST_NAMES = _load_names("male_names.csv")
+    FEMALE_FIRST_NAMES = _load_names("female_names.csv")
+    LAST_NAMES = _load_names("surnames.csv")
+
+
+def append_name(gender: str | None, name: str) -> None:
+    """Append ``name`` to the appropriate pool and update in-memory lists.
+
+    Parameters
+    ----------
+    gender:
+        ``"male"`` or ``"female"`` appends to the respective first-name pool.
+        ``None`` appends to the surname pool.
+    name:
+        The name to add.
+    """
+
+    mapping = {
+        "male": ("male_names.csv", MALE_FIRST_NAMES),
+        "female": ("female_names.csv", FEMALE_FIRST_NAMES),
+        None: ("surnames.csv", LAST_NAMES),
+    }
+    if gender not in mapping:
+        raise ValueError("gender must be 'male', 'female', or None")
+
+    filename, target = mapping[gender]
+    path = DATA_DIR / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow([name])
+    target.append(name.strip())
+
+
 # === Static stage/alias data ===============================================
 
 STAGE_SUFFIXES = [


### PR DESCRIPTION
## Summary
- allow reloading name pools from disk and appending new names
- expose `add_name_to_pool` on the admin service for immediate availability
- test that admin service refreshes name pools when adding names

## Testing
- `pytest` *(fails: ModelField() takes no arguments; ModuleNotFoundError: No module named 'boto3')*
- `pytest backend/tests/admin/test_name_pools_reload.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5a6d6d6e48325b524b80db39820f7