### PR TITLE
feat: add tour planner map and itinerary endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from routes import (
     song_forecast_routes,
     sponsorship,
     tour_collab_routes,
+    tour_planner_routes,
     university_routes,
     video_routes,
 )
@@ -90,6 +91,7 @@ app.include_router(setlist_routes.router, prefix="/api", tags=["Setlists"])
 app.include_router(music_metrics_routes.router)
 app.include_router(song_forecast_routes.router)
 app.include_router(tour_collab_routes.router, prefix="/api", tags=["TourCollab"])
+app.include_router(tour_planner_routes.router, prefix="/api", tags=["TourPlanner"])
 app.include_router(university_routes.router, prefix="/api", tags=["University"])
 app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])
 

--- a/backend/routes/tour_planner_routes.py
+++ b/backend/routes/tour_planner_routes.py
@@ -1,0 +1,117 @@
+"""Routes for tour planning and itinerary optimization."""
+
+from __future__ import annotations
+
+import math
+from typing import List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/tour-planner", tags=["TourPlanner"])
+
+
+class TourRequest(BaseModel):
+    """Incoming payload for tour planning."""
+
+    route: List[str]
+    vehicle_type: str
+
+
+class TourResponse(BaseModel):
+    """Response containing an optimized itinerary and costs."""
+
+    itinerary: List[str]
+    total_distance: float
+    total_time: float
+    total_cost: float
+
+
+# Simple city database with lat/long coordinates
+CITY_COORDS = {
+    "New York": (40.7128, -74.0060),
+    "Los Angeles": (34.0522, -118.2437),
+    "Chicago": (41.8781, -87.6298),
+    "Houston": (29.7604, -95.3698),
+    "Phoenix": (33.4484, -112.0740),
+}
+
+
+VEHICLE_SPEEDS_KMH = {
+    "van": 80.0,
+    "bus": 70.0,
+    "truck": 65.0,
+    "plane": 800.0,
+}
+
+
+COST_PER_KM = {
+    "van": 0.5,
+    "bus": 0.7,
+    "truck": 0.9,
+    "plane": 5.0,
+}
+
+
+def haversine(coord1: tuple[float, float], coord2: tuple[float, float]) -> float:
+    """Return distance in km between two (lat, lon) pairs using Haversine formula."""
+
+    lat1, lon1 = coord1
+    lat2, lon2 = coord2
+    radius = 6371.0
+
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+
+    a = (
+        math.sin(dphi / 2) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    )
+    return 2 * radius * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+@router.post("/optimize", response_model=TourResponse)
+def optimize_tour(payload: TourRequest) -> TourResponse:
+    """Calculate travel distance, time and cost and reorder route greedily."""
+
+    if len(payload.route) < 2:
+        raise HTTPException(status_code=400, detail="At least two cities required")
+
+    for city in payload.route:
+        if city not in CITY_COORDS:
+            raise HTTPException(status_code=400, detail=f"Unknown city: {city}")
+
+    remaining = payload.route[:]
+    itinerary = [remaining.pop(0)]
+    while remaining:
+        last = itinerary[-1]
+        next_city = min(
+            remaining,
+            key=lambda c: haversine(CITY_COORDS[last], CITY_COORDS[c]),
+        )
+        itinerary.append(next_city)
+        remaining.remove(next_city)
+
+    vehicle_key = payload.vehicle_type.lower()
+    speed = VEHICLE_SPEEDS_KMH.get(vehicle_key)
+    cost_km = COST_PER_KM.get(vehicle_key)
+    if speed is None or cost_km is None:
+        raise HTTPException(status_code=400, detail="Unknown vehicle type")
+
+    total_distance = 0.0
+    for i in range(len(itinerary) - 1):
+        total_distance += haversine(
+            CITY_COORDS[itinerary[i]], CITY_COORDS[itinerary[i + 1]]
+        )
+
+    total_time = total_distance / speed
+    total_cost = total_distance * cost_km
+
+    return TourResponse(
+        itinerary=itinerary,
+        total_distance=total_distance,
+        total_time=total_time,
+        total_cost=total_cost,
+    )
+

