### PR TITLE
Add admin book management routes and frontend

### DIFF
--- a/backend/routes/admin_book_routes.py
+++ b/backend/routes/admin_book_routes.py
@@ -1,0 +1,57 @@
+"""Admin routes for managing books."""
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.models.book import Book
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.book_admin_service import BookAdminService, get_book_admin_service
+
+router = APIRouter(
+    prefix="/learning/books", tags=["AdminBooks"], dependencies=[Depends(audit_dependency)]
+)
+svc: BookAdminService = get_book_admin_service()
+
+
+class BookIn(BaseModel):
+    title: str
+    genre: str
+    rarity: str
+    max_skill_level: int
+
+
+async def _ensure_admin(req: Request) -> None:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+
+
+@router.get("/")
+async def list_books(req: Request) -> list[Book]:
+    await _ensure_admin(req)
+    return svc.list_books()
+
+
+@router.post("/")
+async def create_book(payload: BookIn, req: Request) -> Book:
+    await _ensure_admin(req)
+    book = Book(id=None, **payload.dict())
+    return svc.create_book(book)
+
+
+@router.put("/{book_id}")
+async def update_book(book_id: int, payload: BookIn, req: Request) -> Book:
+    await _ensure_admin(req)
+    try:
+        return svc.update_book(book_id, **payload.dict())
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.delete("/{book_id}")
+async def delete_book(book_id: int, req: Request) -> dict[str, str]:
+    await _ensure_admin(req)
+    svc.delete_book(book_id)
+    return {"status": "deleted"}
+
+
+__all__ = ["router", "list_books", "create_book", "update_book", "delete_book", "BookIn", "svc"]

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -7,6 +7,7 @@ from .admin_audit_routes import router as audit_router
 from .admin_business_routes import router as business_router
 from .admin_economy_routes import router as economy_router
 from .admin_item_routes import router as item_router
+from .admin_book_routes import router as book_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
 from .admin_modding_routes import router as modding_router
@@ -40,6 +41,7 @@ router.include_router(quest_router)
 router.include_router(schema_router)
 router.include_router(song_popularity_router)
 router.include_router(item_router)
+router.include_router(book_router)
 router.include_router(venue_router)
 router.include_router(music_router)
 router.include_router(name_router)

--- a/backend/routes/admin_schema_routes.py
+++ b/backend/routes/admin_schema_routes.py
@@ -60,6 +60,13 @@ class ItemSchema(BaseModel):
     stats: Dict[str, float] = {}
 
 
+class BookSchema(BaseModel):
+    title: str
+    genre: str
+    rarity: str
+    max_skill_level: int
+
+
 router = APIRouter(prefix="/schema", tags=["AdminSchema"])
 
 
@@ -108,3 +115,9 @@ async def xp_item_schema(req: Request) -> Dict[str, Any]:
 async def item_schema(req: Request) -> Dict[str, Any]:
     await _ensure_admin(req)
     return ItemSchema.model_json_schema()
+
+
+@router.get("/book")
+async def book_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return BookSchema.model_json_schema()

