### PR TITLE
feat: add Stripe and PayPal gateways

### DIFF
--- a/backend/tests/payment/test_payment_service.py
+++ b/backend/tests/payment/test_payment_service.py
@@ -8,41 +8,35 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from backend.services.economy_service import EconomyService
-from backend.services.payment_service import PaymentError, PaymentGateway, PaymentService
+from backend.services.payment_service import (
+    PaymentError,
+    PaymentService,
+    PayPalGateway,
+    StripeGateway,
+)
 
 
-class DummyGateway(PaymentGateway):
-    def __init__(self, succeed: bool = True):
-        self.succeed = succeed
-        self.counter = 0
-
-    def create_payment(self, amount_cents: int, currency: str) -> str:
-        self.counter += 1
-        return f"pay_{self.counter}"
-
-    def verify_payment(self, payment_id: str) -> bool:
-        return self.succeed
-
-
-def setup_service(success: bool):
+def setup_service(success: bool, gateway_cls):
     fd, path = tempfile.mkstemp()
     os.close(fd)
     econ = EconomyService(db_path=path)
     econ.ensure_schema()
-    gateway = DummyGateway(succeed=success)
+    gateway = gateway_cls(succeed=success)
     svc = PaymentService(gateway, econ)
     return svc
 
 
-def test_purchase_success():
-    svc = setup_service(True)
+@pytest.mark.parametrize("gateway_cls", [StripeGateway, PayPalGateway])
+def test_purchase_success(gateway_cls):
+    svc = setup_service(True, gateway_cls)
     pid = svc.initiate_purchase(user_id=1, amount_cents=500)
     svc.verify_callback(pid)
     assert svc.economy_service.get_balance(1) == 500
 
 
-def test_purchase_failure():
-    svc = setup_service(False)
+@pytest.mark.parametrize("gateway_cls", [StripeGateway, PayPalGateway])
+def test_purchase_failure(gateway_cls):
+    svc = setup_service(False, gateway_cls)
     pid = svc.initiate_purchase(user_id=1, amount_cents=500)
     with pytest.raises(PaymentError):
         svc.verify_callback(pid)


### PR DESCRIPTION
## Summary
- implement StripeGateway and PayPalGateway with mock payment creation and verification
- allow PaymentService to choose gateways via registry
- test successful and failed flows for both gateways

## Testing
- `ruff check backend/services/payment_service.py backend/tests/payment/test_payment_service.py`
- `pytest backend/tests/payment/test_payment_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ac9611b88325b770e0207651483b