--- a/frontend/pages/tour_planner.html
+++ b/frontend/pages/tour_planner.html
@@ -1,19 +1,68 @@
 
 <h2>Tour Planner</h2>
 
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+  integrity="sha256-sA+e8oqJ7uwVB1Cifj8P6R9iW/tSti7ouemZoDUopkw="
+  crossorigin=""
+/>
+<script
+  src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+  integrity="sha256-o9N1j7UwyZwLRyy1A8kz7VF8NjFsg6z2g52n8TbNLD0="
+  crossorigin=""
+></script>
+
 <form id="tourForm">
   <input type="text" name="title" placeholder="Tour Name" required />
   <input type="text" name="band_id" placeholder="Band ID" required />
   <input type="text" name="start_date" placeholder="Start Date (YYYY-MM-DD)" required />
   <input type="text" name="end_date" placeholder="End Date (YYYY-MM-DD)" required />
   <input type="text" name="vehicle_type" placeholder="Vehicle (van, bus, truck, plane)" required />
-  <textarea name="route" placeholder="Cities (comma-separated)" required></textarea>
-  <button type="submit">Create Tour</button>
+  <div id="map" style="height: 400px; margin-top: 10px;"></div>
+  <p id="selectedCities" style="margin-top: 10px;"></p>
+  <button type="submit">Plan Tour</button>
 </form>
 
+<div id="itinerary"></div>
+
 <script>
+const cities = {
+  "New York": [40.7128, -74.006],
+  "Los Angeles": [34.0522, -118.2437],
+  "Chicago": [41.8781, -87.6298],
+  "Houston": [29.7604, -95.3698],
+  "Phoenix": [33.4484, -112.074]
+};
+
+const map = L.map('map').setView([39.5, -98.35], 4);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+const route = [];
+Object.entries(cities).forEach(([name, coords]) => {
+  const marker = L.marker(coords).addTo(map).bindPopup(name);
+  marker.on('click', () => {
+    if (!route.includes(name)) {
+      route.push(name);
+      document.getElementById('selectedCities').innerText = route.join(' -> ');
+    }
+  });
+});
+
 document.getElementById('tourForm').addEventListener('submit', async (e) => {
   e.preventDefault();
+
+  if (route.length < 2) {
+    alert('Select at least two cities.');
+    return;
+  }
+  if (new Set(route).size !== route.length) {
+    alert('Duplicate cities in route.');
+    return;
+  }
+
   const formData = new FormData(e.target);
   const payload = {
     title: formData.get('title'),
@@ -21,16 +70,22 @@ document.getElementById('tourForm').addEventListener('submit', async (e) => {
     start_date: formData.get('start_date'),
     end_date: formData.get('end_date'),
     vehicle_type: formData.get('vehicle_type'),
-    route: formData.get('route').split(',').map(c => c.trim())
+    route: route
   };
 
-  const res = await fetch('/tours', {
+  const res = await fetch('/api/tour-planner/optimize', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
 
   const result = await res.json();
-  alert(JSON.stringify(result));
+  document.getElementById('itinerary').innerHTML = `
+    <h3>Optimized Itinerary</h3>
+    <p>${result.itinerary.join(' -> ')}</p>
+    <p>Total Distance: ${result.total_distance.toFixed(2)} km</p>
+    <p>Total Time: ${result.total_time.toFixed(2)} hrs</p>
+    <p>Estimated Cost: $${result.total_cost.toFixed(2)}</p>
+  `;
 });
 </script>


### PR DESCRIPTION
## Summary
- replace tour route textarea with interactive Leaflet map and show optimized itinerary
- add backend endpoint to compute travel distance, time, and cost for selected cities
- register planner router in FastAPI app

## Testing
- `ruff check backend/routes/tour_planner_routes.py backend/main.py`
- `mypy backend/routes/tour_planner_routes.py backend/main.py` *(fails: Value of type "list[int] | float | int" is not indexable [index])* 
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'email_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68b812b09f3c8325969067aa54a2005c