### PR TITLE
Add admin workshop management

### DIFF
--- a/backend/models/workshop.py
+++ b/backend/models/workshop.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Workshop:
+    """Admin-managed workshop event."""
+
+    id: int | None
+    skill_target: str
+    xp_reward: int
+    ticket_price: int
+    schedule: str
+
+
+__all__ = ["Workshop"]

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -8,6 +8,7 @@ from .admin_audit_routes import router as audit_router
 from .admin_book_routes import router as book_router
 from .admin_business_routes import router as business_router
 from .admin_course_routes import router as course_router
+from .admin_workshop_routes import router as workshop_router
 from .admin_economy_routes import router as economy_router
 from .admin_item_routes import router as item_router
 from .admin_job_routes import router as jobs_router
@@ -48,6 +49,7 @@ router.include_router(item_router)
 
 router.include_router(course_router)
 router.include_router(book_router)
+router.include_router(workshop_router)
 router.include_router(online_tutorial_router)
 router.include_router(tutor_router)
 router.include_router(apprenticeship_router)

--- a/backend/routes/admin_workshop_routes.py
+++ b/backend/routes/admin_workshop_routes.py
@@ -1,0 +1,70 @@
+"""Admin routes for managing workshop events."""
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.models.workshop import Workshop
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.workshop_admin_service import (
+    WorkshopAdminService,
+    get_workshop_admin_service,
+)
+
+router = APIRouter(
+    prefix="/learning/workshops",
+    tags=["AdminWorkshops"],
+    dependencies=[Depends(audit_dependency)],
+)
+svc: WorkshopAdminService = get_workshop_admin_service()
+
+
+class WorkshopIn(BaseModel):
+    skill_target: str
+    xp_reward: int
+    ticket_price: int
+    schedule: str
+
+
+async def _ensure_admin(req: Request) -> None:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+
+
+@router.get("/")
+async def list_workshops(req: Request) -> list[Workshop]:
+    await _ensure_admin(req)
+    return svc.list_workshops()
+
+
+@router.post("/")
+async def create_workshop(payload: WorkshopIn, req: Request) -> Workshop:
+    await _ensure_admin(req)
+    ws = Workshop(id=None, **payload.dict())
+    return svc.create_workshop(ws)
+
+
+@router.put("/{workshop_id}")
+async def update_workshop(workshop_id: int, payload: WorkshopIn, req: Request) -> Workshop:
+    await _ensure_admin(req)
+    try:
+        return svc.update_workshop(workshop_id, **payload.dict())
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.delete("/{workshop_id}")
+async def delete_workshop(workshop_id: int, req: Request) -> dict[str, str]:
+    await _ensure_admin(req)
+    svc.delete_workshop(workshop_id)
+    return {"status": "deleted"}
+
+
+__all__ = [
+    "router",
+    "list_workshops",
+    "create_workshop",
+    "update_workshop",
+    "delete_workshop",
+    "WorkshopIn",
+    "svc",
+]

--- a/backend/schemas/workshop_schemas.py
+++ b/backend/schemas/workshop_schemas.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class WorkshopSchema(BaseModel):
+    id: int
+    skill_target: str
+    xp_reward: int
+    ticket_price: int
+    schedule: str
+
+
+class WorkshopCreateSchema(BaseModel):
+    skill_target: str
+    xp_reward: int
+    ticket_price: int
+    schedule: str
+
+
+__all__ = ["WorkshopSchema", "WorkshopCreateSchema"]

