### PR TITLE
Add dashboard summary page with charts and login redirect

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "tailwindcss": "^3.3.2"
+    "tailwindcss": "^3.3.2",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/pages/Dashboard.jsx
+++ b/frontend/pages/Dashboard.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+function isAuthenticated() {
+  const jwt = localStorage.getItem('jwt');
+  const hasSession = document.cookie
+    .split(';')
+    .some((c) => c.trim().startsWith('session='));
+  return Boolean(jwt || hasSession);
+}
+
+const Dashboard = () => {
+  const [summary, setSummary] = useState(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated()) {
+      window.location.href = '/login';
+      return;
+    }
+
+    fetch('/dashboard/summary')
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return res.json();
+      })
+      .then((data) => setSummary(data))
+      .catch(() => setError(true));
+  }, []);
+
+  if (error) {
+    return <div className="p-4 text-red-500">Unable to load dashboard.</div>;
+  }
+
+  if (!summary) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  const topSongsData = {
+    labels: summary.topSongs.map((s) => s.title),
+    datasets: [
+      {
+        label: 'Plays',
+        data: summary.topSongs.map((s) => s.plays),
+        backgroundColor: 'rgba(75, 192, 192, 0.5)',
+      },
+    ],
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Dashboard</h1>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="bg-white rounded shadow p-4">
+          <h2 className="text-xl mb-2">Top Songs</h2>
+          <Bar data={topSongsData} />
+        </div>
+        <div className="bg-white rounded shadow p-4">
+          <h2 className="text-xl mb-2">Current Gigs</h2>
+          <ul>
+            {summary.currentGigs.map((gig, idx) => (
+              <li key={idx}>
+                {gig.venue} - {gig.date}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="bg-white rounded shadow p-4 md:col-span-2">
+          <h2 className="text-xl mb-2">Financials</h2>
+          <div className="flex flex-col sm:flex-row gap-4">
+            <div className="flex-1">
+              <p>Revenue: ${summary.financials.revenue}</p>
+              <p>Expenses: ${summary.financials.expenses}</p>
+              <p>Profit: ${summary.financials.profit}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/frontend/pages/login.html
+++ b/frontend/pages/login.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Login</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="login-form">
+    <input type="text" id="username" placeholder="Username" required />
+    <input type="password" id="password" placeholder="Password" required />
+    <button type="submit">Login</button>
+  </form>
+  <p id="error" style="color:red; display:none;"></p>
+  <script>
+    document.getElementById('login-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      try {
+        const res = await fetch('/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ username, password })
+        });
+        if (!res.ok) throw new Error('Login failed');
+        const data = await res.json();
+        localStorage.setItem('jwt', data.access_token);
+        window.location.href = '/dashboard';
+      } catch (err) {
+        const errEl = document.getElementById('error');
+        errEl.style.display = 'block';
+        errEl.textContent = 'Invalid credentials';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -6,6 +6,7 @@ interface NavItem {
 }
 
 const navItems: NavItem[] = [
+  { label: 'Dashboard', href: '/dashboard' },
   { label: 'NPCs', href: '/admin/npcs' },
   { label: 'NPC Dialogue', href: '/admin/npcs/dialogue' },
   { label: 'Quests', href: '/admin/quests' },


### PR DESCRIPTION
## Summary
- Add React dashboard page that fetches `/dashboard/summary`, visualizes top songs with charts, lists gigs and financials, and handles errors
- Introduce login page that stores JWT and redirects authenticated users to the dashboard
- Link dashboard from admin sidebar and add chart.js dependencies

## Testing
- `npm install` *(fails: 403 Forbidden retrieving @testing-library/jest-dom)*
- `npm test` *(fails: vitest not found)*
- `pytest` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b8139d57a48325b7b923c76190b6f4