### PR TITLE
Add admin tutor and apprenticeship management

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -317,8 +317,9 @@ def init_db():
         CREATE TABLE IF NOT EXISTS tutors (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL,
-            specialty_skill INTEGER,
-            rate INTEGER
+            specialization TEXT NOT NULL,
+            hourly_rate INTEGER NOT NULL,
+            level_requirement INTEGER NOT NULL DEFAULT 0
         )
         """)
 
@@ -353,6 +354,7 @@ def init_db():
             mentor_type TEXT NOT NULL,
             skill_id INTEGER NOT NULL,
             duration_days INTEGER NOT NULL,
+            level_requirement INTEGER NOT NULL DEFAULT 0,
             start_date TEXT,
             status TEXT NOT NULL DEFAULT 'pending'
         )

--- a/backend/models/apprenticeship.py
+++ b/backend/models/apprenticeship.py
@@ -15,6 +15,7 @@ class Apprenticeship:
     mentor_type: str  # "npc" or "player"
     skill_id: int
     duration_days: int
+    level_requirement: int
     start_date: Optional[str] = None
     status: str = "pending"
 
@@ -30,6 +31,7 @@ class Apprenticeship:
             "mentor_type": self.mentor_type,
             "skill_id": self.skill_id,
             "duration_days": self.duration_days,
+            "level_requirement": self.level_requirement,
             "start_date": self.start_date,
             "status": self.status,
         }

--- a/backend/models/tutor.py
+++ b/backend/models/tutor.py
@@ -11,6 +11,7 @@ class Tutor:
     name: str
     specialization: str
     hourly_rate: int
+    level_requirement: int
 
 
 __all__ = ["Tutor"]

--- a/backend/routes/admin_apprenticeship_routes.py
+++ b/backend/routes/admin_apprenticeship_routes.py
@@ -1,0 +1,72 @@
+"""Admin routes for managing apprenticeships."""
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.models.apprenticeship import Apprenticeship
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.apprenticeship_admin_service import (
+    ApprenticeshipAdminService,
+    get_apprenticeship_admin_service,
+)
+
+router = APIRouter(
+    prefix="/learning/mentors", tags=["AdminApprenticeships"], dependencies=[Depends(audit_dependency)]
+)
+svc: ApprenticeshipAdminService = get_apprenticeship_admin_service()
+
+
+class ApprenticeshipIn(BaseModel):
+    student_id: int
+    mentor_id: int
+    mentor_type: str
+    skill_id: int
+    duration_days: int
+    level_requirement: int
+    start_date: str | None = None
+    status: str = "pending"
+
+
+async def _ensure_admin(req: Request) -> None:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+
+
+@router.get("/")
+async def list_apprenticeships(req: Request) -> list[Apprenticeship]:
+    await _ensure_admin(req)
+    return svc.list_apprenticeships()
+
+
+@router.post("/")
+async def create_apprenticeship(payload: ApprenticeshipIn, req: Request) -> Apprenticeship:
+    await _ensure_admin(req)
+    app = Apprenticeship(id=None, **payload.dict())
+    return svc.create_apprenticeship(app)
+
+
+@router.put("/{app_id}")
+async def update_apprenticeship(app_id: int, payload: ApprenticeshipIn, req: Request) -> Apprenticeship:
+    await _ensure_admin(req)
+    try:
+        return svc.update_apprenticeship(app_id, **payload.dict())
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.delete("/{app_id}")
+async def delete_apprenticeship(app_id: int, req: Request) -> dict[str, str]:
+    await _ensure_admin(req)
+    svc.delete_apprenticeship(app_id)
+    return {"status": "deleted"}
+
+
+__all__ = [
+    "router",
+    "list_apprenticeships",
+    "create_apprenticeship",
+    "update_apprenticeship",
+    "delete_apprenticeship",
+    "ApprenticeshipIn",
+    "svc",
+]

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -3,13 +3,13 @@
 from fastapi import APIRouter
 
 from .admin_analytics_routes import router as analytics_router
+from .admin_apprenticeship_routes import router as apprenticeship_router
 from .admin_audit_routes import router as audit_router
-from .admin_business_routes import router as business_router
-from .admin_economy_routes import router as economy_router
-from .admin_course_routes import router as course_router
-from .admin_item_routes import router as item_router
 from .admin_book_routes import router as book_router
-from .admin_online_tutorial_routes import router as online_tutorial_router
+from .admin_business_routes import router as business_router
+from .admin_course_routes import router as course_router
+from .admin_economy_routes import router as economy_router
+from .admin_item_routes import router as item_router
 from .admin_job_routes import router as jobs_router
 from .admin_media_moderation_routes import router as media_router
 from .admin_modding_routes import router as modding_router
@@ -18,9 +18,11 @@ from .admin_music_routes import router as music_router
 from .admin_name_routes import router as name_router
 from .admin_npc_dialogue_routes import router as npc_dialogue_router
 from .admin_npc_routes import router as npc_router
+from .admin_online_tutorial_routes import router as online_tutorial_router
 from .admin_quest_routes import router as quest_router
 from .admin_schema_routes import router as schema_router
 from .admin_song_popularity_routes import router as song_popularity_router
+from .admin_tutor_routes import router as tutor_router
 from .admin_venue_routes import router as venue_router
 from .admin_xp_event_routes import router as xp_event_router
 from .admin_xp_routes import router as xp_router
@@ -47,6 +49,8 @@ router.include_router(item_router)
 router.include_router(course_router)
 router.include_router(book_router)
 router.include_router(online_tutorial_router)
+router.include_router(tutor_router)
+router.include_router(apprenticeship_router)
 
 router.include_router(venue_router)
 router.include_router(music_router)

--- a/backend/routes/admin_schema_routes.py
+++ b/backend/routes/admin_schema_routes.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Literal
 
 from auth.dependencies import get_current_user_id, require_role
 from fastapi import APIRouter, Request
-
 from pydantic import BaseModel
 
 
@@ -82,6 +81,24 @@ class OnlineTutorialSchema(BaseModel):
     rarity_weight: int
 
 
+class TutorSchema(BaseModel):
+    name: str
+    specialization: str
+    hourly_rate: int
+    level_requirement: int
+
+
+class ApprenticeshipSchema(BaseModel):
+    student_id: int
+    mentor_id: int
+    mentor_type: str
+    skill_id: int
+    duration_days: int
+    level_requirement: int
+    start_date: str | None = None
+    status: str = "pending"
+
+
 router = APIRouter(prefix="/schema", tags=["AdminSchema"])
 
 
@@ -148,3 +165,15 @@ async def book_schema(req: Request) -> Dict[str, Any]:
 async def online_tutorial_schema(req: Request) -> Dict[str, Any]:
     await _ensure_admin(req)
     return OnlineTutorialSchema.model_json_schema()
+
+
+@router.get("/tutor")
+async def tutor_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return TutorSchema.model_json_schema()
+
+
+@router.get("/apprenticeship")
+async def apprenticeship_schema(req: Request) -> Dict[str, Any]:
+    await _ensure_admin(req)
+    return ApprenticeshipSchema.model_json_schema()

--- a/backend/routes/admin_tutor_routes.py
+++ b/backend/routes/admin_tutor_routes.py
@@ -1,0 +1,68 @@
+"""Admin routes for managing tutors."""
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.models.tutor import Tutor
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.tutor_admin_service import (
+    TutorAdminService,
+    get_tutor_admin_service,
+)
+
+router = APIRouter(
+    prefix="/learning/tutors", tags=["AdminTutors"], dependencies=[Depends(audit_dependency)]
+)
+svc: TutorAdminService = get_tutor_admin_service()
+
+
+class TutorIn(BaseModel):
+    name: str
+    specialization: str
+    hourly_rate: int
+    level_requirement: int
+
+
+async def _ensure_admin(req: Request) -> None:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+
+
+@router.get("/")
+async def list_tutors(req: Request) -> list[Tutor]:
+    await _ensure_admin(req)
+    return svc.list_tutors()
+
+
+@router.post("/")
+async def create_tutor(payload: TutorIn, req: Request) -> Tutor:
+    await _ensure_admin(req)
+    tutor = Tutor(id=None, **payload.dict())
+    return svc.create_tutor(tutor)
+
+
+@router.put("/{tutor_id}")
+async def update_tutor(tutor_id: int, payload: TutorIn, req: Request) -> Tutor:
+    await _ensure_admin(req)
+    try:
+        return svc.update_tutor(tutor_id, **payload.dict())
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.delete("/{tutor_id}")
+async def delete_tutor(tutor_id: int, req: Request) -> dict[str, str]:
+    await _ensure_admin(req)
+    svc.delete_tutor(tutor_id)
+    return {"status": "deleted"}
+
+
+__all__ = [
+    "router",
+    "list_tutors",
+    "create_tutor",
+    "update_tutor",
+    "delete_tutor",
+    "TutorIn",
+    "svc",
+]

--- a/backend/services/apprenticeship_admin_service.py
+++ b/backend/services/apprenticeship_admin_service.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import List, Optional
+
+from backend.database import DB_PATH
+from backend.models.apprenticeship import Apprenticeship
+
+
+class ApprenticeshipAdminService:
+    """CRUD helpers for apprenticeship records."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS apprenticeships (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    student_id INTEGER NOT NULL,
+                    mentor_id INTEGER NOT NULL,
+                    mentor_type TEXT NOT NULL,
+                    skill_id INTEGER NOT NULL,
+                    duration_days INTEGER NOT NULL,
+                    level_requirement INTEGER NOT NULL,
+                    start_date TEXT,
+                    status TEXT NOT NULL
+                )
+                """,
+            )
+            conn.commit()
+
+    def list_apprenticeships(self) -> List[Apprenticeship]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT id, student_id, mentor_id, mentor_type, skill_id, duration_days, level_requirement, start_date, status
+                FROM apprenticeships ORDER BY id
+                """
+            )
+            rows = cur.fetchall()
+            return [Apprenticeship(**dict(row)) for row in rows]
+
+    def create_apprenticeship(self, app: Apprenticeship) -> Apprenticeship:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO apprenticeships (student_id, mentor_id, mentor_type, skill_id, duration_days, level_requirement, start_date, status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    app.student_id,
+                    app.mentor_id,
+                    app.mentor_type,
+                    app.skill_id,
+                    app.duration_days,
+                    app.level_requirement,
+                    app.start_date,
+                    app.status,
+                ),
+            )
+            app.id = cur.lastrowid
+            conn.commit()
+            return app
+
+    def update_apprenticeship(self, app_id: int, **changes) -> Apprenticeship:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT id, student_id, mentor_id, mentor_type, skill_id, duration_days, level_requirement, start_date, status
+                FROM apprenticeships WHERE id = ?
+                """,
+                (app_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise ValueError("Apprenticeship not found")
+            data = dict(row)
+            for k, v in changes.items():
+                if k in data and v is not None:
+                    data[k] = v
+            cur.execute(
+                """
+                UPDATE apprenticeships
+                SET student_id=?, mentor_id=?, mentor_type=?, skill_id=?, duration_days=?, level_requirement=?, start_date=?, status=?
+                WHERE id=?
+                """,
+                (
+                    data["student_id"],
+                    data["mentor_id"],
+                    data["mentor_type"],
+                    data["skill_id"],
+                    data["duration_days"],
+                    data["level_requirement"],
+                    data["start_date"],
+                    data["status"],
+                    app_id,
+                ),
+            )
+            conn.commit()
+            return Apprenticeship(**data)
+
+    def delete_apprenticeship(self, app_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM apprenticeships WHERE id=?", (app_id,))
+            conn.commit()
+
+    def clear(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM apprenticeships")
+            conn.commit()
+
+
+apprenticeship_admin_service = ApprenticeshipAdminService()
+
+
+def get_apprenticeship_admin_service() -> ApprenticeshipAdminService:
+    return apprenticeship_admin_service
+
+
+__all__ = [
+    "ApprenticeshipAdminService",
+    "apprenticeship_admin_service",
+    "get_apprenticeship_admin_service",
+]

--- a/backend/services/apprenticeship_service.py
+++ b/backend/services/apprenticeship_service.py
@@ -20,7 +20,15 @@ class ApprenticeshipService:
         return sqlite3.connect(self.db_path)
 
     # ------------------------------------------------------------------
-    def request(self, student_id: int, mentor_id: int, mentor_type: str, skill_id: int, duration_days: int) -> Apprenticeship:
+    def request(
+        self,
+        student_id: int,
+        mentor_id: int,
+        mentor_type: str,
+        skill_id: int,
+        duration_days: int,
+        level_requirement: int = 0,
+    ) -> Apprenticeship:
         """Record an apprenticeship request waiting for mentor approval."""
 
         app = Apprenticeship(
@@ -30,16 +38,25 @@ class ApprenticeshipService:
             mentor_type=mentor_type,
             skill_id=skill_id,
             duration_days=duration_days,
+            level_requirement=level_requirement,
             status="pending",
         )
         with self._connect() as conn:
             cur = conn.cursor()
             cur.execute(
                 """
