### PR TITLE
Add downgrade for mail attachments migration

### DIFF
--- a/backend/migrations/versions/0012_045_mail_attachments_and_fts.py
+++ b/backend/migrations/versions/0012_045_mail_attachments_and_fts.py
@@ -13,5 +13,7 @@ def upgrade() -> None:
     op.execute(SQL_FILE.read_text())
 
 def downgrade() -> None:
-    # Upgrade performed no schema changes; nothing to undo.
-    pass
+    op.execute("DROP TRIGGER IF EXISTS mail_messages_ai;")
+    op.execute("DROP TRIGGER IF EXISTS mail_messages_ad;")
+    op.execute("DROP TABLE IF EXISTS mail_fts;")
+    op.execute("DROP TABLE IF EXISTS mail_attachments;")

--- a/docs/migration_notes.md
+++ b/docs/migration_notes.md
@@ -3,3 +3,5 @@
 ## Irreversible Migrations
 
 - **0022_100_song_licensing**: Adds `license_fee` and `royalty_rate` columns to the `songs` table. SQLite lacks straightforward support for dropping columns prior to v3.35 and doing so would require recreating the table and migrating data, which is unsafe for production. The migration therefore only drops the `cover_royalties` table during downgrade and leaves the added columns in place.
+
+All other migrations include downgrade steps that fully reverse their schema changes.


### PR DESCRIPTION
## Summary
- add downgrade logic for mail attachments and FTS migration
- clarify migration notes about irreversible song licensing change

## Testing
- `python - <<'PY'
from sqlalchemy import create_engine, text
from alembic.runtime.migration import MigrationContext
from alembic import op as alembic_op
import importlib

engine = create_engine('sqlite:///throwaway.db')
with engine.begin() as conn:
    raw = conn.connection
    raw.executescript('''
    CREATE TABLE mail_messages(id INTEGER);
    CREATE TABLE mail_attachments(id INTEGER PRIMARY KEY);
    CREATE VIRTUAL TABLE mail_fts USING fts5(content);
    CREATE TRIGGER mail_messages_ai AFTER INSERT ON mail_messages BEGIN INSERT INTO mail_fts(rowid, content) VALUES (new.id,''); END;
    CREATE TRIGGER mail_messages_ad AFTER DELETE ON mail_messages BEGIN DELETE FROM mail_fts WHERE rowid=old.id; END;
    ''')
    ctx = MigrationContext.configure(conn)
    alembic_op._proxy = alembic_op.Operations(ctx)
    mig = importlib.import_module('backend.migrations.versions.0012_045_mail_attachments_and_fts')
    mig.downgrade()
    remaining = conn.execute(text("SELECT name, type FROM sqlite_master WHERE name LIKE 'mail%'")).fetchall()
    print(remaining)
PY`
- `alembic upgrade head` (fails: You can only execute one statement at a time)


------
https://chatgpt.com/codex/tasks/task_e_68b80579d4308325a2aa3fecbb56c853