### PR TITLE
feat: add theme toggle and user settings endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,7 @@ from routes import (
     tour_planner_routes,
     university_routes,
     video_routes,
+    user_settings_routes,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -94,6 +95,7 @@ app.include_router(tour_collab_routes.router, prefix="/api", tags=["TourCollab"]
 app.include_router(tour_planner_routes.router, prefix="/api", tags=["TourPlanner"])
 app.include_router(university_routes.router, prefix="/api", tags=["University"])
 app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])
+app.include_router(user_settings_routes.router, prefix="/api", tags=["UserSettings"])
 
 
 @app.get("/metrics")

--- a/backend/routes/user_settings_routes.py
+++ b/backend/routes/user_settings_routes.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/user-settings", tags=["UserSettings"])
+
+_USER_THEME: dict[int, str] = {}
+
+
+class ThemePref(BaseModel):
+  theme: str
+
+
+@router.get("/theme/{user_id}")
+def get_theme(user_id: int) -> dict[str, str]:
+  return {"theme": _USER_THEME.get(user_id, "light")}
+
+
+@router.post("/theme/{user_id}")
+def set_theme(user_id: int, pref: ThemePref) -> dict[str, str]:
+  _USER_THEME[user_id] = pref.theme
+  return {"theme": pref.theme}

--- a/frontend/components/themeToggle.js
+++ b/frontend/components/themeToggle.js
@@ -1,0 +1,26 @@
+const THEME_KEY = 'theme';
+
+function applyTheme(theme) {
+  document.body.dataset.theme = theme;
+}
+
+function toggleTheme() {
+  const newTheme = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+  applyTheme(newTheme);
+  localStorage.setItem(THEME_KEY, newTheme);
+  // Optionally persist to server
+  fetch('/api/user-settings/theme/1', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ theme: newTheme })
+  }).catch(() => {});
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const saved = localStorage.getItem(THEME_KEY) || 'light';
+  applyTheme(saved);
+  const btn = document.getElementById('theme-toggle');
+  if (btn) {
+    btn.addEventListener('click', toggleTheme);
+  }
+});

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -1,0 +1,16 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --accent-color: #ff4081;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+[data-theme="dark"] {
+  --bg-color: #1a1a1a;
+  --text-color: #e0e0e0;
+  --accent-color: #ff79c6;
+}

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <title>RockMundo Daily</title>
+    <link rel="stylesheet" href="../index.css">
 </head>
 <body>
+    <button id="theme-toggle">Toggle Theme</button>
     <h1>Welcome to RockMundo</h1>
     <div id="notification-root"></div>
     <div id="daily-banner">
@@ -13,6 +15,7 @@
         <p id="reward">Reward: --</p>
         <button id="claim-btn">Claim Reward</button>
     </div>
+    <script src="../components/themeToggle.js"></script>
     <script src="../components/notification.js"></script>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>

--- a/frontend/pages/music_library.html
+++ b/frontend/pages/music_library.html
@@ -1,78 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Music Library</title>
+  <link rel="stylesheet" href="../index.css" />
+</head>
+<body>
+  <button id="theme-toggle">Toggle Theme</button>
+  <h2>Your Music Library</h2>
+  <div>
+    <input type="text" id="searchInput" placeholder="Search..." />
+    <select id="sortSelect">
+      <option value="title">Title</option>
+      <option value="duration">Duration</option>
+      <option value="plays">Plays</option>
+    </select>
+  </div>
+  <div id="tabs">
+    <button onclick="showTab('songs')">Songs</button>
+    <button onclick="showTab('albums')">Albums</button>
+  </div>
+  <div id="songsTab" class="tab">
+    <h3>Songs</h3>
+    <ul id="songList"></ul>
+  </div>
+  <div id="albumsTab" class="tab" style="display:none;">
+    <h3>Albums</h3>
+    <ul id="albumList"></ul>
+  </div>
+  <script>
+  function showTab(tab) {
+    document.getElementById('songsTab').style.display = tab === 'songs' ? 'block' : 'none';
+    document.getElementById('albumsTab').style.display = tab === 'albums' ? 'block' : 'none';
+  }
+  </script>
+  <script>
+  const BAND_ID = 1;
 
