### PR TITLE
Add skill book model and reading service

### DIFF
--- a/backend/models/book.py
+++ b/backend/models/book.py
@@ -1,0 +1,28 @@
+"""Simple model for skill books used in training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Book:
+    """Representation of a skill book.
+
+    Attributes:
+        title: Title of the book.
+        genre: Thematic genre the book belongs to.
+        rarity: Availability descriptor.
+        max_skill_level: Highest skill level the book can teach.
+    """
+
+    id: Optional[int]
+    title: str
+    genre: str
+    rarity: str
+    max_skill_level: int
+
+
+__all__ = ["Book"]
+

--- a/backend/services/books_service.py
+++ b/backend/services/books_service.py
@@ -1,0 +1,79 @@
+"""Service for managing skill books and reading sessions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+from backend.models.book import Book
+from backend.models.skill import Skill
+from backend.models.learning_method import LearningMethod
+from backend.services.skill_service import skill_service
+
+
+class BooksService:
+    def __init__(self) -> None:
+        self._books: Dict[int, Book] = {}
+        self._inventories: Dict[int, List[int]] = {}
+        self._id_seq = 1
+
+    # ------------------------------------------------------------------
+    # Book CRUD / inventory helpers
+    def create_book(self, book: Book) -> Book:
+        book.id = self._id_seq
+        self._books[book.id] = book
+        self._id_seq += 1
+        return book
+
+    def add_to_inventory(self, user_id: int, book_id: int) -> None:
+        if book_id not in self._books:
+            raise ValueError("invalid book")
+        self._inventories.setdefault(user_id, []).append(book_id)
+
+    def list_inventory(self, user_id: int) -> List[Book]:
+        return [self._books[i] for i in self._inventories.get(user_id, [])]
+
+    # ------------------------------------------------------------------
+    # Reading sessions
+    def queue_reading(self, user_id: int, book_id: int, skill: Skill, hours: int) -> dict:
+        """Queue a reading session that will grant skill XP when completed."""
+
+        if book_id not in self._inventories.get(user_id, []):
+            raise ValueError("book not in inventory")
+
+        run_at = datetime.utcnow() + timedelta(hours=hours)
+        params = {
+            "user_id": user_id,
+            "book_id": book_id,
+            "skill": {
+                "id": skill.id,
+                "name": skill.name,
+                "category": skill.category,
+                "parent_id": skill.parent_id,
+            },
+            "hours": hours,
+        }
+
+        from backend.services.scheduler_service import schedule_task
+
+        return schedule_task("complete_reading", params, run_at.isoformat())
+
+    def complete_reading(self, user_id: int, book_id: int, skill: dict, hours: int) -> dict:
+        book = self._books.get(book_id)
+        if not book:
+            return {"status": "error", "message": "book not found"}
+
+        sk = Skill(**skill)
+        skill_service.train_with_method(user_id, sk, LearningMethod.BOOK, hours, book)
+
+        inv = self._inventories.get(user_id, [])
+        if book_id in inv:
+            inv.remove(book_id)
+
+        return {"status": "ok"}
+
+
+books_service = BooksService()
+
+__all__ = ["BooksService", "books_service"]
+

--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 from backend.database import DB_PATH
 from backend.services import chart_service, fan_service, song_popularity_service
+from backend.services.books_service import books_service
 from backend.services.song_popularity_forecast import forecast_service
 from backend.services.skill_service import skill_service
 from backend.services.social_sentiment_service import social_sentiment_service
@@ -16,6 +17,7 @@ EVENT_HANDLERS = {
     "aggregate_global_popularity": song_popularity_service.aggregate_global_popularity,
     "song_popularity_forecast": forecast_service.recompute_all,
     "social_sentiment": social_sentiment_service.process_song,
+    "complete_reading": books_service.complete_reading,
     # Add more event handlers here as needed
 }
 

--- a/tests/test_books_service.py
+++ b/tests/test_books_service.py
@@ -1,0 +1,119 @@
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "backend"))
+
+from backend import database
+from backend.models.book import Book
+from backend.models.skill import Skill
+from backend.services import scheduler_service
+from backend.services.books_service import books_service
+from backend.services.skill_service import skill_service
+
+
+def _setup_db(tmp_path):
+    db = tmp_path / "sched.sqlite"
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE scheduled_tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type TEXT,
+            params TEXT,
+            run_at TEXT,
+            recurring INTEGER,
+            interval_days INTEGER,
+            last_run TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    database.DB_PATH = db
+    scheduler_service.DB_PATH = db
+    skill_service.db_path = db
+    return db
+
+
+def _reset_services():
+    books_service._books.clear()
+    books_service._inventories.clear()
+    books_service._id_seq = 1
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+
+
+def test_queue_reading(tmp_path):
+    _setup_db(tmp_path)
+    _reset_services()
+
+    book = books_service.create_book(
+        Book(id=None, title="Guitar 101", genre="music", rarity="common", max_skill_level=5)
+    )
+    books_service.add_to_inventory(1, book.id)
+    skill = Skill(id=1, name="guitar", category="instrument")
+
+    books_service.queue_reading(1, book.id, skill, hours=1)
+
+    conn = sqlite3.connect(scheduler_service.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT event_type FROM scheduled_tasks")
+    rows = cur.fetchall()
+    conn.close()
+    assert rows == [("complete_reading",)]
+
+
+def test_reading_completion(tmp_path):
+    _setup_db(tmp_path)
+    _reset_services()
+
+    book = books_service.create_book(
+        Book(id=None, title="Drums", genre="music", rarity="rare", max_skill_level=10)
+    )
+    books_service.add_to_inventory(1, book.id)
+    skill = Skill(id=2, name="drums", category="instrument")
+
+    books_service.queue_reading(1, book.id, skill, hours=1)
+
+    conn = sqlite3.connect(scheduler_service.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("UPDATE scheduled_tasks SET run_at = ?", (datetime.utcnow().isoformat(),))
+    conn.commit()
+    conn.close()
+
+    scheduler_service.run_due_tasks()
+
+    inst = skill_service._skills[(1, skill.id)]
+    assert inst.xp == 10
+    assert book.id not in books_service._inventories.get(1, [])
+
+
+def test_book_level_cap(tmp_path):
+    _setup_db(tmp_path)
+    _reset_services()
+
+    skill = Skill(id=3, name="bass", category="instrument", xp=150, level=2)
+    skill_service._skills[(1, skill.id)] = skill
+
+    book = books_service.create_book(
+        Book(id=None, title="Advanced", genre="music", rarity="epic", max_skill_level=3)
+    )
+    books_service.add_to_inventory(1, book.id)
+
+    books_service.queue_reading(1, book.id, skill, hours=20)
+
+    conn = sqlite3.connect(scheduler_service.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("UPDATE scheduled_tasks SET run_at = ?", (datetime.utcnow().isoformat(),))
+    conn.commit()
+    conn.close()
+
+    scheduler_service.run_due_tasks()
+
+    inst = skill_service._skills[(1, skill.id)]
+    assert inst.level == 3
+    assert inst.xp == 299
+


### PR DESCRIPTION
## Summary
- add Book dataclass for training limits
- implement BooksService to manage book inventory and schedule reading sessions
- reduce XP gain and enforce book level caps in skill training

## Testing
- `PYTHONPATH=. pytest tests/test_books_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b759b7a54883259ec280fcd1dcf78a