### PR TITLE
Award practice XP for gigs and studio sessions

### DIFF
--- a/backend/services/gig_service.py
+++ b/backend/services/gig_service.py
@@ -1,8 +1,13 @@
 import sqlite3
 import random
 from datetime import datetime, timedelta
+
 from backend.database import DB_PATH
 from backend.services import fan_service
+from backend.services.skill_service import skill_service
+from backend.models.skill import Skill
+from backend.models.learning_method import LearningMethod
+from seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 def create_gig(band_id: int, city: str, venue_size: int, date: str, ticket_price: int) -> dict:
@@ -83,6 +88,15 @@ def simulate_gig_result(gig_id: int):
 
     # Boost fans after gig
     fan_service.boost_fans_after_gig(band_id, city, attendance)
+
+    # Practice boosts performance skill scaled by venue size
+    performance_skill = Skill(
+        id=SKILL_NAME_TO_ID["performance"], name="performance", category="stage"
+    )
+    difficulty = max(1, venue_size // 50)
+    skill_service.train_with_method(
+        band_id, performance_skill, LearningMethod.PRACTICE, difficulty
+    )
 
     return {
         "attendance": attendance,

--- a/backend/services/recording_service.py
+++ b/backend/services/recording_service.py
@@ -4,6 +4,10 @@ from typing import Dict, List, Optional
 
 from backend.models.recording_session import RecordingSession
 from backend.services.economy_service import EconomyError, EconomyService
+from backend.services.skill_service import skill_service
+from backend.models.skill import Skill
+from backend.models.learning_method import LearningMethod
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 class RecordingService:
@@ -59,6 +63,16 @@ class RecordingService:
         if not session:
             raise KeyError("session_not_found")
         session.track_statuses[track_id] = status
+
+        # Award practice XP to all personnel based on task difficulty
+        difficulty = {"recorded": 1, "mixed": 2, "mastered": 3}.get(status, 1)
+        skill = Skill(
+            id=SKILL_NAME_TO_ID["music_production"],
+            name="music_production",
+            category="creative",
+        )
+        for uid in session.personnel:
+            skill_service.train_with_method(uid, skill, LearningMethod.PRACTICE, difficulty)
 
     def get_session(self, session_id: int) -> Optional[RecordingSession]:
         return self.sessions.get(session_id)

--- a/tests/test_practice_xp.py
+++ b/tests/test_practice_xp.py
@@ -1,0 +1,81 @@
+import sqlite3
+from pathlib import Path
+
+from backend.services.skill_service import skill_service
+from backend.models.skill import Skill
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+
+
+def _setup_gig_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE bands (id INTEGER PRIMARY KEY, fame INTEGER DEFAULT 0)"
+    )
+    cur.execute(
+        """
+        CREATE TABLE gigs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            band_id INTEGER,
+            city TEXT,
+            venue_size INTEGER,
+            date TEXT,
+            ticket_price INTEGER,
+            status TEXT,
+            attendance INTEGER,
+            revenue INTEGER,
+            fame_gain INTEGER
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_gig_performance_grants_skill(monkeypatch, tmp_path):
+    from backend.services import gig_service as gs
+
+    db = tmp_path / "gig.db"
+    _setup_gig_db(db)
+    monkeypatch.setattr(gs, "DB_PATH", str(db))
+    monkeypatch.setattr(gs.fan_service, "get_band_fan_stats", lambda _bid: {"total_fans": 0, "average_loyalty": 0})
+    monkeypatch.setattr(gs.fan_service, "boost_fans_after_gig", lambda *a, **k: None)
+
+    conn = sqlite3.connect(db)
+    conn.execute("INSERT INTO bands (id, fame) VALUES (1, 0)")
+    conn.commit()
+    conn.close()
+
+    gs.create_gig(1, "Test City", 100, "2024-01-01", 10)
+
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+    gs.simulate_gig_result(1)
+
+    perf_skill = Skill(id=SKILL_NAME_TO_ID["performance"], name="performance", category="stage")
+    inst = skill_service.train(1, perf_skill, 0)
+    assert inst.xp == 20
+
+
+class DummyEconomy:
+    def ensure_schema(self) -> None:
+        pass
+
+    def withdraw(self, *args, **kwargs) -> None:
+        pass
+
+
+def test_recording_session_grants_skill():
+    from backend.services.recording_service import RecordingService
+
+    svc = RecordingService(economy=DummyEconomy())
+    session = svc.schedule_session(1, "Studio", "2024-01-01", "2024-01-02", [1], 0)
+    svc.assign_personnel(session.id, 42)
+
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+    svc.update_track_status(session.id, 1, "mixed")
+
+    prod_skill = Skill(id=SKILL_NAME_TO_ID["music_production"], name="music_production", category="creative")
+    inst = skill_service.train(42, prod_skill, 0)
+    assert inst.xp == 20


### PR DESCRIPTION
## Summary
- Train performance skill via PRACTICE after gigs, scaling XP by venue difficulty
- Grant music production PRACTICE XP to studio personnel when tracks progress
- Cover new gig and recording practice scenarios with tests

## Testing
- `PYTHONPATH=.:backend pytest tests/test_practice_xp.py -q`
- `PYTHONPATH=.:backend pytest -q` *(fails: ModuleNotFoundError: No module named 'email_validator')*


------
https://chatgpt.com/codex/tasks/task_e_68b763f159388325a8a194a3a0fc3b8c