### PR TITLE
Add admin course management

### DIFF
--- a/backend/routes/admin_course_routes.py
+++ b/backend/routes/admin_course_routes.py
@@ -1,0 +1,53 @@
+"""Admin routes for managing courses."""
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.models.course import Course
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.course_admin_service import course_admin_service, CourseAdminService
+from pydantic import BaseModel
+
+router = APIRouter(
+    prefix="/courses", tags=["AdminCourses"], dependencies=[Depends(audit_dependency)]
+)
+svc: CourseAdminService = course_admin_service
+
+
+class CourseIn(BaseModel):
+    skill_target: str
+    duration: int
+    prerequisites: dict | None = None
+    prestige: bool = False
+
+
+@router.get("/")
+async def list_courses(req: Request) -> list[Course]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    return svc.list_courses()
+
+
+@router.post("/")
+async def create_course(payload: CourseIn, req: Request) -> Course:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    course = Course(id=0, **payload.dict())
+    return svc.create_course(course)
+
+
+@router.put("/{course_id}")
+async def update_course(course_id: int, payload: CourseIn, req: Request) -> Course:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    try:
+        return svc.update_course(course_id, **payload.dict())
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.delete("/{course_id}")
+async def delete_course(course_id: int, req: Request) -> dict[str, str]:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+    svc.delete_course(course_id)
+    return {"status": "deleted"}

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -6,6 +6,7 @@ from .admin_analytics_routes import router as analytics_router
 from .admin_audit_routes import router as audit_router
 from .admin_business_routes import router as business_router
 from .admin_economy_routes import router as economy_router
+from .admin_course_routes import router as course_router
 from .admin_item_routes import router as item_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
@@ -40,6 +41,7 @@ router.include_router(quest_router)
 router.include_router(schema_router)
 router.include_router(song_popularity_router)
 router.include_router(item_router)
+router.include_router(course_router)
 router.include_router(venue_router)
 router.include_router(music_router)
 router.include_router(name_router)

--- a/backend/routes/admin_schema_routes.py
+++ b/backend/routes/admin_schema_routes.py
@@ -60,6 +60,13 @@ class ItemSchema(BaseModel):
     stats: Dict[str, float] = {}
 
 
+class CourseSchema(BaseModel):
+    skill_target: str
+    duration: int
+    prerequisites: Dict[str, Any] | None = None
+    prestige: bool = False
+
+
 router = APIRouter(prefix="/schema", tags=["AdminSchema"])
 
 
@@ -108,3 +115,9 @@ async def xp_item_schema(req: Request) -> Dict[str, Any]:
 async def item_schema(req: Request) -> Dict[str, Any]:
     await _ensure_admin(req)
     return ItemSchema.model_json_schema()
+
+
+@router.get("/course")
+async def course_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return CourseSchema.model_json_schema()

