### PR TITLE
Add YouTube training method with breakthroughs and device requirement

### DIFF
--- a/backend/models/learning_method.py
+++ b/backend/models/learning_method.py
@@ -44,7 +44,7 @@ METHOD_PROFILES: Dict[LearningMethod, MethodProfile] = {
         xp_per_hour=30, cost_per_hour=50, min_level=10
     ),
     LearningMethod.YOUTUBE: MethodProfile(
-        xp_per_hour=15, cost_per_hour=0, max_level=30
+        xp_per_hour=50, cost_per_hour=0, max_level=10
     ),
     LearningMethod.TUTOR: MethodProfile(xp_per_hour=35, cost_per_hour=70, min_level=15),
     LearningMethod.BANDMATE: MethodProfile(


### PR DESCRIPTION
## Summary
- Boost YouTube learning profile with high XP and low max level
- Require an internet device to use YouTube training and allow 5% breakthrough XP doubles
- Test item gating, YouTube plateau, and breakthrough XP doubling

## Testing
- `PYTHONPATH=. pytest tests/test_skill_service.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'email_validator')*


------
https://chatgpt.com/codex/tasks/task_e_68b75e7c6a808325a39b0fd7d0d1fa99