-                INSERT INTO apprenticeships (student_id, mentor_id, mentor_type, skill_id, duration_days, status)
-                VALUES (?, ?, ?, ?, ?, ?)
+                INSERT INTO apprenticeships (student_id, mentor_id, mentor_type, skill_id, duration_days, level_requirement, status)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (app.student_id, app.mentor_id, app.mentor_type, app.skill_id, app.duration_days, app.status),
+                (
+                    app.student_id,
+                    app.mentor_id,
+                    app.mentor_type,
+                    app.skill_id,
+                    app.duration_days,
+                    app.level_requirement,
+                    app.status,
+                ),
             )
             app.id = cur.lastrowid
             conn.commit()

--- a/backend/services/tutor_admin_service.py
+++ b/backend/services/tutor_admin_service.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import List, Optional
+
+from backend.database import DB_PATH
+from backend.models.tutor import Tutor
+
+
+class TutorAdminService:
+    """CRUD helpers for tutor records."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tutors (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    specialization TEXT NOT NULL,
+                    hourly_rate INTEGER NOT NULL,
+                    level_requirement INTEGER NOT NULL
+                )
+                """,
+            )
+            conn.commit()
+
+    def list_tutors(self) -> List[Tutor]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, name, specialization, hourly_rate, level_requirement FROM tutors ORDER BY id"
+            )
+            rows = cur.fetchall()
+            return [Tutor(**dict(row)) for row in rows]
+
+    def create_tutor(self, tutor: Tutor) -> Tutor:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO tutors (name, specialization, hourly_rate, level_requirement) VALUES (?, ?, ?, ?)",
+                (tutor.name, tutor.specialization, tutor.hourly_rate, tutor.level_requirement),
+            )
+            tutor.id = cur.lastrowid
+            conn.commit()
+            return tutor
+
+    def update_tutor(self, tutor_id: int, **changes) -> Tutor:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, name, specialization, hourly_rate, level_requirement FROM tutors WHERE id = ?",
+                (tutor_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise ValueError("Tutor not found")
+            data = dict(row)
+            for k, v in changes.items():
+                if k in data and v is not None:
+                    data[k] = v
+            cur.execute(
+                "UPDATE tutors SET name=?, specialization=?, hourly_rate=?, level_requirement=? WHERE id=?",
+                (
+                    data["name"],
+                    data["specialization"],
+                    data["hourly_rate"],
+                    data["level_requirement"],
+                    tutor_id,
+                ),
+            )
+            conn.commit()
+            return Tutor(**data)
+
+    def delete_tutor(self, tutor_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM tutors WHERE id=?", (tutor_id,))
+            conn.commit()
+
+    def clear(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM tutors")
+            conn.commit()
+
+
+tutor_admin_service = TutorAdminService()
+
+
+def get_tutor_admin_service() -> TutorAdminService:
+    return tutor_admin_service
+
+
+__all__ = ["TutorAdminService", "tutor_admin_service", "get_tutor_admin_service"]

--- a/frontend/src/admin/App.tsx
+++ b/frontend/src/admin/App.tsx
@@ -11,6 +11,8 @@ import XPItemForm from './components/XPItemForm';
 import { EventsCalendar } from './events';
 import BooksAdmin from './learning/BooksAdmin';
 import TutorialsAdmin from './learning/TutorialsAdmin';
+import TutorsAdmin from './learning/TutorsAdmin';
+import MentorsAdmin from './learning/MentorsAdmin';
 
 const App: React.FC = () => {
   const path = window.location.pathname;
@@ -41,6 +43,10 @@ const App: React.FC = () => {
     content = <BooksAdmin />;
   } else if (path.includes('/admin/learning/tutorials')) {
     content = <TutorialsAdmin />;
+  } else if (path.includes('/admin/learning/tutors')) {
+    content = <TutorsAdmin />;
+  } else if (path.includes('/admin/learning/mentors')) {
+    content = <MentorsAdmin />;
   }
 
   return (

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -16,6 +16,8 @@ const navItems: NavItem[] = [
   { label: 'Events', href: '/admin/events' },
   { label: 'Books', href: '/admin/learning/books' },
   { label: 'Tutorials', href: '/admin/learning/tutorials' },
+  { label: 'Tutors', href: '/admin/learning/tutors' },
+  { label: 'Mentors', href: '/admin/learning/mentors' },
   { label: 'Venues', href: '/admin/venues' },
   { label: 'Audit Logs', href: '/admin/audit' },
   { label: 'Modding', href: '/admin/modding' },

--- a/frontend/src/admin/learning/MentorsAdmin.tsx
+++ b/frontend/src/admin/learning/MentorsAdmin.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import SchemaForm from '../components/SchemaForm';
+
+interface Apprenticeship {
+  id: number;
+  student_id: number;
+  mentor_id: number;
+  mentor_type: string;
+  skill_id: number;
+  duration_days: number;
+  level_requirement: number;
+  start_date?: string | null;
+  status: string;
+}
+
+const MentorsAdmin: React.FC = () => {
+  const [apps, setApps] = useState<Apprenticeship[]>([]);
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const loadApps = () => {
+    fetch('/admin/learning/mentors')
+      .then(res => res.json())
+      .then(setApps);
+  };
+
+  useEffect(() => {
+    loadApps();
+  }, []);
+
+  const handleDelete = async (id: number) => {
+    await fetch(`/admin/learning/mentors/${id}`, { method: 'DELETE' });
+    setEditingId(null);
+    loadApps();
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Mentors Admin</h2>
+      <SchemaForm
+        schemaUrl="/admin/schema/apprenticeship"
+        submitUrl="/admin/learning/mentors"
+        onSubmitted={loadApps}
+      />
+      <h3 className="text-lg mt-6 mb-2">Existing Apprenticeships</h3>
+      <ul className="space-y-4">
+        {apps.map(app => (
+          <li key={app.id} className="border p-2">
+            <div className="flex justify-between">
+              <span>
+                Student {app.student_id} with Mentor {app.mentor_id} ({app.status})
+              </span>
+              <span className="space-x-2">
+                <button
+                  className="text-blue-500"
+                  onClick={() =>
+                    setEditingId(editingId === app.id ? null : app.id)
+                  }
+                >
+                  Edit
+                </button>
+                <button
+                  className="text-red-500"
+                  onClick={() => handleDelete(app.id)}
+                >
+                  Delete
+                </button>
+              </span>
+            </div>
+            {editingId === app.id && (
+              <div className="mt-2">
+                <SchemaForm
+                  schemaUrl="/admin/schema/apprenticeship"
+                  submitUrl={`/admin/learning/mentors/${app.id}`}
+                  method="PUT"
+                  onSubmitted={loadApps}
+                />
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MentorsAdmin;

--- a/frontend/src/admin/learning/TutorsAdmin.tsx
+++ b/frontend/src/admin/learning/TutorsAdmin.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import SchemaForm from '../components/SchemaForm';
+
+interface Tutor {
+  id: number;
+  name: string;
+  specialization: string;
+  hourly_rate: number;
+  level_requirement: number;
+}
+
+const TutorsAdmin: React.FC = () => {
+  const [tutors, setTutors] = useState<Tutor[]>([]);
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const loadTutors = () => {
+    fetch('/admin/learning/tutors')
+      .then(res => res.json())
+      .then(setTutors);
+  };
+
+  useEffect(() => {
+    loadTutors();
+  }, []);
+
+  const handleDelete = async (id: number) => {
+    await fetch(`/admin/learning/tutors/${id}`, { method: 'DELETE' });
+    setEditingId(null);
+    loadTutors();
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Tutors Admin</h2>
+      <SchemaForm
+        schemaUrl="/admin/schema/tutor"
+        submitUrl="/admin/learning/tutors"
+        onSubmitted={loadTutors}
+      />
+      <h3 className="text-lg mt-6 mb-2">Existing Tutors</h3>
+      <ul className="space-y-4">
+        {tutors.map(tutor => (
+          <li key={tutor.id} className="border p-2">
+            <div className="flex justify-between">
+              <span>
+                {tutor.name} - {tutor.specialization} (${tutor.hourly_rate}/hr)
+              </span>
+              <span className="space-x-2">
+                <button
+                  className="text-blue-500"
+                  onClick={() =>
+                    setEditingId(editingId === tutor.id ? null : tutor.id)
+                  }
+                >
+                  Edit
+                </button>
+                <button
+                  className="text-red-500"
+                  onClick={() => handleDelete(tutor.id)}
+                >
+                  Delete
+                </button>
+              </span>
+            </div>
+            {editingId === tutor.id && (
+              <div className="mt-2">
+                <SchemaForm
+                  schemaUrl="/admin/schema/tutor"
+                  submitUrl={`/admin/learning/tutors/${tutor.id}`}
+                  method="PUT"
+                  onSubmitted={loadTutors}
+                />
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TutorsAdmin;

--- a/tests/admin/test_apprenticeship_routes.py
+++ b/tests/admin/test_apprenticeship_routes.py
@@ -1,0 +1,90 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, Request
+
+BASE = Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE))
+sys.path.append(str(BASE / "backend"))
+
+from backend.routes.admin_apprenticeship_routes import (  # type: ignore  # noqa: E402,I001
+    ApprenticeshipIn,
+    create_apprenticeship,
+    delete_apprenticeship,
+    list_apprenticeships,
+    update_apprenticeship,
+    svc,
+)
+
+
+def test_apprenticeship_routes_require_admin():
+    req = Request({"type": "http", "headers": []})
+    payload = ApprenticeshipIn(
+        student_id=1,
+        mentor_id=2,
+        mentor_type="player",
+        skill_id=3,
+        duration_days=7,
+        level_requirement=0,
+    )
+    with pytest.raises(HTTPException):
+        asyncio.run(list_apprenticeships(req))
+    with pytest.raises(HTTPException):
+        asyncio.run(create_apprenticeship(payload, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(update_apprenticeship(1, payload, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(delete_apprenticeship(1, req))
+
+
+def test_apprenticeship_routes_crud(monkeypatch, tmp_path):
+    async def fake_current_user(req):
+        return 1
+
+    async def fake_require_role(roles, user_id):
+        return True
+
+    monkeypatch.setattr(
+        "backend.routes.admin_apprenticeship_routes.get_current_user_id", fake_current_user
+    )
+    monkeypatch.setattr(
+        "backend.routes.admin_apprenticeship_routes.require_role", fake_require_role
+    )
+
+    svc.db_path = str(tmp_path / "apprenticeships.db")
+    svc.ensure_schema()
+    svc.clear()
+
+    req = Request({"type": "http", "headers": []})
+    payload = ApprenticeshipIn(
+        student_id=1,
+        mentor_id=2,
+        mentor_type="player",
+        skill_id=3,
+        duration_days=7,
+        level_requirement=0,
+    )
+    app = asyncio.run(create_apprenticeship(payload, req))
+    assert app.id is not None
+
+    apps = asyncio.run(list_apprenticeships(req))
+    assert len(apps) == 1
+
+    upd = ApprenticeshipIn(
+        student_id=1,
+        mentor_id=3,
+        mentor_type="npc",
+        skill_id=4,
+        duration_days=10,
+        level_requirement=5,
+        status="active",
+    )
+    updated = asyncio.run(update_apprenticeship(app.id, upd, req))
+    assert updated.mentor_id == 3
+    assert updated.status == "active"
+
+    res = asyncio.run(delete_apprenticeship(app.id, req))
+    assert res == {"status": "deleted"}
+    assert asyncio.run(list_apprenticeships(req)) == []

--- a/tests/admin/test_tutor_routes.py
+++ b/tests/admin/test_tutor_routes.py
@@ -1,0 +1,83 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, Request
+
+BASE = Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE))
+sys.path.append(str(BASE / "backend"))
+
+from backend.routes.admin_tutor_routes import (  # type: ignore  # noqa: E402,I001
+    TutorIn,
+    create_tutor,
+    delete_tutor,
+    list_tutors,
+    update_tutor,
+    svc,
+)
+
+
+def test_tutor_routes_require_admin():
+    req = Request({"type": "http", "headers": []})
+    payload = TutorIn(
+        name="Maestro",
+        specialization="guitar",
+        hourly_rate=50,
+        level_requirement=10,
+    )
+    with pytest.raises(HTTPException):
+        asyncio.run(list_tutors(req))
+    with pytest.raises(HTTPException):
+        asyncio.run(create_tutor(payload, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(update_tutor(1, payload, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(delete_tutor(1, req))
+
+
+def test_tutor_routes_crud(monkeypatch, tmp_path):
+    async def fake_current_user(req):
+        return 1
+
+    async def fake_require_role(roles, user_id):
+        return True
+
+    monkeypatch.setattr(
+        "backend.routes.admin_tutor_routes.get_current_user_id", fake_current_user
+    )
+    monkeypatch.setattr(
+        "backend.routes.admin_tutor_routes.require_role", fake_require_role
+    )
+
+    svc.db_path = str(tmp_path / "tutors.db")
+    svc.ensure_schema()
+    svc.clear()
+
+    req = Request({"type": "http", "headers": []})
+    payload = TutorIn(
+        name="Maestro",
+        specialization="guitar",
+        hourly_rate=50,
+        level_requirement=10,
+    )
+    tutor = asyncio.run(create_tutor(payload, req))
+    assert tutor.id is not None
+
+    tutors = asyncio.run(list_tutors(req))
+    assert len(tutors) == 1
+
+    upd = TutorIn(
+        name="Master",
+        specialization="drums",
+        hourly_rate=60,
+        level_requirement=5,
+    )
+    updated = asyncio.run(update_tutor(tutor.id, upd, req))
+    assert updated.name == "Master"
+    assert updated.specialization == "drums"
+
+    res = asyncio.run(delete_tutor(tutor.id, req))
+    assert res == {"status": "deleted"}
+    assert asyncio.run(list_tutors(req)) == []

--- a/tests/test_tutor_service.py
+++ b/tests/test_tutor_service.py
@@ -1,8 +1,8 @@
 import pytest
 
+from backend.models.learning_method import METHOD_PROFILES, LearningMethod
 from backend.models.skill import Skill
 from backend.models.tutor import Tutor
-from backend.models.learning_method import METHOD_PROFILES, LearningMethod
 from backend.services.economy_service import EconomyService
 from backend.services.skill_service import SkillService
 from backend.services.tutor_service import TutorService
@@ -19,7 +19,13 @@ def _setup_services(tmp_path):
 def test_tutor_requires_level(tmp_path):
     svc, economy, skills = _setup_services(tmp_path)
     tutor = svc.create_tutor(
-        Tutor(id=None, name="Maestro", specialization="guitar", hourly_rate=70)
+        Tutor(
+            id=None,
+            name="Maestro",
+            specialization="guitar",
+            hourly_rate=70,
+            level_requirement=1,
+        )
     )
     skill = Skill(id=1, name="guitar", category="instrument")
 
@@ -35,7 +41,13 @@ def test_tutor_requires_level(tmp_path):
 def test_tutor_session_cost_and_xp(tmp_path):
     svc, economy, skills = _setup_services(tmp_path)
     tutor = svc.create_tutor(
-        Tutor(id=None, name="Maestro", specialization="guitar", hourly_rate=70)
+        Tutor(
+            id=None,
+            name="Maestro",
+            specialization="guitar",
+            hourly_rate=70,
+            level_requirement=1,
+        )
     )
     skill = Skill(id=2, name="guitar", category="instrument")
 


### PR DESCRIPTION
## Summary
- extend tutor and apprenticeship models with admin-editable fields
- add CRUD admin routes, services, schemas and UI for tutors and mentorships
- cover new endpoints with tests and update tutor service tests

## Testing
- `python -m ruff check backend/models/tutor.py backend/models/apprenticeship.py backend/services/tutor_admin_service.py backend/services/apprenticeship_admin_service.py backend/services/apprenticeship_service.py backend/routes/admin_tutor_routes.py backend/routes/admin_apprenticeship_routes.py backend/routes/admin_routes.py backend/routes/admin_schema_routes.py backend/database.py tests/admin/test_tutor_routes.py tests/admin/test_apprenticeship_routes.py tests/test_tutor_service.py`
- `pytest tests/admin/test_tutor_routes.py tests/admin/test_apprenticeship_routes.py tests/admin/test_online_tutorial_routes.py tests/test_tutor_service.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'email_validator')*


------
https://chatgpt.com/codex/tasks/task_e_68b76e2a08d883259eda95dd570f675c