--- a/backend/services/book_admin_service.py
+++ b/backend/services/book_admin_service.py
@@ -1,0 +1,108 @@
+"""Admin service for managing books in SQLite."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import List, Optional
+
+from backend.models.book import Book
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class BookAdminService:
+    """CRUD helpers for skill books."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS books (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT NOT NULL,
+                    genre TEXT NOT NULL,
+                    rarity TEXT NOT NULL,
+                    max_skill_level INTEGER NOT NULL
+                )
+                """,
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def list_books(self) -> List[Book]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, title, genre, rarity, max_skill_level FROM books ORDER BY id"
+            )
+            rows = cur.fetchall()
+            return [Book(**dict(row)) for row in rows]
+
+    # ------------------------------------------------------------------
+    def create_book(self, book: Book) -> Book:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO books (title, genre, rarity, max_skill_level) VALUES (?, ?, ?, ?)",
+                (book.title, book.genre, book.rarity, book.max_skill_level),
+            )
+            book.id = cur.lastrowid
+            conn.commit()
+            return book
+
+    # ------------------------------------------------------------------
+    def update_book(self, book_id: int, **changes) -> Book:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, title, genre, rarity, max_skill_level FROM books WHERE id = ?",
+                (book_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise ValueError("Book not found")
+            data = dict(row)
+            for k, v in changes.items():
+                if k in data and v is not None:
+                    data[k] = v
+            cur.execute(
+                "UPDATE books SET title=?, genre=?, rarity=?, max_skill_level=? WHERE id=?",
+                (
+                    data["title"],
+                    data["genre"],
+                    data["rarity"],
+                    data["max_skill_level"],
+                    book_id,
+                ),
+            )
+            conn.commit()
+            return Book(**data)
+
+    # ------------------------------------------------------------------
+    def delete_book(self, book_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM books WHERE id=?", (book_id,))
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM books")
+            conn.commit()
+
+
+book_admin_service = BookAdminService()
+
+
+def get_book_admin_service() -> BookAdminService:
+    return book_admin_service
+
+
+__all__ = ["BookAdminService", "book_admin_service", "get_book_admin_service"]

--- a/backend/tests/admin/test_book_routes.py
+++ b/backend/tests/admin/test_book_routes.py
@@ -1,0 +1,66 @@
+import asyncio
+import pytest
+from fastapi import HTTPException, Request
+
+from backend.routes.admin_book_routes import (
+    BookIn,
+    create_book,
+    delete_book,
+    list_books,
+    update_book,
+    svc,
+)
+
+
+def test_admin_book_routes_require_admin():
+    req = Request({"type": "http", "headers": []})
+    payload = BookIn(title="t", genre="g", rarity="common", max_skill_level=1)
+    with pytest.raises(HTTPException):
+        asyncio.run(list_books(req))
+    with pytest.raises(HTTPException):
+        asyncio.run(create_book(payload, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(update_book(1, payload, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(delete_book(1, req))
+
+
+def test_admin_book_routes_crud(monkeypatch, tmp_path):
+    async def fake_current_user(req):
+        return 1
+
+    async def fake_require_role(roles, user_id):
+        return True
+
+    monkeypatch.setattr(
+        "backend.routes.admin_book_routes.get_current_user_id", fake_current_user
+    )
+    monkeypatch.setattr(
+        "backend.routes.admin_book_routes.require_role", fake_require_role
+    )
+
+    # use temporary db
+    svc.db_path = str(tmp_path / "books.db")
+    svc.ensure_schema()
+    svc.clear()
+
+    req = Request({"type": "http", "headers": []})
+    payload = BookIn(
+        title="A", genre="fiction", rarity="common", max_skill_level=5
+    )
+    book = asyncio.run(create_book(payload, req))
+    assert book.id is not None
+
+    books = asyncio.run(list_books(req))
+    assert len(books) == 1
+
+    upd = BookIn(
+        title="B", genre="fiction", rarity="rare", max_skill_level=6
+    )
+    updated = asyncio.run(update_book(book.id, upd, req))
+    assert updated.title == "B"
+    assert updated.rarity == "rare"
+
+    res = asyncio.run(delete_book(book.id, req))
+    assert res == {"status": "deleted"}
+    assert asyncio.run(list_books(req)) == []

--- a/frontend/src/admin/App.tsx
+++ b/frontend/src/admin/App.tsx
@@ -9,6 +9,7 @@ import { PluginManager } from './modding';
 import XPEventForm from './components/XPEventForm';
 import XPItemForm from './components/XPItemForm';
 import { EventsCalendar } from './events';
+import BooksAdmin from './learning/BooksAdmin';
 
 const App: React.FC = () => {
   const path = window.location.pathname;
@@ -35,6 +36,8 @@ const App: React.FC = () => {
     content = <PluginManager />;
   } else if (path.includes('/admin/events')) {
     content = <EventsCalendar />;
+  } else if (path.includes('/admin/learning/books')) {
+    content = <BooksAdmin />;
   }
 
   return (

--- a/frontend/src/admin/components/SchemaForm.tsx
+++ b/frontend/src/admin/components/SchemaForm.tsx
@@ -4,9 +4,10 @@ interface SchemaFormProps {
   schemaUrl: string;
   submitUrl: string;
   method?: string;
+  onSubmitted?: () => void;
 }
 
-const SchemaForm: React.FC<SchemaFormProps> = ({ schemaUrl, submitUrl, method = 'POST' }) => {
+const SchemaForm: React.FC<SchemaFormProps> = ({ schemaUrl, submitUrl, method = 'POST', onSubmitted }) => {
   const [schema, setSchema] = useState<any>(null);
   const [formData, setFormData] = useState<Record<string, any>>({});
 
@@ -34,6 +35,9 @@ const SchemaForm: React.FC<SchemaFormProps> = ({ schemaUrl, submitUrl, method = 
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(formData),
     });
+    if (onSubmitted) {
+      onSubmitted();
+    }
   };
 
   return (

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -14,6 +14,7 @@ const navItems: NavItem[] = [
   { label: 'XP Events', href: '/admin/xp-events' },
   { label: 'XP Items', href: '/admin/xp-items' },
   { label: 'Events', href: '/admin/events' },
+  { label: 'Books', href: '/admin/learning/books' },
   { label: 'Venues', href: '/admin/venues' },
   { label: 'Audit Logs', href: '/admin/audit' },
   { label: 'Modding', href: '/admin/modding' },

--- a/frontend/src/admin/learning/BooksAdmin.tsx
+++ b/frontend/src/admin/learning/BooksAdmin.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from 'react';
+import SchemaForm from '../components/SchemaForm';
+
+interface Book {
+  id: number;
+  title: string;
+  genre: string;
+  rarity: string;
+  max_skill_level: number;
+}
+
+const BooksAdmin: React.FC = () => {
+  const [books, setBooks] = useState<Book[]>([]);
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const loadBooks = () => {
+    fetch('/admin/learning/books')
+      .then(res => res.json())
+      .then(setBooks);
+  };
+
+  useEffect(() => {
+    loadBooks();
+  }, []);
+
+  const handleDelete = async (id: number) => {
+    await fetch(`/admin/learning/books/${id}`, { method: 'DELETE' });
+    setEditingId(null);
+    loadBooks();
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Books Admin</h2>
+      <SchemaForm
+        schemaUrl="/admin/schema/book"
+        submitUrl="/admin/learning/books"
+        onSubmitted={loadBooks}
+      />
+      <h3 className="text-lg mt-6 mb-2">Existing Books</h3>
+      <ul className="space-y-4">
+        {books.map(book => (
+          <li key={book.id} className="border p-2">
+            <div className="flex justify-between">
+              <span>
+                {book.title} ({book.genre}) - {book.rarity} max:{' '}
+                {book.max_skill_level}
+              </span>
+              <span className="space-x-2">
+                <button
+                  className="text-blue-500"
+                  onClick={() =>
+                    setEditingId(editingId === book.id ? null : book.id)
+                  }
+                >
+                  Edit
+                </button>
+                <button
+                  className="text-red-500"
+                  onClick={() => handleDelete(book.id)}
+                >
+                  Delete
+                </button>
+              </span>
+            </div>
+            {editingId === book.id && (
+              <div className="mt-2">
+                <SchemaForm
+                  schemaUrl="/admin/schema/book"
+                  submitUrl={`/admin/learning/books/${book.id}`}
+                  method="PUT"
+                  onSubmitted={loadBooks}
+                />
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default BooksAdmin;


### PR DESCRIPTION
## Summary
- add BookAdminService with SQLite CRUD operations
- expose admin book routes with admin role check and audit logging
- register book router and schema, and add frontend management page

## Testing
- `pytest backend/tests/admin/test_book_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7696ddf5083259614731b1d7bdaf2