### PR TITLE
feat: add frontend i18n support

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -1,0 +1,10 @@
+{
+  "language": "Language",
+  "login": {
+    "title": "Login",
+    "username": "Username",
+    "password": "Password",
+    "submit": "Login",
+    "error": "Invalid credentials"
+  }
+}

--- a/frontend/locales/es.json
+++ b/frontend/locales/es.json
@@ -1,0 +1,10 @@
+{
+  "language": "Idioma",
+  "login": {
+    "title": "Iniciar sesión",
+    "username": "Nombre de usuario",
+    "password": "Contraseña",
+    "submit": "Acceder",
+    "error": "Credenciales inválidas"
+  }
+}

--- a/frontend/pages/login.html
+++ b/frontend/pages/login.html
@@ -2,17 +2,22 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Login</title>
+  <title data-i18n="login.title">Login</title>
 </head>
 <body>
-  <h1>Login</h1>
+  <label for="locale-select" data-i18n="language">Language</label>
+  <select id="locale-select"></select>
+
+  <h1 data-i18n="login.title">Login</h1>
   <form id="login-form">
-    <input type="text" id="username" placeholder="Username" required />
-    <input type="password" id="password" placeholder="Password" required />
-    <button type="submit">Login</button>
+    <input type="text" id="username" data-i18n-placeholder="login.username" placeholder="Username" required />
+    <input type="password" id="password" data-i18n-placeholder="login.password" placeholder="Password" required />
+    <button type="submit" data-i18n="login.submit">Login</button>
   </form>
-  <p id="error" style="color:red; display:none;"></p>
-  <script>
+  <p id="error" data-i18n="login.error" style="color:red; display:none;"></p>
+  <script type="module">
+    import { initI18n, t, getLocale } from '../utils/i18n.js';
+    await initI18n();
     document.getElementById('login-form').addEventListener('submit', async (e) => {
       e.preventDefault();
       const username = document.getElementById('username').value;
@@ -20,7 +25,7 @@
       try {
         const res = await fetch('/auth/login', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Accept-Language': getLocale() },
           body: new URLSearchParams({ username, password })
         });
         if (!res.ok) throw new Error('Login failed');
@@ -30,7 +35,7 @@
       } catch (err) {
         const errEl = document.getElementById('error');
         errEl.style.display = 'block';
-        errEl.textContent = 'Invalid credentials';
+        errEl.textContent = t('login.error');
       }
     });
   </script>

--- a/frontend/utils/i18n.js
+++ b/frontend/utils/i18n.js
@@ -1,0 +1,58 @@
+let translations = {};
+let currentLocale = 'en';
+
+export function getLocale() {
+  return currentLocale;
+}
+
+export function t(key) {
+  return key.split('.').reduce((obj, k) => (obj || {})[k], translations) || key;
+}
+
+export async function initI18n() {
+  const res = await fetch('/api/locales');
+  const { default: defaultLocale, locales } = await res.json();
+  let locale = localStorage.getItem('locale');
+  if (!locale || !locales.includes(locale)) {
+    locale = defaultLocale;
+    localStorage.setItem('locale', locale);
+  }
+  currentLocale = locale;
+
+  translations = await (await fetch(`/locales/${locale}.json`)).json();
+
+  document.querySelectorAll('[data-i18n]').forEach((el) => {
+    const key = el.getAttribute('data-i18n');
+    const text = t(key);
+    if (text) el.textContent = text;
+  });
+
+  document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
+    const key = el.getAttribute('data-i18n-placeholder');
+    const text = t(key);
+    if (text) el.setAttribute('placeholder', text);
+  });
+
+  const select = document.getElementById('locale-select');
+  if (select) {
+    select.innerHTML = '';
+    locales.forEach((loc) => {
+      const opt = document.createElement('option');
+      opt.value = loc;
+      opt.textContent = loc;
+      if (loc === locale) opt.selected = true;
+      select.appendChild(opt);
+    });
+    select.onchange = async () => {
+      localStorage.setItem('locale', select.value);
+      await initI18n();
+    };
+  }
+}
+
+const originalFetch = window.fetch.bind(window);
+window.fetch = (resource, init = {}) => {
+  const headers = new Headers(init.headers || {});
+  headers.set('Accept-Language', localStorage.getItem('locale') || currentLocale);
+  return originalFetch(resource, { ...init, headers });
+};


### PR DESCRIPTION
## Summary
- add English and Spanish translation files
- load selected locale and patch fetch requests with Accept-Language header
- translate login page and add locale selector

## Testing
- `pytest` *(fails: email-validator, passlib, boto3 missing)*
- `npm test --prefix frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81a14820c8325b2fe076c20cf9313