### PR TITLE
Handle economy schema errors in JamService

### DIFF
--- a/backend/services/jam_service.py
+++ b/backend/services/jam_service.py
@@ -26,7 +26,7 @@ class JamService:
             self.economy.ensure_schema()
         except Exception as exc:
             logger.exception("Failed to ensure economy schema")
-            raise RuntimeError("failed to ensure economy schema") from exc
+            raise RuntimeError(f"failed to ensure economy schema: {exc}") from exc
         self.db_path = str(db_path or DB_PATH)
         self.ensure_schema()
         self.invites: Dict[str, Set[int]] = {}

--- a/backend/tests/jam_sessions/test_jam_service_failure.py
+++ b/backend/tests/jam_sessions/test_jam_service_failure.py
@@ -12,6 +12,8 @@ class FailingEconomy(EconomyService):
 
 def test_jam_service_init_raises_and_logs(caplog):
     econ = FailingEconomy()
-    with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError, match="failed to ensure economy schema"):
+    with caplog.at_level(logging.ERROR), pytest.raises(
+        RuntimeError, match="failed to ensure economy schema: boom"
+    ):
         JamService(economy=econ)
     assert "Failed to ensure economy schema" in caplog.text


### PR DESCRIPTION
## Summary
- Log and wrap `EconomyService.ensure_schema` failures in `JamService` as `RuntimeError`s including original message
- Adjust jam service failure test to expect the detailed error message

## Testing
- `pytest backend/tests/jam_sessions/test_jam_service_failure.py -q`
- `pytest backend/tests/jam_sessions/test_jam_gateway.py -q`
- `pytest tests/realtime/test_jam_gateway_ws.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8096248bc8325b403c046af5693b1