### PR TITLE
Ensure realtime modules require FastAPI and add websocket tests

### DIFF
--- a/backend/realtime/jam_gateway.py
+++ b/backend/realtime/jam_gateway.py
@@ -6,37 +6,12 @@ import json
 import logging
 from typing import Any, Dict
 
-try:  # pragma: no cover - used in real app
-    from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, Header
-except Exception:  # pragma: no cover - fallback for tests without FastAPI
-    class APIRouter:  # type: ignore
-        def __init__(self, *args, **kwargs):
-            pass
+try:  # pragma: no cover - explicit failure if FastAPI missing
+    from fastapi import APIRouter, Depends, Header, WebSocket, WebSocketDisconnect
+except ModuleNotFoundError as exc:  # pragma: no cover - FastAPI required
+    raise ImportError("FastAPI must be installed to use backend.realtime.jam_gateway") from exc
 
-        def websocket(self, path: str):
-            def decorator(func):
-                return func
-
-            return decorator
-
-    def Depends(dep):  # type: ignore
-        return dep
-
-    class WebSocket:  # type: ignore
-        async def accept(self):
-            pass
-
-        async def send_text(self, text: str):
-            pass
-
-        async def receive_text(self) -> str:
-            return ""
-
-    class WebSocketDisconnect(Exception):
-        pass
-
-    def Header(default=None, alias=None):  # type: ignore
-        return default
+from backend.services.jam_service import JamService
 
 
 async def get_current_user_id_dep(  # pragma: no cover - simple fallback
@@ -50,8 +25,6 @@ async def get_current_user_id_dep(  # pragma: no cover - simple fallback
         if len(parts) == 2 and parts[0].lower() == "bearer":
             return int(parts[1])
     return 0
-
-from backend.services.jam_service import JamService
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/jam", tags=["realtime"])

--- a/backend/realtime/polling.py
+++ b/backend/realtime/polling.py
@@ -5,29 +5,10 @@ import asyncio
 import json
 from typing import Dict
 
-try:  # pragma: no cover - used in real app
-    from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, Header
-except Exception:  # pragma: no cover - fallback for tests without FastAPI
-    class APIRouter:  # type: ignore
-        def __init__(self, *args, **kwargs):
-            pass
-        def websocket(self, path: str):
-            def decorator(func):
-                return func
-            return decorator
-    class WebSocket:  # type: ignore
-        async def accept(self):
-            pass
-        async def send_text(self, text: str):
-            pass
-        async def receive_text(self) -> str:
-            return ""
-    class WebSocketDisconnect(Exception):
-        pass
-    def Header(default=None, alias=None):  # type: ignore
-        return default
-    def Depends(dep):  # type: ignore
-        return dep
+try:  # pragma: no cover - explicit failure if FastAPI missing
+    from fastapi import APIRouter, Depends, Header, WebSocket, WebSocketDisconnect
+except ModuleNotFoundError as exc:  # pragma: no cover - FastAPI required
+    raise ImportError("FastAPI must be installed to use backend.realtime.polling") from exc
 
 
 async def get_current_user_id_dep(  # pragma: no cover - simple fallback

--- a/tests/realtime/test_jam_gateway_ws.py
+++ b/tests/realtime/test_jam_gateway_ws.py
@@ -1,0 +1,65 @@
+import pathlib
+import sys
+import types
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Ensure the project root is on sys.path for imports
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+
+class FakeStream:
+    def __init__(self, user_id: int, stream_id: str, codec: str, premium: bool):
+        self.user_id = user_id
+        self.stream_id = stream_id
+        self.codec = codec
+        self.premium = premium
+        self.started_at = "now"
+
+
+class FakeJamService:
+    def join_session(self, session_id: str, user_id: int) -> None:  # pragma: no cover - trivial
+        pass
+
+    def leave_session(self, session_id: str, user_id: int) -> None:  # pragma: no cover - trivial
+        pass
+
+    def start_stream(
+        self, session_id: str, user_id: int, stream_id: str, codec: str, premium: bool = False
+    ):
+        return FakeStream(user_id, stream_id, codec, premium)
+
+    def stop_stream(self, session_id: str, user_id: int) -> None:  # pragma: no cover - trivial
+        pass
+
+
+# Inject our fake JamService module before importing the gateway
+fake_module = types.ModuleType("jam_service")
+fake_module.JamService = FakeJamService
+sys.modules["backend.services.jam_service"] = fake_module
+
+from backend.realtime import jam_gateway  # noqa: E402
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    jam_gateway.jam_service = FakeJamService()
+    app.include_router(jam_gateway.router)
+    return app
+
+
+def test_jam_gateway_ping_and_stream():
+    app = create_app()
+    client = TestClient(app)
+    with client.websocket_connect("/jam/ws/s1", headers={"X-User-Id": "1"}) as ws:
+        joined = ws.receive_json()
+        assert joined == {"type": "joined", "user_id": 1}
+        ws.send_json({"op": "ping"})
+        assert ws.receive_json() == {"op": "pong"}
+        ws.send_json({"op": "start_stream", "stream_id": "sA", "codec": "opus", "premium": True})
+        started = ws.receive_json()
+        assert started["type"] == "stream_started"
+        assert started["user_id"] == 1
+        assert started["stream"]["stream_id"] == "sA"
+

--- a/tests/realtime/test_polling_ws.py
+++ b/tests/realtime/test_polling_ws.py
@@ -1,0 +1,24 @@
+import pathlib
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from backend.realtime import polling
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(polling.router)
+    return app
+
+
+def test_polling_vote_flow():
+    app = create_app()
+    client = TestClient(app)
+    with client.websocket_connect("/encore/ws/rock", headers={"X-User-Id": "1"}) as ws:
+        ws.send_json({"vote": "A"})
+        message = ws.receive_json()
+        assert message["type"] == "leaderboard"
+        assert message["votes"] == {"A": 1}


### PR DESCRIPTION
## Summary
- Remove in-module FastAPI stubs and raise import errors when FastAPI is missing
- Provide separate test-only mocks and integration tests for polling and jam gateways
- Cover WebSocket connect/send/receive flows with FastAPI's TestClient

## Testing
- `pytest tests/realtime/test_polling_ws.py tests/realtime/test_jam_gateway_ws.py -q`
- `pytest -q` *(fails: email-validator and other optional dependencies missing)*
- `ruff check backend/realtime/polling.py backend/realtime/jam_gateway.py tests/realtime/test_polling_ws.py tests/realtime/test_jam_gateway_ws.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5b63408dc8325b1904c631d267d00