### PR TITLE
Add learning methods and training session infrastructure

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -297,4 +297,28 @@ def init_db():
             """
         )
 
+        # Learning sessions for skill training
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS learning_sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            skill_id INTEGER NOT NULL,
+            method TEXT NOT NULL,
+            duration INTEGER NOT NULL,
+            status TEXT NOT NULL DEFAULT 'queued',
+            scheduled_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """)
+
+        # Optional tutor metadata
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS tutors (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            specialty_skill INTEGER,
+            rate INTEGER
+        )
+        """)
+
         conn.commit()

--- a/backend/models/learning_method.py
+++ b/backend/models/learning_method.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict
+
+
+class LearningMethod(str, Enum):
+    """Different approaches for learning a skill."""
+
+    BOOK = "book"
+    UNIVERSITY = "university"
+    APPRENTICESHIP = "apprenticeship"
+    YOUTUBE = "youtube"
+    TUTOR = "tutor"
+    BANDMATE = "bandmate"
+    WORKSHOP = "workshop"
+    PRACTICE = "practice"
+
+
+@dataclass(frozen=True)
+class MethodProfile:
+    """Configuration for a learning method.
+
+    Attributes:
+        xp_per_hour: Base XP earned per hour.
+        cost_per_hour: Monetary cost per hour.
+        session_cap: Optional maximum XP awarded per session.
+        min_level: Minimum skill level required to use the method.
+        max_level: Optional maximum skill level after which the method is no longer effective.
+    """
+
+    xp_per_hour: int
+    cost_per_hour: int
+    session_cap: int | None = None
+    min_level: int = 1
+    max_level: int | None = None
+
+
+METHOD_PROFILES: Dict[LearningMethod, MethodProfile] = {
+    LearningMethod.BOOK: MethodProfile(xp_per_hour=20, cost_per_hour=10, max_level=20),
+    LearningMethod.UNIVERSITY: MethodProfile(xp_per_hour=40, cost_per_hour=100, min_level=20),
+    LearningMethod.APPRENTICESHIP: MethodProfile(
+        xp_per_hour=30, cost_per_hour=50, min_level=10
+    ),
+    LearningMethod.YOUTUBE: MethodProfile(
+        xp_per_hour=15, cost_per_hour=0, max_level=30
+    ),
+    LearningMethod.TUTOR: MethodProfile(xp_per_hour=35, cost_per_hour=70, min_level=15),
+    LearningMethod.BANDMATE: MethodProfile(
+        xp_per_hour=25, cost_per_hour=0, session_cap=100
+    ),
+    LearningMethod.WORKSHOP: MethodProfile(
+        xp_per_hour=50, cost_per_hour=150, min_level=25
+    ),
+    LearningMethod.PRACTICE: MethodProfile(xp_per_hour=10, cost_per_hour=0),
+}
+
+
+__all__ = ["LearningMethod", "MethodProfile", "METHOD_PROFILES"]

--- a/backend/routes/learning_routes.py
+++ b/backend/routes/learning_routes.py
@@ -1,0 +1,40 @@
+"""Routing stubs for skill learning sessions."""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.models.learning_method import LearningMethod
+from backend.models.skill import Skill
+from backend.services.skill_service import SkillService
+
+router = APIRouter(prefix="/learning", tags=["Learning"])
+svc = SkillService()
+
+
+class SessionRequest(BaseModel):
+    user_id: int
+    skill_id: int
+    skill_name: str
+    skill_category: str
+    method: LearningMethod
+    duration: int
+
+
+@router.post("/sessions")
+def enqueue_session(payload: SessionRequest):
+    """Enqueue a learning session (stub)."""
+    skill = Skill(id=payload.skill_id, name=payload.skill_name, category=payload.skill_category)
+    try:
+        svc.train_with_method(payload.user_id, skill, payload.method, payload.duration)
+    except ValueError as exc:  # pragma: no cover - stub handler
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "queued"}
+
+
+@router.delete("/sessions/{session_id}")
+def cancel_session(session_id: int):
+    """Cancel a queued session (stub)."""
+    return {"status": "cancelled", "session_id": session_id}
+
+
+__all__ = ["router"]


### PR DESCRIPTION
## Summary
- define `LearningMethod` enum and method profiles for XP, cost and level limits
- extend `SkillService` with `train_with_method` to apply method-specific XP with gating
- create DB tables for `learning_sessions` and optional `tutors`
- add FastAPI stubs to enqueue/cancel learning sessions

## Testing
- `pytest` *(fails: NoReferencedTableError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b758facc1c83259bd4491cbc558dd6