-<h2>Your Music Library</h2>
-<div>
-  <input type="text" id="searchInput" placeholder="Search..." />
-  <select id="sortSelect">
-    <option value="title">Title</option>
-    <option value="duration">Duration</option>
-    <option value="plays">Plays</option>
-  </select>
-</div>
-<div id="tabs">
-  <button onclick="showTab('songs')">Songs</button>
-  <button onclick="showTab('albums')">Albums</button>
-</div>
-<div id="songsTab" class="tab">
-  <h3>Songs</h3>
-  <ul id="songList"></ul>
-</div>
-<div id="albumsTab" class="tab" style="display:none;">
-  <h3>Albums</h3>
-  <ul id="albumList"></ul>
-</div>
-<script>
-function showTab(tab) {
-  document.getElementById('songsTab').style.display = tab === 'songs' ? 'block' : 'none';
-  document.getElementById('albumsTab').style.display = tab === 'albums' ? 'block' : 'none';
-}
-</script>
-<script>
-const BAND_ID = 1;
+  async function loadSongs(search = '', sort = 'title') {
+    const res = await fetch(`/songs/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
+    const data = await res.json();
+    const list = document.getElementById('songList');
+    list.innerHTML = '';
+    data.forEach(song => {
+      const li = document.createElement('li');
+      li.textContent = `${song.title} (${song.genre})`;
+      list.appendChild(li);
+    });
+    filterList();
+  }
 
-async function loadSongs(search = '', sort = 'title') {
-  const res = await fetch(`/songs/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
-  const data = await res.json();
-  const list = document.getElementById('songList');
-  list.innerHTML = '';
-  data.forEach(song => {
-    const li = document.createElement('li');
-    li.textContent = `${song.title} (${song.genre})`;
-    list.appendChild(li);
+  async function loadAlbums(search = '', sort = 'title') {
+    const res = await fetch(`/albums/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
+    const data = await res.json();
+    const list = document.getElementById('albumList');
+    list.innerHTML = '';
+    data.forEach(album => {
+      const li = document.createElement('li');
+      li.textContent = `${album.title} (${album.format})`;
+      list.appendChild(li);
+    });
+    filterList();
+  }
+
+  function filterList() {
+    const query = document.getElementById('searchInput').value.toLowerCase();
+    document.querySelectorAll('#songList li, #albumList li').forEach(li => {
+      li.style.display = li.textContent.toLowerCase().includes(query) ? '' : 'none';
+    });
+  }
+
+  function handleInput() {
+    const search = document.getElementById('searchInput').value;
+    const sort = document.getElementById('sortSelect').value;
+    loadSongs(search, sort);
+    loadAlbums(search, sort);
+    filterList();
+  }
+
+  window.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('searchInput').addEventListener('input', handleInput);
+    document.getElementById('sortSelect').addEventListener('change', handleInput);
+    handleInput();
   });
-  filterList();
-}
-
-async function loadAlbums(search = '', sort = 'title') {
-  const res = await fetch(`/albums/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
-  const data = await res.json();
-  const list = document.getElementById('albumList');
-  list.innerHTML = '';
-  data.forEach(album => {
-    const li = document.createElement('li');
-    li.textContent = `${album.title} (${album.format})`;
-    list.appendChild(li);
-  });
-  filterList();
-}
-
-function filterList() {
-  const query = document.getElementById('searchInput').value.toLowerCase();
-  document.querySelectorAll('#songList li, #albumList li').forEach(li => {
-    li.style.display = li.textContent.toLowerCase().includes(query) ? '' : 'none';
-  });
-}
-
-function handleInput() {
-  const search = document.getElementById('searchInput').value;
-  const sort = document.getElementById('sortSelect').value;
-  loadSongs(search, sort);
-  loadAlbums(search, sort);
-  filterList();
-}
-
-window.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('searchInput').addEventListener('input', handleInput);
-  document.getElementById('sortSelect').addEventListener('change', handleInput);
-  handleInput();
-});
-</script>
+  </script>
+  <script src="../components/themeToggle.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add CSS variables with dark mode override and a client-side theme toggle
- wire theme toggle into index and music library pages
- expose user-settings API to persist theme preference

## Testing
- `pytest`
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b8191e2ac4832584d8c289139313a4