--- a/backend/services/course_admin_service.py
+++ b/backend/services/course_admin_service.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import List, Optional
+
+from backend.database import DB_PATH
+from backend.models.course import Course
+
+
+class CourseAdminService:
+    """CRUD operations for courses stored in SQLite."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    # ------------------------------------------------------------------
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS courses (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    skill_target TEXT NOT NULL,
+                    duration INTEGER NOT NULL,
+                    prerequisites TEXT,
+                    prestige INTEGER NOT NULL DEFAULT 0
+                )
+                """,
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def list_courses(self) -> List[Course]:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, skill_target, duration, prerequisites, prestige FROM courses"
+            )
+            rows = cur.fetchall()
+        courses: List[Course] = []
+        for row in rows:
+            prereqs = json.loads(row[3]) if row[3] else None
+            courses.append(
+                Course(
+                    id=row[0],
+                    skill_target=row[1],
+                    duration=row[2],
+                    prerequisites=prereqs,
+                    prestige=bool(row[4]),
+                )
+            )
+        return courses
+
+    # ------------------------------------------------------------------
+    def create_course(self, course: Course) -> Course:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO courses (skill_target, duration, prerequisites, prestige) VALUES (?, ?, ?, ?)",
+                (
+                    course.skill_target,
+                    course.duration,
+                    json.dumps(course.prerequisites) if course.prerequisites else None,
+                    int(course.prestige),
+                ),
+            )
+            course_id = cur.lastrowid
+            conn.commit()
+        return Course(
+            id=course_id,
+            skill_target=course.skill_target,
+            duration=course.duration,
+            prerequisites=course.prerequisites,
+            prestige=course.prestige,
+        )
+
+    # ------------------------------------------------------------------
+    def update_course(self, course_id: int, **changes) -> Course:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT skill_target, duration, prerequisites, prestige FROM courses WHERE id = ?",
+                (course_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise ValueError("course_not_found")
+            skill_target = changes.get("skill_target", row[0])
+            duration = changes.get("duration", row[1])
+            prerequisites = changes.get(
+                "prerequisites", json.loads(row[2]) if row[2] else None
+            )
+            prestige = changes.get("prestige", bool(row[3]))
+            cur.execute(
+                """
+                UPDATE courses
+                SET skill_target = ?, duration = ?, prerequisites = ?, prestige = ?
+                WHERE id = ?
+                """,
+                (
+                    skill_target,
+                    duration,
+                    json.dumps(prerequisites) if prerequisites else None,
+                    int(prestige),
+                    course_id,
+                ),
+            )
+            conn.commit()
+        return Course(
+            id=course_id,
+            skill_target=skill_target,
+            duration=duration,
+            prerequisites=prerequisites,
+            prestige=prestige,
+        )
+
+    # ------------------------------------------------------------------
+    def delete_course(self, course_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM courses WHERE id = ?", (course_id,))
+            conn.commit()
+
+
+course_admin_service = CourseAdminService()
+
+__all__ = ["CourseAdminService", "course_admin_service"]

--- a/backend/tests/admin/test_course_routes.py
+++ b/backend/tests/admin/test_course_routes.py
@@ -1,0 +1,56 @@
+import asyncio
+import pytest
+from fastapi import HTTPException, Request
+
+from backend.routes.admin_course_routes import (
+    CourseIn,
+    create_course,
+    delete_course,
+    list_courses,
+    update_course,
+    svc,
+)
+
+
+def sample_course() -> CourseIn:
+    return CourseIn(skill_target="guitar", duration=10, prestige=False)
+
+
+def test_course_routes_require_admin():
+    req = Request({"type": "http", "headers": []})
+    with pytest.raises(HTTPException):
+        asyncio.run(create_course(sample_course(), req))
+    with pytest.raises(HTTPException):
+        asyncio.run(update_course(1, sample_course(), req))
+    with pytest.raises(HTTPException):
+        asyncio.run(delete_course(1, req))
+
+
+def test_course_crud(monkeypatch, tmp_path):
+    async def fake_current_user(req):
+        return 1
+
+    async def fake_require_role(roles, user_id):
+        return True
+
+    monkeypatch.setattr(
+        "backend.routes.admin_course_routes.get_current_user_id", fake_current_user
+    )
+    monkeypatch.setattr(
+        "backend.routes.admin_course_routes.require_role", fake_require_role
+    )
+
+    svc.db_path = str(tmp_path / "courses.db")
+    svc.ensure_schema()
+
+    req = Request({"type": "http", "headers": []})
+    created = asyncio.run(create_course(sample_course(), req))
+    assert created.id > 0
+    listed = asyncio.run(list_courses(req))
+    assert len(listed) == 1
+    updated = asyncio.run(
+        update_course(created.id, CourseIn(skill_target="piano", duration=12), req)
+    )
+    assert updated.skill_target == "piano"
+    asyncio.run(delete_course(created.id, req))
+    assert asyncio.run(list_courses(req)) == []

--- a/frontend/src/admin/learning/CoursesAdmin.tsx
+++ b/frontend/src/admin/learning/CoursesAdmin.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+
+interface Course {
+  id: number;
+  skill_target: string;
+  duration: number;
+  prerequisites?: Record<string, any> | null;
+  prestige: boolean;
+}
+
+const CoursesAdmin: React.FC = () => {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [form, setForm] = useState({
+    skill_target: '',
+    duration: 0,
+    prerequisites: '',
+    prestige: false,
+  });
+
+  const load = async () => {
+    const res = await fetch('/admin/courses/');
+    if (res.ok) {
+      setCourses(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, type, checked } = e.target;
+    setForm(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const payload = {
+      skill_target: form.skill_target,
+      duration: Number(form.duration),
+      prerequisites: form.prerequisites ? JSON.parse(form.prerequisites) : null,
+      prestige: form.prestige,
+    };
+    await fetch('/admin/courses/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    setForm({ skill_target: '', duration: 0, prerequisites: '', prestige: false });
+    load();
+  };
+
+  const handleDelete = async (id: number) => {
+    await fetch(`/admin/courses/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Courses</h2>
+      <form onSubmit={handleCreate} className="space-y-2 mb-4">
+        <input
+          className="border p-1 w-full"
+          name="skill_target"
+          placeholder="Skill target"
+          value={form.skill_target}
+          onChange={handleChange}
+        />
+        <input
+          className="border p-1 w-full"
+          name="duration"
+          type="number"
+          placeholder="Duration"
+          value={form.duration}
+          onChange={handleChange}
+        />
+        <input
+          className="border p-1 w-full"
+          name="prerequisites"
+          placeholder='Prerequisites JSON'
+          value={form.prerequisites}
+          onChange={handleChange}
+        />
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            name="prestige"
+            checked={form.prestige}
+            onChange={handleChange}
+          />
+          <span>Prestige</span>
+        </label>
+        <button type="submit" className="px-4 py-2 bg-blue-500 text-white">
+          Create
+        </button>
+      </form>
+      <ul className="space-y-1">
+        {courses.map(c => (
+          <li key={c.id} className="flex justify-between items-center">
+            <span>
+              {c.skill_target} - {c.duration}w {c.prestige ? '(Prestige)' : ''}
+            </span>
+            <button
+              className="text-red-600"
+              onClick={() => handleDelete(c.id)}
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CoursesAdmin;


### PR DESCRIPTION
## Summary
- add SQLite-backed CourseAdminService
- expose admin course CRUD API with audit logging and schema endpoint
- build basic React interface for managing courses

## Testing
- `pytest backend/tests/admin/test_course_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76ac700fc83258e7f5fc1d434f47a