### PR TITLE
Add apprenticeship model, service, and API

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -343,4 +343,18 @@ def init_db():
         )
         """)
 
+        # Apprenticeships linking mentors and students
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS apprenticeships (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            student_id INTEGER NOT NULL,
+            mentor_id INTEGER NOT NULL,
+            mentor_type TEXT NOT NULL,
+            skill_id INTEGER NOT NULL,
+            duration_days INTEGER NOT NULL,
+            start_date TEXT,
+            status TEXT NOT NULL DEFAULT 'pending'
+        )
+        """)
+
         conn.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,19 +11,20 @@ from middleware.observability import ObservabilityMiddleware
 from middleware.rate_limit import RateLimitMiddleware
 from routes import (
     admin_routes,
+    apprenticeship_routes,
     event_routes,
     legacy_routes,
     lifestyle_routes,
     locale_routes,
-    onboarding_routes,
-    social_routes,
-    sponsorship,
-    video_routes,
-    setlist_routes,
     music_metrics_routes,
+    onboarding_routes,
+    setlist_routes,
+    social_routes,
     song_forecast_routes,
+    sponsorship,
     tour_collab_routes,
     university_routes,
+    video_routes,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -69,6 +70,7 @@ app.include_router(event_routes.router, prefix="/api/events", tags=["Events"])
 app.include_router(lifestyle_routes.router, prefix="/api", tags=["Lifestyle"])
 app.include_router(admin_routes.router, prefix="/admin", tags=["Admin"])
 app.include_router(admin_mfa_router)
+app.include_router(apprenticeship_routes.router, prefix="/api", tags=["Apprenticeships"])
 
 # Additional routers
 app.include_router(sponsorship.router, prefix="/api/sponsorships", tags=["Sponsorships"])

--- a/backend/models/apprenticeship.py
+++ b/backend/models/apprenticeship.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Apprenticeship:
+    """Link a student with a mentor for targeted skill training."""
+
+    id: int | None
+    student_id: int
+    mentor_id: int
+    mentor_type: str  # "npc" or "player"
+    skill_id: int
+    duration_days: int
+    start_date: Optional[str] = None
+    status: str = "pending"
+
+    def __post_init__(self) -> None:
+        if self.start_date is None and self.status == "active":
+            self.start_date = datetime.utcnow().isoformat()
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "student_id": self.student_id,
+            "mentor_id": self.mentor_id,
+            "mentor_type": self.mentor_type,
+            "skill_id": self.skill_id,
+            "duration_days": self.duration_days,
+            "start_date": self.start_date,
+            "status": self.status,
+        }
+
+
+__all__ = ["Apprenticeship"]

--- a/backend/routes/apprenticeship_routes.py
+++ b/backend/routes/apprenticeship_routes.py
@@ -1,0 +1,67 @@
+"""Routes for managing skill apprenticeships."""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from backend.services.apprenticeship_service import ApprenticeshipService
+from backend.services.karma_service import KarmaService
+
+
+class _KarmaDB:
+    def insert_karma_event(self, event):
+        pass
+
+    def update_user_karma(self, user_id, amount):
+        pass
+
+    def get_user_karma_total(self, user_id):
+        return 0
+
+
+router = APIRouter(prefix="/apprenticeships", tags=["Apprenticeships"])
+svc = ApprenticeshipService(karma=KarmaService(_KarmaDB()))
+
+
+class RequestIn(BaseModel):
+    student_id: int
+    mentor_id: int
+    mentor_type: str = "player"
+    skill_id: int
+    duration_days: int
+
+
+@router.post("/request")
+def request_apprenticeship(payload: RequestIn):
+    app = svc.request(
+        payload.student_id,
+        payload.mentor_id,
+        payload.mentor_type,
+        payload.skill_id,
+        payload.duration_days,
+    )
+    return app.to_dict()
+
+
+class AcceptIn(BaseModel):
+    apprenticeship_id: int
+
+
+@router.post("/accept")
+def accept_apprenticeship(payload: AcceptIn):
+    svc.start(payload.apprenticeship_id)
+    return {"status": "started"}
+
+
+class CompleteIn(BaseModel):
+    apprenticeship_id: int
+    mentor_level: int
+    relationship: int
+
+
+@router.post("/complete")
+def complete_apprenticeship(payload: CompleteIn):
+    xp = svc.stop(payload.apprenticeship_id, payload.mentor_level, payload.relationship)
+    return {"xp": xp}
+
+
+__all__ = ["router"]

