### PR TITLE
feat: add form notifications

### DIFF
--- a/backend/routes/album_routes.py
+++ b/backend/routes/album_routes.py
@@ -10,7 +10,7 @@ def create_release():
     try:
         return jsonify(album_service.create_release(data)), 201
     except ValueError as e:
-        return jsonify({'error': str(e)}), 400
+        return jsonify({'status': 'error', 'message': str(e)}), 400
 
 @album_routes.route('/albums/band/<int:band_id>', methods=['GET'])
 def get_band_releases(band_id):

--- a/backend/routes/song_routes.py
+++ b/backend/routes/song_routes.py
@@ -11,7 +11,7 @@ def create_song():
     try:
         return jsonify(song_service.create_song(data)), 201
     except Exception as e:
-        return jsonify({'error': str(e)}), 400
+        return jsonify({'status': 'error', 'message': str(e)}), 400
 
 @song_routes.route('/songs/band/<int:band_id>', methods=['GET'])
 def get_band_songs(band_id):

--- a/frontend/components/notification.js
+++ b/frontend/components/notification.js
@@ -1,0 +1,22 @@
+(function(){
+  if (!document.getElementById('notification-styles')) {
+    const style = document.createElement('style');
+    style.id = 'notification-styles';
+    style.textContent = `
+      .notification{position:fixed;top:20px;right:20px;padding:10px 15px;color:#fff;border-radius:4px;z-index:1000;font-family:sans-serif;}
+      .notification.success{background:#4caf50;}
+      .notification.error{background:#f44336;}
+    `;
+    document.head.appendChild(style);
+  }
+  function showNotification(message, type='success'){
+    const note=document.createElement('div');
+    note.className=`notification ${type}`;
+    note.textContent=message;
+    document.body.appendChild(note);
+    setTimeout(()=>{
+      note.remove();
+    },3000);
+  }
+  window.showNotification=showNotification;
+})();

--- a/frontend/pages/album_form.html
+++ b/frontend/pages/album_form.html
@@ -18,3 +18,44 @@
   <input type="file" name="cover_art" />
   <button type="submit">Create Release</button>
 </form>
+
+<script src="../components/notification.js"></script>
+<script>
+  document.getElementById('albumForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const form = e.target;
+    const tracks = Array.from(document.querySelectorAll('#songSelector input[type="checkbox"]:checked')).map(i => i.value);
+    const format = form.format.value;
+    if (tracks.length === 0) {
+      showNotification('Please select at least one track', 'error');
+      return;
+    }
+    if (format === 'ep' && tracks.length > 4) {
+      showNotification('EP releases can have at most 4 tracks', 'error');
+      return;
+    }
+    const payload = {
+      title: form.title.value.trim(),
+      format,
+      genre: form.genre.value.trim(),
+      distribution_channels: Array.from(form.distribution_channels.selectedOptions).map(o => o.value),
+      tracks
+    };
+    try {
+      const res = await fetch('/albums', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const data = await res.json();
+      if (res.ok) {
+        showNotification('Release created successfully', 'success');
+        form.reset();
+      } else {
+        showNotification(data.message || data.error || 'Failed to create release', 'error');
+      }
+    } catch (err) {
+      showNotification('Network error', 'error');
+    }
+  });
+</script>

--- a/frontend/pages/song_form.html
+++ b/frontend/pages/song_form.html
@@ -7,7 +7,7 @@
 </div>
 <form id="songForm">
   <input type="text" name="title" placeholder="Song Title" required />
-  <input type="number" name="duration_sec" placeholder="Duration (sec)" required />
+  <input type="text" name="duration_sec" placeholder="Duration (sec or mm:ss)" required />
   <input type="text" name="genre" placeholder="Genre" required />
 
   <label for="themes">Themes (choose up to 3)</label>
@@ -35,7 +35,7 @@
   </select>
   <button type="submit">Create Song</button>
 </form>
-
+<script src="../components/notification.js"></script>
 <script>
   function loadSkill() {
     fetch('/songwriting/skill')
@@ -70,5 +70,49 @@
   document.getElementById('generateDraft').addEventListener('click', function() {
     // Draft generation happens elsewhere; refresh skill progress afterwards
     loadSkill();
+  });
+
+  document.getElementById('songForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const form = e.target;
+    const durationInput = form.duration_sec.value.trim();
+    if (!/^\d+(?:[:]\d{2})?$/.test(durationInput)) {
+      showNotification('Duration must be a number of seconds or mm:ss', 'error');
+      return;
+    }
+    let duration_sec = Number(durationInput);
+    if (durationInput.includes(':')) {
+      const parts = durationInput.split(':').map(Number);
+      duration_sec = parts[0] * 60 + parts[1];
+    }
+    if (duration_sec <= 0) {
+      showNotification('Duration must be positive', 'error');
+      return;
+    }
+    const payload = {
+      title: form.title.value.trim(),
+      duration_sec,
+      genre: form.genre.value.trim(),
+      themes: Array.from(document.getElementById('themes').selectedOptions).map(o => o.value),
+      lyrics: form.lyrics.value,
+      chord_progression: form.chord_progression.value,
+      distribution_channels: Array.from(form.distribution_channels.selectedOptions).map(o => o.value)
+    };
+    try {
+      const res = await fetch('/songs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const data = await res.json();
+      if (res.ok) {
+        showNotification('Song created successfully', 'success');
+        form.reset();
+      } else {
+        showNotification(data.message || data.error || 'Failed to create song', 'error');
+      }
+    } catch (err) {
+      showNotification('Network error', 'error');
+    }
   });
 </script>


### PR DESCRIPTION
## Summary
- add reusable notification component for frontend forms
- validate song and album forms client-side and submit via fetch
- return structured error messages from album and song routes

## Testing
- `pytest tests/test_books_service.py` *(fails: ModuleNotFoundError: No module named 'backend')*
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68b814c9ecd483259325c6c66721f820