### PR TITLE
Log construction schema failures and upgrade errors

### DIFF
--- a/backend/services/construction_service.py
+++ b/backend/services/construction_service.py
@@ -1,6 +1,7 @@
 """Service for managing building construction queues and upgrades."""
 from __future__ import annotations
 
+import logging
 from typing import Dict, List, Optional
 
 from models.construction import Blueprint, ConstructionTask, LandParcel
@@ -23,11 +24,13 @@ class ConstructionService:
         try:
             self.property_service.ensure_schema()
         except Exception:
-            pass
+            logging.exception("Failed to ensure property schema")
+            raise
         try:
             self.venue_service.ensure_schema()
         except Exception:
-            pass
+            logging.exception("Failed to ensure venue schema")
+            raise
         self.parcels: Dict[int, LandParcel] = {}
         self.queue: List[ConstructionTask] = []
         self._next_parcel_id = 1
@@ -86,7 +89,7 @@ class ConstructionService:
             try:
                 self.property_service.upgrade_property(task.target_id, task.owner_id)
             except Exception:
-                pass
+                logging.exception("Failed to upgrade property %s", task.target_id)
             effect = task.blueprint.upgrade_effect
             if effect:
                 import sqlite3
@@ -103,7 +106,7 @@ class ConstructionService:
             try:
                 self.venue_service.update_venue(task.target_id, updates)
             except Exception:
-                pass
+                logging.exception("Failed to update venue %s", task.target_id)
 
     # ---------------- helpers ----------------
     def get_queue(self) -> List[Dict[str, int]]:

--- a/tests/test_construction_service_failures.py
+++ b/tests/test_construction_service_failures.py
@@ -1,0 +1,103 @@
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make backend modules like `models` importable
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.extend([str(ROOT), str(ROOT / "backend")])
+
+from services.construction_service import ConstructionService
+from models.construction import BuildPhase, Blueprint, ConstructionTask
+
+
+class DummyEconomy:
+    def ensure_schema(self) -> None:  # pragma: no cover - no logic
+        pass
+
+    def deposit(self, owner_id: int, amount: int) -> None:  # pragma: no cover - no logic
+        pass
+
+    def withdraw(self, owner_id: int, amount: int) -> None:  # pragma: no cover - no logic
+        pass
+
+
+class StubPropertyService:
+    db_path = ":memory:"
+
+    def ensure_schema(self) -> None:  # pragma: no cover - no logic
+        pass
+
+    def upgrade_property(self, property_id: int, owner_id: int) -> None:  # pragma: no cover - no logic
+        pass
+
+
+class FailingPropertySchemaService(StubPropertyService):
+    def ensure_schema(self) -> None:
+        raise RuntimeError("prop schema fail")
+
+
+class FailingUpgradePropertyService(StubPropertyService):
+    def upgrade_property(self, property_id: int, owner_id: int) -> None:
+        raise RuntimeError("upgrade fail")
+
+
+class StubVenueService:
+    def ensure_schema(self) -> None:  # pragma: no cover - no logic
+        pass
+
+    def update_venue(self, venue_id: int, updates: dict) -> None:  # pragma: no cover - no logic
+        pass
+
+    def get_venue(self, venue_id: int) -> dict:  # pragma: no cover - no logic
+        return {}
+
+
+class FailingVenueSchemaService(StubVenueService):
+    def ensure_schema(self) -> None:
+        raise RuntimeError("venue schema fail")
+
+
+class FailingUpdateVenueService(StubVenueService):
+    def update_venue(self, venue_id: int, updates: dict) -> None:
+        raise RuntimeError("update fail")
+
+
+def _make_service(prop_service: StubPropertyService, venue_service: StubVenueService) -> ConstructionService:
+    economy = DummyEconomy()
+    return ConstructionService(economy=economy, properties=prop_service, venues=venue_service)
+
+
+def test_init_fails_when_property_schema_fails(caplog: pytest.LogCaptureFixture) -> None:
+    venue_service = StubVenueService()
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError, match="prop schema fail"):
+            _make_service(FailingPropertySchemaService(), venue_service)
+    assert "Failed to ensure property schema" in caplog.text
+
+
+def test_init_fails_when_venue_schema_fails(caplog: pytest.LogCaptureFixture) -> None:
+    prop_service = StubPropertyService()
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError, match="venue schema fail"):
+            _make_service(prop_service, FailingVenueSchemaService())
+    assert "Failed to ensure venue schema" in caplog.text
+
+
+def test_complete_task_logs_property_upgrade_failure(caplog: pytest.LogCaptureFixture) -> None:
+    service = _make_service(FailingUpgradePropertyService(), StubVenueService())
+    blueprint = Blueprint("bp", 0, [BuildPhase("phase", 1)], "property", {})
+    task = ConstructionTask(parcel_id=1, blueprint=blueprint, owner_id=1, target_id=1)
+    with caplog.at_level(logging.ERROR):
+        service._complete_task(task)
+    assert "Failed to upgrade property" in caplog.text
+
+
+def test_complete_task_logs_venue_update_failure(caplog: pytest.LogCaptureFixture) -> None:
+    service = _make_service(StubPropertyService(), FailingUpdateVenueService())
+    blueprint = Blueprint("bp", 0, [BuildPhase("phase", 1)], "venue", {})
+    task = ConstructionTask(parcel_id=1, blueprint=blueprint, owner_id=1, target_id=1)
+    with caplog.at_level(logging.ERROR):
+        service._complete_task(task)
+    assert "Failed to update venue" in caplog.text


### PR DESCRIPTION
## Summary
- log and re-raise property/venue schema preparation errors during construction service initialization
- log property and venue upgrade errors during task completion
- add unit tests for schema failure raising and upgrade logging

## Testing
- `pytest tests/test_construction_service_failures.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'email_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68b5b465d024832584b38b944112be23