--- a/backend/services/workshop_admin_service.py
+++ b/backend/services/workshop_admin_service.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import List, Optional
+
+from backend.database import DB_PATH
+from backend.models.workshop import Workshop
+
+
+class WorkshopAdminService:
+    """CRUD helpers for workshop events stored in SQLite."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    # ------------------------------------------------------------------
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS workshops (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    skill_target TEXT NOT NULL,
+                    xp_reward INTEGER NOT NULL,
+                    ticket_price INTEGER NOT NULL,
+                    schedule TEXT NOT NULL
+                )
+                """,
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def list_workshops(self) -> List[Workshop]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, skill_target, xp_reward, ticket_price, schedule FROM workshops ORDER BY id"
+            )
+            rows = cur.fetchall()
+            return [Workshop(**dict(row)) for row in rows]
+
+    # ------------------------------------------------------------------
+    def create_workshop(self, ws: Workshop) -> Workshop:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO workshops (skill_target, xp_reward, ticket_price, schedule) VALUES (?, ?, ?, ?)",
+                (ws.skill_target, ws.xp_reward, ws.ticket_price, ws.schedule),
+            )
+            ws.id = cur.lastrowid
+            conn.commit()
+            return ws
+
+    # ------------------------------------------------------------------
+    def update_workshop(self, workshop_id: int, **changes) -> Workshop:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, skill_target, xp_reward, ticket_price, schedule FROM workshops WHERE id = ?",
+                (workshop_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise ValueError("workshop_not_found")
+            data = dict(row)
+            for k, v in changes.items():
+                if k in data and v is not None:
+                    data[k] = v
+            cur.execute(
+                "UPDATE workshops SET skill_target=?, xp_reward=?, ticket_price=?, schedule=? WHERE id=?",
+                (
+                    data["skill_target"],
+                    data["xp_reward"],
+                    data["ticket_price"],
+                    data["schedule"],
+                    workshop_id,
+                ),
+            )
+            conn.commit()
+            return Workshop(**data)
+
+    # ------------------------------------------------------------------
+    def delete_workshop(self, workshop_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM workshops WHERE id=?", (workshop_id,))
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM workshops")
+            conn.commit()
+
+
+workshop_admin_service = WorkshopAdminService()
+
+
+def get_workshop_admin_service() -> WorkshopAdminService:
+    return workshop_admin_service
+
+
+__all__ = ["WorkshopAdminService", "workshop_admin_service", "get_workshop_admin_service"]

--- a/frontend/src/admin/learning/WorkshopsAdmin.tsx
+++ b/frontend/src/admin/learning/WorkshopsAdmin.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react';
+
+interface Workshop {
+  id: number;
+  skill_target: string;
+  xp_reward: number;
+  ticket_price: number;
+  schedule: string;
+}
+
+const WorkshopsAdmin: React.FC = () => {
+  const [workshops, setWorkshops] = useState<Workshop[]>([]);
+  const [form, setForm] = useState({
+    skill_target: '',
+    xp_reward: 0,
+    ticket_price: 0,
+    schedule: '',
+  });
+
+  const load = async () => {
+    const res = await fetch('/admin/learning/workshops/');
+    if (res.ok) {
+      setWorkshops(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const payload = {
+      skill_target: form.skill_target,
+      xp_reward: Number(form.xp_reward),
+      ticket_price: Number(form.ticket_price),
+      schedule: form.schedule,
+    };
+    await fetch('/admin/learning/workshops/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    setForm({ skill_target: '', xp_reward: 0, ticket_price: 0, schedule: '' });
+    load();
+  };
+
+  const handleDelete = async (id: number) => {
+    await fetch(`/admin/learning/workshops/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Workshops</h2>
+      <form onSubmit={handleCreate} className="space-y-2 mb-4">
+        <input
+          className="border p-1 w-full"
+          name="skill_target"
+          placeholder="Skill target"
+          value={form.skill_target}
+          onChange={handleChange}
+        />
+        <input
+          className="border p-1 w-full"
+          name="xp_reward"
+          type="number"
+          placeholder="XP reward"
+          value={form.xp_reward}
+          onChange={handleChange}
+        />
+        <input
+          className="border p-1 w-full"
+          name="ticket_price"
+          type="number"
+          placeholder="Ticket price"
+          value={form.ticket_price}
+          onChange={handleChange}
+        />
+        <input
+          className="border p-1 w-full"
+          name="schedule"
+          placeholder="Schedule"
+          value={form.schedule}
+          onChange={handleChange}
+        />
+        <button type="submit" className="px-4 py-2 bg-blue-500 text-white">
+          Create
+        </button>
+      </form>
+      <ul className="space-y-1">
+        {workshops.map(w => (
+          <li key={w.id} className="flex justify-between items-center">
+            <span>
+              {w.skill_target} - {w.schedule} (${w.ticket_price})
+            </span>
+            <button className="text-red-600" onClick={() => handleDelete(w.id)}>
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default WorkshopsAdmin;

--- a/tests/admin/test_workshop_routes.py
+++ b/tests/admin/test_workshop_routes.py
@@ -1,0 +1,88 @@
+import asyncio
+import sys
+from pathlib import Path
+
+# isort: skip_file
+
+import pytest
+from fastapi import HTTPException, Request
+
+# allow import backend
+BASE = Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE))
+sys.path.append(str(BASE / "backend"))
+
+from backend.routes.admin_workshop_routes import (  # type: ignore  # noqa: E402
+    WorkshopIn,
+    create_workshop,
+    delete_workshop,
+    list_workshops,
+    update_workshop,
+    svc,
+)  # isort: skip
+
+
+def test_workshop_routes_require_admin():
+    req = Request({"type": "http", "headers": []})
+    payload = WorkshopIn(
+        skill_target="guitar",
+        xp_reward=10,
+        ticket_price=100,
+        schedule="2024-01-01T00:00:00Z",
+    )
+    with pytest.raises(HTTPException):
+        asyncio.run(list_workshops(req))
+    with pytest.raises(HTTPException):
+        asyncio.run(create_workshop(payload, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(update_workshop(1, payload, req))
+    with pytest.raises(HTTPException):
+        asyncio.run(delete_workshop(1, req))
+
+
+def test_workshop_routes_crud(monkeypatch, tmp_path):
+    async def fake_current_user(req):
+        return 1
+
+    async def fake_require_role(roles, user_id):
+        return True
+
+    monkeypatch.setattr(
+        "backend.routes.admin_workshop_routes.get_current_user_id",
+        fake_current_user,
+    )
+    monkeypatch.setattr(
+        "backend.routes.admin_workshop_routes.require_role",
+        fake_require_role,
+    )
+
+    svc.db_path = str(tmp_path / "workshops.db")
+    svc.ensure_schema()
+    svc.clear()
+
+    req = Request({"type": "http", "headers": []})
+    payload = WorkshopIn(
+        skill_target="guitar",
+        xp_reward=10,
+        ticket_price=100,
+        schedule="2024-01-01T00:00:00Z",
+    )
+    ws = asyncio.run(create_workshop(payload, req))
+    assert ws.id is not None
+
+    workshops = asyncio.run(list_workshops(req))
+    assert len(workshops) == 1
+
+    upd = WorkshopIn(
+        skill_target="drums",
+        xp_reward=20,
+        ticket_price=150,
+        schedule="2024-02-02T00:00:00Z",
+    )
+    updated = asyncio.run(update_workshop(ws.id, upd, req))
+    assert updated.skill_target == "drums"
+    assert updated.xp_reward == 20
+
+    res = asyncio.run(delete_workshop(ws.id, req))
+    assert res == {"status": "deleted"}
+    assert asyncio.run(list_workshops(req)) == []


### PR DESCRIPTION
## Summary
- add workshop model, service, and admin CRUD routes with audit logging
- register workshop router and add admin frontend for managing workshops
- cover workshop admin flow with unit tests

## Testing
- `ruff check backend/routes/admin_workshop_routes.py backend/services/workshop_admin_service.py backend/models/workshop.py tests/admin/test_workshop_routes.py`
- `pytest tests/admin/test_workshop_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b770c8194883259635daca47a53622