### PR TITLE
Refactor realtime gateways to require FastAPI and add WebSocket tests

### DIFF
--- a/backend/realtime/jam_gateway.py
+++ b/backend/realtime/jam_gateway.py
@@ -7,24 +7,12 @@ import logging
 from typing import Any, Dict
 
 try:  # pragma: no cover - explicit failure if FastAPI missing
-    from fastapi import APIRouter, Depends, Header, WebSocket, WebSocketDisconnect
+    from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 except ModuleNotFoundError as exc:  # pragma: no cover - FastAPI required
     raise ImportError("FastAPI must be installed to use backend.realtime.jam_gateway") from exc
 
 from backend.services.jam_service import JamService
-
-
-async def get_current_user_id_dep(  # pragma: no cover - simple fallback
-    x_user_id: str | None = Header(default=None, alias="X-User-Id"),
-    authorization: str | None = Header(default=None, alias="Authorization"),
-) -> int:
-    if x_user_id:
-        return int(x_user_id)
-    if authorization:
-        parts = authorization.split()
-        if len(parts) == 2 and parts[0].lower() == "bearer":
-            return int(parts[1])
-    return 0
+from .gateway import get_current_user_id_dep
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/jam", tags=["realtime"])

--- a/backend/realtime/polling.py
+++ b/backend/realtime/polling.py
@@ -6,22 +6,11 @@ import json
 from typing import Dict
 
 try:  # pragma: no cover - explicit failure if FastAPI missing
-    from fastapi import APIRouter, Depends, Header, WebSocket, WebSocketDisconnect
+    from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 except ModuleNotFoundError as exc:  # pragma: no cover - FastAPI required
     raise ImportError("FastAPI must be installed to use backend.realtime.polling") from exc
 
-
-async def get_current_user_id_dep(  # pragma: no cover - simple fallback
-    x_user_id: str | None = Header(default=None, alias="X-User-Id"),
-    authorization: str | None = Header(default=None, alias="Authorization"),
-) -> int:
-    if x_user_id:
-        return int(x_user_id)
-    if authorization:
-        parts = authorization.split()
-        if len(parts) == 2 and parts[0].lower() == "bearer":
-            return int(parts[1])
-    return 0
+from .gateway import get_current_user_id_dep
 
 router = APIRouter(prefix="/encore", tags=["realtime"])
 

--- a/tests/realtime/test_jam_gateway_ws.py
+++ b/tests/realtime/test_jam_gateway_ws.py
@@ -46,13 +46,16 @@ def create_app() -> FastAPI:
     app = FastAPI()
     jam_gateway.jam_service = FakeJamService()
     app.include_router(jam_gateway.router)
+    async def _uid() -> int:
+        return 1
+    app.dependency_overrides[jam_gateway.get_current_user_id_dep] = _uid
     return app
 
 
 def test_jam_gateway_ping_and_stream():
     app = create_app()
     client = TestClient(app)
-    with client.websocket_connect("/jam/ws/s1", headers={"X-User-Id": "1"}) as ws:
+    with client.websocket_connect("/jam/ws/s1") as ws:
         joined = ws.receive_json()
         assert joined == {"type": "joined", "user_id": 1}
         ws.send_json({"op": "ping"})

--- a/tests/realtime/test_polling_ws.py
+++ b/tests/realtime/test_polling_ws.py
@@ -11,13 +11,16 @@ from backend.realtime import polling
 def create_app() -> FastAPI:
     app = FastAPI()
     app.include_router(polling.router)
+    async def _uid() -> int:
+        return 1
+    app.dependency_overrides[polling.get_current_user_id_dep] = _uid
     return app
 
 
 def test_polling_vote_flow():
     app = create_app()
     client = TestClient(app)
-    with client.websocket_connect("/encore/ws/rock", headers={"X-User-Id": "1"}) as ws:
+    with client.websocket_connect("/encore/ws/rock") as ws:
         ws.send_json({"vote": "A"})
         message = ws.receive_json()
         assert message["type"] == "leaderboard"


### PR DESCRIPTION
## Summary
- enforce FastAPI imports for polling and jam gateways and share authentication dependency
- exercise websocket vote and jam flows with FastAPI TestClient

## Testing
- `pytest tests/realtime/test_polling_ws.py tests/realtime/test_jam_gateway_ws.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b80ab1ad4c8325a16765219ee1f060