### PR TITLE
Add learning-style and environment modifiers to skill XP

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -15,7 +15,8 @@ def init_db():
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             username TEXT UNIQUE NOT NULL,
             password_hash TEXT NOT NULL,
-            role TEXT DEFAULT 'player'
+            role TEXT DEFAULT 'player',
+            learning_style TEXT DEFAULT 'balanced'
         )
         """)
 

--- a/backend/models/learning_style.py
+++ b/backend/models/learning_style.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict
+
+from backend.models.learning_method import LearningMethod
+
+
+class LearningStyle(str, Enum):
+    """Preferred way a user tends to learn new skills."""
+
+    BALANCED = "balanced"
+    VISUAL = "visual"
+    AUDITORY = "auditory"
+    READING = "reading"
+    KINESTHETIC = "kinesthetic"
+
+
+# XP multipliers per learning style and method
+LEARNING_STYLE_BONUS: Dict[LearningStyle, Dict[LearningMethod, float]] = {
+    LearningStyle.VISUAL: {LearningMethod.YOUTUBE: 1.2},
+    LearningStyle.AUDITORY: {LearningMethod.TUTOR: 1.2},
+    LearningStyle.READING: {LearningMethod.BOOK: 1.2},
+    LearningStyle.KINESTHETIC: {
+        LearningMethod.PRACTICE: 1.2,
+        LearningMethod.APPRENTICESHIP: 1.1,
+    },
+}
+
+
+__all__ = ["LearningStyle", "LEARNING_STYLE_BONUS"]

--- a/backend/models/recording_session.py
+++ b/backend/models/recording_session.py
@@ -17,6 +17,7 @@ class RecordingSession:
     track_statuses: Dict[int, str] = field(default_factory=dict)
     personnel: List[int] = field(default_factory=list)
     cost_cents: int = 0
+    environment_quality: float = 1.0
     created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
 
     def to_dict(self) -> dict:
@@ -29,6 +30,7 @@ class RecordingSession:
             "track_statuses": dict(self.track_statuses),
             "personnel": list(self.personnel),
             "cost_cents": self.cost_cents,
+            "environment_quality": self.environment_quality,
             "created_at": self.created_at,
         }
 

--- a/backend/services/lifestyle_scheduler.py
+++ b/backend/services/lifestyle_scheduler.py
@@ -4,7 +4,6 @@ import sqlite3
 from datetime import datetime
 from pathlib import Path
 
-from .skill_service import skill_service
 from .xp_event_service import XPEventService
 
 DB_PATH = Path(__file__).resolve().parent.parent / "rockmundo.db"
@@ -33,6 +32,8 @@ def lifestyle_xp_modifier(sleep, stress, discipline, mental):
     return round(modifier, 2)
 
 def apply_lifestyle_decay_and_xp_effects():
+    from .skill_service import skill_service  # local import to avoid cycle
+
     event_svc = XPEventService()
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()

--- a/backend/services/recording_service.py
+++ b/backend/services/recording_service.py
@@ -27,6 +27,7 @@ class RecordingService:
         end: str,
         tracks: List[int],
         cost_cents: int,
+        environment_quality: float = 1.0,
     ) -> RecordingSession:
         """Schedule a new recording session and charge the band."""
 
@@ -42,6 +43,7 @@ class RecordingService:
             end=end,
             track_statuses={tid: "pending" for tid in tracks},
             cost_cents=cost_cents,
+            environment_quality=environment_quality,
         )
         self.sessions[session.id] = session
         self._id_seq += 1


### PR DESCRIPTION
## Summary
- add `learning_style` to user profiles with style-based XP bonuses
- factor lifestyle metrics, environment quality, and burnout history into skill training
- extend rehearsal and recording sessions with environment quality tracking
- cover new modifiers with unit tests

## Testing
- `PYTHONPATH=. pytest tests/test_skill_service.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'email_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68b7660f275083258f8ece1c296e53c8