### PR TITLE
Add daily loop persistence, endpoints, UI banner and scheduler

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -360,4 +360,17 @@ def init_db():
         )
         """)
 
+        # Daily loop table for login streaks and challenges
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS daily_loop (
+            user_id INTEGER PRIMARY KEY,
+            login_streak INTEGER DEFAULT 0,
+            last_login TEXT,
+            current_challenge TEXT,
+            challenge_progress INTEGER DEFAULT 0,
+            reward_claimed INTEGER DEFAULT 0,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """)
+
         conn.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from middleware.rate_limit import RateLimitMiddleware
 from routes import (
     admin_routes,
     apprenticeship_routes,
+    daily_loop_routes,
     event_routes,
     legacy_routes,
     lifestyle_routes,
@@ -29,6 +30,7 @@ from routes import (
 from utils.db import init_pool
 from utils.i18n import _
 
+from backend.services.scheduler_service import schedule_daily_loop_reset
 from backend.utils.error_handlers import http_exception_handler
 from backend.utils.logging import setup_logging
 from backend.utils.metrics import CONTENT_TYPE_LATEST, generate_latest
@@ -63,6 +65,7 @@ def startup() -> None:
     setup_tracing(exporter)
     init_db()
     init_pool()
+    schedule_daily_loop_reset()
 
 
 # Existing routers
@@ -88,6 +91,7 @@ app.include_router(music_metrics_routes.router)
 app.include_router(song_forecast_routes.router)
 app.include_router(tour_collab_routes.router, prefix="/api", tags=["TourCollab"])
 app.include_router(university_routes.router, prefix="/api", tags=["University"])
+app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])
 
 
 @app.get("/metrics")

--- a/backend/models/daily_loop.py
+++ b/backend/models/daily_loop.py
@@ -1,0 +1,98 @@
+import random
+import sqlite3
+from datetime import date
+from typing import Dict
+
+from backend.database import DB_PATH
+
+CHALLENGES = [
+    "Practice scales",
+    "Write a chorus",
+    "Listen to a new song",
+]
+
+
+def _ensure_row(cur: sqlite3.Cursor, user_id: int) -> None:
+    cur.execute("""
+        INSERT OR IGNORE INTO daily_loop (user_id, login_streak, last_login, current_challenge, challenge_progress, reward_claimed)
+        VALUES (?, 0, NULL, '', 0, 0)
+    """, (user_id,))
+
+
+def get_status(user_id: int) -> Dict:
+    """Return current streak, challenge, and reward state for a user."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    _ensure_row(cur, user_id)
+    cur.execute(
+        """
+        SELECT login_streak, last_login, current_challenge, challenge_progress, reward_claimed
+        FROM daily_loop
+        WHERE user_id = ?
+    """,
+        (user_id,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    return {
+        "login_streak": row[0],
+        "last_login": row[1],
+        "current_challenge": row[2],
+        "challenge_progress": row[3],
+        "reward_claimed": bool(row[4]),
+    }
+
+
+def increment_login_streak(user_id: int) -> Dict:
+    """Increment the login streak for today."""
+    today = date.today().isoformat()
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    _ensure_row(cur, user_id)
+    cur.execute(
+        "SELECT login_streak, last_login FROM daily_loop WHERE user_id = ?",
+        (user_id,),
+    )
+    streak, last_login = cur.fetchone()
+    if last_login == today:
+        conn.close()
+        return get_status(user_id)
+    if last_login == (date.today() - date.resolution).isoformat():
+        streak += 1
+    else:
+        streak = 1
+    cur.execute(
+        "UPDATE daily_loop SET login_streak = ?, last_login = ? WHERE user_id = ?",
+        (streak, today, user_id),
+    )
+    conn.commit()
+    conn.close()
+    return get_status(user_id)
+
+
+def claim_reward(user_id: int) -> Dict:
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    _ensure_row(cur, user_id)
+    cur.execute(
+        "UPDATE daily_loop SET reward_claimed = 1 WHERE user_id = ?",
+        (user_id,),
+    )
+    conn.commit()
+    conn.close()
+    return get_status(user_id)
+
+
+def rotate_daily_challenge() -> None:
+    challenge = random.choice(CHALLENGES)
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        UPDATE daily_loop
+        SET current_challenge = ?, challenge_progress = 0, reward_claimed = 0
+    """,
+        (challenge,),
+    )
+    conn.commit()
+    conn.close()

--- a/backend/routes/daily_loop_routes.py
+++ b/backend/routes/daily_loop_routes.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from backend.models import daily_loop
+
+router = APIRouter(prefix="/daily", tags=["DailyLoop"])
+
+
+@router.get("/status/{user_id}")
+def get_status(user_id: int):
+    return daily_loop.get_status(user_id)
+
+
+class ClaimRequest(BaseModel):
+    user_id: int
+
+
+@router.post("/claim")
+def claim_reward(req: ClaimRequest):
+    return daily_loop.claim_reward(req.user_id)

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>RockMundo Daily</title>
+</head>
+<body>
+    <h1>Welcome to RockMundo</h1>
+    <div id="daily-banner">
+        <p id="streak">Streak: --</p>
+        <p id="challenge">Today's challenge: --</p>
+        <p id="reward">Reward: --</p>
+        <button id="claim-btn">Claim Reward</button>
+    </div>
+    <script>
+    async function loadDaily() {
+        const res = await fetch('/api/daily/status/1');
+        const data = await res.json();
+        document.getElementById('streak').textContent = `Streak: ${data.login_streak}`;
+        document.getElementById('challenge').textContent = `Today's challenge: ${data.current_challenge}`;
+        document.getElementById('reward').textContent = data.reward_claimed ? 'Reward: claimed' : 'Reward: available';
+        document.getElementById('claim-btn').disabled = data.reward_claimed;
+    }
+    document.getElementById('claim-btn').addEventListener('click', async () => {
+        await fetch('/api/daily/claim', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ user_id: 1 })
+        });
+        loadDaily();
+    });
+    loadDaily();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Track login streaks and challenge progress with new `daily_loop` model and database table
- Provide `/api/daily` endpoints to fetch status and claim rewards
- Display streak and challenge info on homepage with ability to claim reward
- Schedule daily job to rotate challenges and reset availability

## Testing
- `ruff check backend/models/daily_loop.py backend/routes/daily_loop_routes.py backend/services/scheduler_service.py backend/main.py backend/database.py`
- `pytest` *(fails: Foreign key associated with column ... NoReferencedTableError)*


------
https://chatgpt.com/codex/tasks/task_e_68b81051cecc832584d90282bf49b043