### PR TITLE
feat: add music library search and sort

### DIFF
--- a/backend/routes/album_routes.py
+++ b/backend/routes/album_routes.py
@@ -14,7 +14,9 @@ def create_release():
 
 @album_routes.route('/albums/band/<int:band_id>', methods=['GET'])
 def get_band_releases(band_id):
-    return jsonify(album_service.list_releases_by_band(band_id))
+    search = request.args.get('search')
+    sort = request.args.get('sort')
+    return jsonify(album_service.list_releases_by_band(band_id, search=search, sort=sort))
 
 @album_routes.route("/albums/<int:release_id>", methods=["PUT"])
 def update_release(release_id):

--- a/backend/routes/song_routes.py
+++ b/backend/routes/song_routes.py
@@ -1,6 +1,5 @@
-from auth.dependencies import get_current_user_id, require_role
 
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, jsonify, request
 from services.song_service import SongService
 
 song_routes = Blueprint('song_routes', __name__)
@@ -16,7 +15,9 @@ def create_song():
 
 @song_routes.route('/songs/band/<int:band_id>', methods=['GET'])
 def get_band_songs(band_id):
-    return jsonify(song_service.list_songs_by_band(band_id))
+    search = request.args.get('search')
+    sort = request.args.get('sort')
+    return jsonify(song_service.list_songs_by_band(band_id, search=search, sort=sort))
 
 
 @song_routes.route('/songs/<int:song_id>/covers', methods=['GET'])

--- a/frontend/pages/music_library.html
+++ b/frontend/pages/music_library.html
@@ -1,5 +1,13 @@
 
 <h2>Your Music Library</h2>
+<div>
+  <input type="text" id="searchInput" placeholder="Search..." />
+  <select id="sortSelect">
+    <option value="title">Title</option>
+    <option value="duration">Duration</option>
+    <option value="plays">Plays</option>
+  </select>
+</div>
 <div id="tabs">
   <button onclick="showTab('songs')">Songs</button>
   <button onclick="showTab('albums')">Albums</button>
@@ -17,4 +25,54 @@ function showTab(tab) {
   document.getElementById('songsTab').style.display = tab === 'songs' ? 'block' : 'none';
   document.getElementById('albumsTab').style.display = tab === 'albums' ? 'block' : 'none';
 }
+</script>
+<script>
+const BAND_ID = 1;
+
+async function loadSongs(search = '', sort = 'title') {
+  const res = await fetch(`/songs/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
+  const data = await res.json();
+  const list = document.getElementById('songList');
+  list.innerHTML = '';
+  data.forEach(song => {
+    const li = document.createElement('li');
+    li.textContent = `${song.title} (${song.genre})`;
+    list.appendChild(li);
+  });
+  filterList();
+}
+
+async function loadAlbums(search = '', sort = 'title') {
+  const res = await fetch(`/albums/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
+  const data = await res.json();
+  const list = document.getElementById('albumList');
+  list.innerHTML = '';
+  data.forEach(album => {
+    const li = document.createElement('li');
+    li.textContent = `${album.title} (${album.format})`;
+    list.appendChild(li);
+  });
+  filterList();
+}
+
+function filterList() {
+  const query = document.getElementById('searchInput').value.toLowerCase();
+  document.querySelectorAll('#songList li, #albumList li').forEach(li => {
+    li.style.display = li.textContent.toLowerCase().includes(query) ? '' : 'none';
+  });
+}
+
+function handleInput() {
+  const search = document.getElementById('searchInput').value;
+  const sort = document.getElementById('sortSelect').value;
+  loadSongs(search, sort);
+  loadAlbums(search, sort);
+  filterList();
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('searchInput').addEventListener('input', handleInput);
+  document.getElementById('sortSelect').addEventListener('change', handleInput);
+  handleInput();
+});
 </script>


### PR DESCRIPTION
## Summary
- allow music library list endpoints to filter and sort via query params
- add search box and sorting in music library page with client-side filtering

## Testing
- `pytest` *(fails: 8 errors)*
- `ruff check backend/routes/album_routes.py backend/routes/song_routes.py backend/services/album_service.py backend/services/song_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8114b1c54832596411c35cebcd248