### PR TITLE
Add tutor model and paid training service

### DIFF
--- a/backend/models/tutor.py
+++ b/backend/models/tutor.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Tutor:
+    """Represents a skill tutor available for hire."""
+
+    id: int | None
+    name: str
+    specialization: str
+    hourly_rate: int
+
+
+__all__ = ["Tutor"]

--- a/backend/services/tutor_service.py
+++ b/backend/services/tutor_service.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Service layer for handling tutor-led training sessions."""
+
+from typing import Dict, Optional
+
+from backend.models.tutor import Tutor
+from backend.models.skill import Skill
+from backend.models.learning_method import LearningMethod, METHOD_PROFILES
+from backend.services.economy_service import EconomyService
+from backend.services.skill_service import SkillService, skill_service
+
+
+class TutorService:
+    """Manage tutor definitions and paid training sessions."""
+
+    def __init__(
+        self,
+        economy: Optional[EconomyService] = None,
+        skills: Optional[SkillService] = None,
+    ) -> None:
+        self.economy = economy or EconomyService()
+        # Ensure economy schema exists for tests/in-memory usage
+        try:
+            self.economy.ensure_schema()
+        except Exception:
+            pass
+        self.skills = skills or skill_service
+        self._tutors: Dict[int, Tutor] = {}
+        self._id_seq = 1
+
+    # ------------------------------------------------------------------
+    # Tutor management
+    def create_tutor(self, tutor: Tutor) -> Tutor:
+        tutor.id = self._id_seq
+        self._tutors[tutor.id] = tutor
+        self._id_seq += 1
+        return tutor
+
+    def list_tutors(self) -> list[Tutor]:
+        return list(self._tutors.values())
+
+    # ------------------------------------------------------------------
+    # Session logic
+    def schedule_session(
+        self, user_id: int, skill: Skill, tutor_id: int, hours: int
+    ) -> dict:
+        """Withdraw cost and grant XP for a tutor session."""
+
+        tutor = self._tutors.get(tutor_id)
+        if not tutor:
+            raise ValueError("invalid tutor")
+        if tutor.specialization != skill.name:
+            raise ValueError("tutor does not teach this skill")
+
+        inst = self.skills.train(user_id, skill, 0)
+        profile = METHOD_PROFILES[LearningMethod.TUTOR]
+        if inst.level < profile.min_level:
+            raise ValueError("skill level too low for tutor")
+
+        cost = tutor.hourly_rate * hours
+        self.economy.withdraw(user_id, cost)
+
+        before = inst.xp
+        updated = self.skills.train_with_method(
+            user_id, skill, LearningMethod.TUTOR, hours
+        )
+        gained = updated.xp - before
+        xp_per_hour = gained // hours if hours else 0
+        return {
+            "status": "ok",
+            "skill": updated,
+            "xp_gained": gained,
+            "xp_per_hour": xp_per_hour,
+        }
+
+    def highest_xp_per_hour(self) -> int:
+        """Return the XP rate per hour for tutor sessions."""
+
+        return METHOD_PROFILES[LearningMethod.TUTOR].xp_per_hour
+
+
+# Shared instance
+tutor_service = TutorService()
+
+__all__ = ["TutorService", "tutor_service"]

--- a/tests/test_tutor_service.py
+++ b/tests/test_tutor_service.py
@@ -1,0 +1,54 @@
+import pytest
+
+from backend.models.skill import Skill
+from backend.models.tutor import Tutor
+from backend.models.learning_method import METHOD_PROFILES, LearningMethod
+from backend.services.economy_service import EconomyService
+from backend.services.skill_service import SkillService
+from backend.services.tutor_service import TutorService
+
+
+def _setup_services(tmp_path):
+    db = tmp_path / "db.sqlite"
+    economy = EconomyService(db_path=db)
+    skills = SkillService()
+    svc = TutorService(economy, skills)
+    return svc, economy, skills
+
+
+def test_tutor_requires_level(tmp_path):
+    svc, economy, skills = _setup_services(tmp_path)
+    tutor = svc.create_tutor(
+        Tutor(id=None, name="Maestro", specialization="guitar", hourly_rate=70)
+    )
+    skill = Skill(id=1, name="guitar", category="instrument")
+
+    economy.deposit(1, 1000)
+    balance_before = economy.get_balance(1)
+
+    with pytest.raises(ValueError):
+        svc.schedule_session(1, skill, tutor.id, 1)
+
+    assert economy.get_balance(1) == balance_before
+
+
+def test_tutor_session_cost_and_xp(tmp_path):
+    svc, economy, skills = _setup_services(tmp_path)
+    tutor = svc.create_tutor(
+        Tutor(id=None, name="Maestro", specialization="guitar", hourly_rate=70)
+    )
+    skill = Skill(id=2, name="guitar", category="instrument")
+
+    economy.deposit(1, 10000)
+    # Train to level 15
+    skills.train(1, skill, 1400)
+
+    balance_before = economy.get_balance(1)
+
+    result = svc.schedule_session(1, skill, tutor.id, 2)
+
+    balance_after = economy.get_balance(1)
+    assert balance_after == balance_before - tutor.hourly_rate * 2
+
+    assert result["xp_per_hour"] == METHOD_PROFILES[LearningMethod.TUTOR].xp_per_hour
+    assert result["xp_gained"] == METHOD_PROFILES[LearningMethod.TUTOR].xp_per_hour * 2


### PR DESCRIPTION
## Summary
- add Tutor dataclass with specialization and hourly rate
- implement TutorService to manage paid sessions with level checks and XP computation
- test tutor session level gating and economy deduction

## Testing
- `PYTHONPATH=.:backend pytest tests/test_tutor_service.py tests/test_skill_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68b75fb1246883258bc74a4c83430643