### PR TITLE
Add admin online tutorial management

### DIFF
--- a/backend/models/online_tutorial.py
+++ b/backend/models/online_tutorial.py
@@ -1,0 +1,29 @@
+"""Data model for online tutorials used in learning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class OnlineTutorial:
+    """Representation of an online tutorial video.
+
+    Attributes:
+        video_url: Link or identifier for the tutorial video.
+        skill: Skill the tutorial teaches.
+        xp_rate: XP gained per completion.
+        plateau_level: Level after which the tutorial is less effective.
+        rarity_weight: Weight used when selecting tutorials based on rarity.
+    """
+
+    id: Optional[int]
+    video_url: str
+    skill: str
+    xp_rate: int
+    plateau_level: int
+    rarity_weight: int
+
+
+__all__ = ["OnlineTutorial"]

--- a/backend/routes/admin_online_tutorial_routes.py
+++ b/backend/routes/admin_online_tutorial_routes.py
@@ -1,0 +1,74 @@
+"""Admin routes for managing online tutorials."""
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.models.online_tutorial import OnlineTutorial
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.online_tutorial_admin_service import (
+    OnlineTutorialAdminService,
+    get_online_tutorial_admin_service,
+)
+
+router = APIRouter(
+    prefix="/learning/tutorials",
+    tags=["AdminTutorials"],
+    dependencies=[Depends(audit_dependency)],
+)
+svc: OnlineTutorialAdminService = get_online_tutorial_admin_service()
+
+
+class OnlineTutorialIn(BaseModel):
+    video_url: str
+    skill: str
+    xp_rate: int
+    plateau_level: int
+    rarity_weight: int
+
+
+async def _ensure_admin(req: Request) -> None:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+
+
+@router.get("/")
+async def list_tutorials(req: Request) -> list[OnlineTutorial]:
+    await _ensure_admin(req)
+    return svc.list_tutorials()
+
+
+@router.post("/")
+async def create_tutorial(payload: OnlineTutorialIn, req: Request) -> OnlineTutorial:
+    await _ensure_admin(req)
+    tutorial = OnlineTutorial(id=None, **payload.dict())
+    return svc.create_tutorial(tutorial)
+
+
+@router.put("/{tutorial_id}")
+async def update_tutorial(
+    tutorial_id: int, payload: OnlineTutorialIn, req: Request
+) -> OnlineTutorial:
+    await _ensure_admin(req)
+    try:
+        return svc.update_tutorial(tutorial_id, **payload.dict())
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.delete("/{tutorial_id}")
+async def delete_tutorial(tutorial_id: int, req: Request) -> dict[str, str]:
+    await _ensure_admin(req)
+    svc.delete_tutorial(tutorial_id)
+    return {"status": "deleted"}
+
+
+__all__ = [
+    "router",
+    "list_tutorials",
+    "create_tutorial",
+    "update_tutorial",
+    "delete_tutorial",
+    "OnlineTutorialIn",
+    "svc",
+]

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -8,6 +8,7 @@ from .admin_business_routes import router as business_router
 from .admin_economy_routes import router as economy_router
 from .admin_item_routes import router as item_router
 from .admin_book_routes import router as book_router
+from .admin_online_tutorial_routes import router as online_tutorial_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
 from .admin_modding_routes import router as modding_router
@@ -42,6 +43,7 @@ router.include_router(schema_router)
 router.include_router(song_popularity_router)
 router.include_router(item_router)
 router.include_router(book_router)
+router.include_router(online_tutorial_router)
 router.include_router(venue_router)
 router.include_router(music_router)
 router.include_router(name_router)

--- a/backend/routes/admin_schema_routes.py
+++ b/backend/routes/admin_schema_routes.py
@@ -67,6 +67,14 @@ class BookSchema(BaseModel):
     max_skill_level: int
 
 
+class OnlineTutorialSchema(BaseModel):
+    video_url: str
+    skill: str
+    xp_rate: int
+    plateau_level: int
+    rarity_weight: int
+
+
 router = APIRouter(prefix="/schema", tags=["AdminSchema"])
 
 
@@ -121,3 +129,9 @@ async def item_schema(req: Request) -> Dict[str, Any]:
 async def book_schema(req: Request) -> Dict[str, Any]:
     await _ensure_admin(req)
     return BookSchema.model_json_schema()
+
+
+@router.get("/online_tutorial")
+async def online_tutorial_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return OnlineTutorialSchema.model_json_schema()

--- a/backend/services/online_tutorial_admin_service.py
+++ b/backend/services/online_tutorial_admin_service.py
@@ -1,0 +1,116 @@
+"""Admin service for managing online tutorials in SQLite."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import List, Optional
+
+from backend.models.online_tutorial import OnlineTutorial
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class OnlineTutorialAdminService:
+    """CRUD helpers for online tutorials."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS online_tutorials (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    video_url TEXT NOT NULL,
+                    skill TEXT NOT NULL,
+                    xp_rate INTEGER NOT NULL,
+                    plateau_level INTEGER NOT NULL,
+                    rarity_weight INTEGER NOT NULL
+                )
+                """,
+            )
+            conn.commit()
+
+    def list_tutorials(self) -> List[OnlineTutorial]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, video_url, skill, xp_rate, plateau_level, rarity_weight FROM online_tutorials ORDER BY id"
+            )
+            rows = cur.fetchall()
+            return [OnlineTutorial(**dict(row)) for row in rows]
+
+    def create_tutorial(self, tutorial: OnlineTutorial) -> OnlineTutorial:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO online_tutorials (video_url, skill, xp_rate, plateau_level, rarity_weight) VALUES (?, ?, ?, ?, ?)",
+                (
+                    tutorial.video_url,
+                    tutorial.skill,
+                    tutorial.xp_rate,
+                    tutorial.plateau_level,
+                    tutorial.rarity_weight,
+                ),
+            )
+            tutorial.id = cur.lastrowid
+            conn.commit()
+            return tutorial
+
+    def update_tutorial(self, tutorial_id: int, **changes) -> OnlineTutorial:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, video_url, skill, xp_rate, plateau_level, rarity_weight FROM online_tutorials WHERE id = ?",
+                (tutorial_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise ValueError("Tutorial not found")
+            data = dict(row)
+            for k, v in changes.items():
+                if k in data and v is not None:
+                    data[k] = v
+            cur.execute(
+                "UPDATE online_tutorials SET video_url=?, skill=?, xp_rate=?, plateau_level=?, rarity_weight=? WHERE id=?",
+                (
+                    data["video_url"],
+                    data["skill"],
+                    data["xp_rate"],
+                    data["plateau_level"],
+                    data["rarity_weight"],
+                    tutorial_id,
+                ),
+            )
+            conn.commit()
+            return OnlineTutorial(**data)
+
+    def delete_tutorial(self, tutorial_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM online_tutorials WHERE id=?", (tutorial_id,))
+            conn.commit()
+
+    def clear(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM online_tutorials")
+            conn.commit()
+
+
+online_tutorial_admin_service = OnlineTutorialAdminService()
+
+
+def get_online_tutorial_admin_service() -> OnlineTutorialAdminService:
+    return online_tutorial_admin_service
+
+
+__all__ = [
+    "OnlineTutorialAdminService",
+    "online_tutorial_admin_service",
+    "get_online_tutorial_admin_service",
+]

--- a/frontend/src/admin/App.tsx
+++ b/frontend/src/admin/App.tsx
@@ -10,6 +10,7 @@ import XPEventForm from './components/XPEventForm';
 import XPItemForm from './components/XPItemForm';
 import { EventsCalendar } from './events';
 import BooksAdmin from './learning/BooksAdmin';
+import TutorialsAdmin from './learning/TutorialsAdmin';
 
 const App: React.FC = () => {
   const path = window.location.pathname;
@@ -38,6 +39,8 @@ const App: React.FC = () => {
     content = <EventsCalendar />;
   } else if (path.includes('/admin/learning/books')) {
     content = <BooksAdmin />;
+  } else if (path.includes('/admin/learning/tutorials')) {
+    content = <TutorialsAdmin />;
   }
 
   return (

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -15,6 +15,7 @@ const navItems: NavItem[] = [
   { label: 'XP Items', href: '/admin/xp-items' },
   { label: 'Events', href: '/admin/events' },
   { label: 'Books', href: '/admin/learning/books' },
+  { label: 'Tutorials', href: '/admin/learning/tutorials' },
   { label: 'Venues', href: '/admin/venues' },
   { label: 'Audit Logs', href: '/admin/audit' },
   { label: 'Modding', href: '/admin/modding' },

--- a/frontend/src/admin/learning/TutorialsAdmin.tsx
+++ b/frontend/src/admin/learning/TutorialsAdmin.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from 'react';
+import SchemaForm from '../components/SchemaForm';
+
+interface OnlineTutorial {
+  id: number;
+  video_url: string;
+  skill: string;
+  xp_rate: number;
+  plateau_level: number;
+  rarity_weight: number;
+}
+
+const TutorialsAdmin: React.FC = () => {
+  const [tutorials, setTutorials] = useState<OnlineTutorial[]>([]);
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const loadTutorials = () => {
+    fetch('/admin/learning/tutorials')
+      .then(res => res.json())
+      .then(setTutorials);
+  };
+
+  useEffect(() => {
+    loadTutorials();
+  }, []);
+
+  const handleDelete = async (id: number) => {
+    await fetch(`/admin/learning/tutorials/${id}`, { method: 'DELETE' });
+    setEditingId(null);
+    loadTutorials();
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Online Tutorials Admin</h2>
+      <SchemaForm
+        schemaUrl="/admin/schema/online_tutorial"
+        submitUrl="/admin/learning/tutorials"
+        onSubmitted={loadTutorials}
+      />
+      <h3 className="text-lg mt-6 mb-2">Existing Tutorials</h3>
+      <ul className="space-y-4">
+        {tutorials.map(tutorial => (
+          <li key={tutorial.id} className="border p-2">
+            <div className="flex justify-between">
+              <span>
+                {tutorial.skill} - {tutorial.video_url}
+              </span>
+              <span className="space-x-2">
+                <button
+                  className="text-blue-500"
+                  onClick={() =>
+                    setEditingId(editingId === tutorial.id ? null : tutorial.id)
+                  }
+                >
+                  Edit
+                </button>
+                <button
+                  className="text-red-500"
+                  onClick={() => handleDelete(tutorial.id)}
+                >
+                  Delete
+                </button>
+              </span>
+            </div>
+            {editingId === tutorial.id && (
+              <div className="mt-2">
+                <SchemaForm
+                  schemaUrl="/admin/schema/online_tutorial"
+                  submitUrl={`/admin/learning/tutorials/${tutorial.id}`}
+                  method="PUT"
+                  onSubmitted={loadTutorials}
+                />
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TutorialsAdmin;

--- a/tests/admin/test_online_tutorial_routes.py
+++ b/tests/admin/test_online_tutorial_routes.py
@@ -1,0 +1,88 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, Request
+
+# Allow importing the backend package and its auth helpers
+BASE = Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE))
+sys.path.append(str(BASE / "backend"))
+
+from backend.routes.admin_online_tutorial_routes import (  # type: ignore
+    OnlineTutorialIn,
+    create_tutorial,
+    delete_tutorial,
+    list_tutorials,
+    update_tutorial,
+    svc,
+)
+
+
+def test_online_tutorial_routes_require_admin():
+    req = Request({"type": "http", "headers": []})
+    payload = OnlineTutorialIn(
+        video_url="https://example.com",
+        skill="guitar",
+        xp_rate=5,
+        plateau_level=10,
+        rarity_weight=1,
+    )
+    with pytest.raises(HTTPException):
+        asyncio.run(list_tutorials(req))
+    with pytest.raises(HTTPException):
+        asyncio.run(create_tutorial(payload, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(update_tutorial(1, payload, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(delete_tutorial(1, req))
+
+
+def test_online_tutorial_routes_crud(monkeypatch, tmp_path):
+    async def fake_current_user(req):
+        return 1
+
+    async def fake_require_role(roles, user_id):
+        return True
+
+    monkeypatch.setattr(
+        "backend.routes.admin_online_tutorial_routes.get_current_user_id",
+        fake_current_user,
+    )
+    monkeypatch.setattr(
+        "backend.routes.admin_online_tutorial_routes.require_role", fake_require_role
+    )
+
+    svc.db_path = str(tmp_path / "tutorials.db")
+    svc.ensure_schema()
+    svc.clear()
+
+    req = Request({"type": "http", "headers": []})
+    payload = OnlineTutorialIn(
+        video_url="https://example.com",
+        skill="guitar",
+        xp_rate=5,
+        plateau_level=10,
+        rarity_weight=1,
+    )
+    tutorial = asyncio.run(create_tutorial(payload, req))
+    assert tutorial.id is not None
+
+    tutorials = asyncio.run(list_tutorials(req))
+    assert len(tutorials) == 1
+
+    upd = OnlineTutorialIn(
+        video_url="https://example.com/2",
+        skill="drums",
+        xp_rate=6,
+        plateau_level=12,
+        rarity_weight=2,
+    )
+    updated = asyncio.run(update_tutorial(tutorial.id, upd, req))
+    assert updated.skill == "drums"
+    assert updated.video_url.endswith("/2")
+
+    res = asyncio.run(delete_tutorial(tutorial.id, req))
+    assert res == {"status": "deleted"}
+    assert asyncio.run(list_tutorials(req)) == []


### PR DESCRIPTION
## Summary
- add `OnlineTutorial` model and service for CRUD
- expose `/admin/learning/tutorials` endpoints with schema support
- create TutorialsAdmin UI and tests for managing tutorials

## Testing
- `pytest tests/admin/test_online_tutorial_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76b30387883258db684409a885bd6