--- a/backend/services/apprenticeship_service.py
+++ b/backend/services/apprenticeship_service.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from backend.database import DB_PATH
+from backend.models.apprenticeship import Apprenticeship
+from backend.services.karma_service import KarmaService
+
+
+class ApprenticeshipService:
+    """Manage apprenticeship lifecycle and XP rewards."""
+
+    def __init__(self, db_path: Path | None = None, karma: KarmaService | None = None) -> None:
+        self.db_path = Path(db_path or DB_PATH)
+        self.karma = karma
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    # ------------------------------------------------------------------
+    def request(self, student_id: int, mentor_id: int, mentor_type: str, skill_id: int, duration_days: int) -> Apprenticeship:
+        """Record an apprenticeship request waiting for mentor approval."""
+
+        app = Apprenticeship(
+            id=None,
+            student_id=student_id,
+            mentor_id=mentor_id,
+            mentor_type=mentor_type,
+            skill_id=skill_id,
+            duration_days=duration_days,
+            status="pending",
+        )
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO apprenticeships (student_id, mentor_id, mentor_type, skill_id, duration_days, status)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (app.student_id, app.mentor_id, app.mentor_type, app.skill_id, app.duration_days, app.status),
+            )
+            app.id = cur.lastrowid
+            conn.commit()
+        return app
+
+    def start(self, apprenticeship_id: int) -> None:
+        """Activate an apprenticeship after mentor approval."""
+
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "UPDATE apprenticeships SET start_date = ?, status = 'active' WHERE id = ?",
+                (datetime.utcnow().isoformat(), apprenticeship_id),
+            )
+            conn.commit()
+
+    def stop(self, apprenticeship_id: int, mentor_level: int, relationship: int) -> int:
+        """Complete an apprenticeship and return XP gained."""
+
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT student_id, mentor_id, skill_id, duration_days FROM apprenticeships WHERE id = ?",
+                (apprenticeship_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise ValueError("apprenticeship not found")
+            student_id, mentor_id, _skill_id, duration_days = row
+            xp = self.compute_xp(mentor_level, relationship, duration_days)
+            cur.execute(
+                "UPDATE apprenticeships SET status = 'completed' WHERE id = ?",
+                (apprenticeship_id,),
+            )
+            conn.commit()
+
+        if self.karma:
+            self.karma.adjust_karma(mentor_id, +2, "apprenticeship", "mentor", grant_xp=False)
+            self.karma.adjust_karma(student_id, +1, "apprenticeship", "student", grant_xp=False)
+        return xp
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def compute_xp(mentor_level: int, relationship: int, duration_days: int) -> int:
+        """Basic XP formula based on mentor level and relationship."""
+
+        base = mentor_level * duration_days
+        multiplier = 1 + (relationship / 100)
+        return int(base * multiplier)
+
+
+__all__ = ["ApprenticeshipService"]


### PR DESCRIPTION
## Summary
- add Apprenticeship model linking student, mentor, skill, and duration
- implement ApprenticeshipService to request, start, and complete apprenticeships with XP calculation
- expose FastAPI routes and integrate into main app

## Testing
- `pytest` *(fails: NoReferencedTableError and other setup errors)*
- `ruff check backend/models/apprenticeship.py backend/services/apprenticeship_service.py backend/routes/apprenticeship_routes.py backend/main.py backend/database.py`

------
https://chatgpt.com/codex/tasks/task_e_68b75d2531488325a6ce24d4413083c6