### PR TITLE
Add workshop events and ticketing

### DIFF
--- a/backend/models/event.py
+++ b/backend/models/event.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List
+
+
+class EventType(str, Enum):
+    """Enumeration of supported in-game event types."""
+
+    WORKSHOP = "WORKSHOP"
+
+
+@dataclass
+class Event:
+    """Generic event record used for workshops and similar activities."""
+
+    id: int
+    type: EventType
+    name: str
+    skill_target: str
+    ticket_cost: int
+    xp_reward: int
+    capacity: int
+    attendees: List[int] = field(default_factory=list)
+
+    def has_space(self) -> bool:
+        """Return True if more attendees can register."""
+
+        return len(self.attendees) < self.capacity

--- a/backend/routes/event_routes.py
+++ b/backend/routes/event_routes.py
@@ -1,12 +1,17 @@
-"""Route definitions for random daily events."""
+"""Route definitions for event-related actions."""
 
-from fastapi import APIRouter
+from dataclasses import asdict
 
+from fastapi import APIRouter, HTTPException
 from seeds.skill_seed import SKILL_NAME_TO_ID
-from services.event_service import apply_event_effect, roll_for_daily_event
+from services.event_service import (
+    apply_event_effect,
+    list_workshops,
+    purchase_workshop_ticket,
+    roll_for_daily_event,
+)
 
 from backend.schemas.events_schemas import EventRollRequest, EventRollResponse
-
 
 router = APIRouter()
 
@@ -22,3 +27,21 @@ def trigger_daily_event(payload: EventRollRequest) -> EventRollResponse:
         apply_event_effect(payload.user_id, event)
         return EventRollResponse(message="Event triggered", event=event)
     return EventRollResponse(message="No event today")
+
+
+@router.get("/events/workshops")
+def get_workshops():
+    """List all upcoming workshops."""
+
+    return {"workshops": [asdict(w) for w in list_workshops()]}
+
+
+@router.post("/events/workshops/{event_id}/purchase")
+def purchase_workshop(event_id: int, user_id: int):
+    """Purchase a ticket for a workshop and register attendance."""
+
+    try:
+        workshop = purchase_workshop_ticket(user_id, event_id)
+    except ValueError as exc:  # pragma: no cover - simple passthrough
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"workshop": asdict(workshop)}


### PR DESCRIPTION
## Summary
- introduce generic Event model with WORKSHOP type and related fields
- extend event service with workshop scheduling, ticket purchases, and XP rewards
- expose workshop listing and ticket purchase endpoints and tests

## Testing
- `ruff check backend/models/event.py backend/services/event_service.py backend/routes/event_routes.py backend/tests/services/test_event_service.py`
- `pytest backend/tests/services/test_event_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b762a38fd88325bc7b0b3d94470b5c