### PR TITLE
Add workshop schema endpoint and validations

### DIFF
--- a/tests/admin/test_admin_schema_routes.py
+++ b/tests/admin/test_admin_schema_routes.py
@@ -1,0 +1,56 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, Request
+
+BASE = Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE))
+sys.path.append(str(BASE / "backend"))
+
+from backend.routes.admin_schema_routes import (  # type: ignore
+    apprenticeship_schema,
+    book_schema,
+    course_schema,
+    online_tutorial_schema,
+    tutor_schema,
+    workshop_schema,
+)
+
+SCHEMA_FUNCS = [
+    book_schema,
+    course_schema,
+    online_tutorial_schema,
+    tutor_schema,
+    apprenticeship_schema,
+    workshop_schema,
+]
+
+
+@pytest.mark.parametrize("func", SCHEMA_FUNCS)
+def test_admin_schema_requires_admin(func):
+    req = Request({"type": "http", "headers": []})
+    with pytest.raises(HTTPException):
+        asyncio.run(func(req))
+
+
+@pytest.mark.parametrize("func", SCHEMA_FUNCS)
+def test_admin_schema_available(monkeypatch, func):
+    async def fake_current_user(req):
+        return 1
+
+    async def fake_require_role(roles, user_id):
+        return True
+
+    monkeypatch.setattr(
+        "backend.routes.admin_schema_routes.get_current_user_id", fake_current_user
+    )
+    monkeypatch.setattr(
+        "backend.routes.admin_schema_routes.require_role", fake_require_role
+    )
+
+    req = Request({"type": "http", "headers": []})
+    schema = asyncio.run(func(req))
+    props = schema.get("properties", {})
+    assert {"xp_rate", "level_cap", "prerequisites"}.issubset(props.keys())


### PR DESCRIPTION
## Summary
- add shared LearningSchema with XP rate, level cap and prerequisites validation
- expose schema endpoints for books, courses, tutorials, tutors, apprenticeships, and workshops
- cover admin schema routes with tests ensuring admin access and schema fields

## Testing
- `pytest tests/admin/test_admin_schema_routes.py`
- `pytest` *(fails: NoReferencedTableError in several auth/service tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7732ca4248325971a813447e207d1