### PR TITLE
Add playlist management with API and frontend pages

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from routes import (
     locale_routes,
     music_metrics_routes,
     onboarding_routes,
+    playlist_routes,
     setlist_routes,
     social_routes,
     song_forecast_routes,
@@ -26,8 +27,8 @@ from routes import (
     tour_collab_routes,
     tour_planner_routes,
     university_routes,
-    video_routes,
     user_settings_routes,
+    video_routes,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -96,6 +97,7 @@ app.include_router(tour_planner_routes.router, prefix="/api", tags=["TourPlanner
 app.include_router(university_routes.router, prefix="/api", tags=["University"])
 app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])
 app.include_router(user_settings_routes.router, prefix="/api", tags=["UserSettings"])
+app.include_router(playlist_routes.router, prefix="/api", tags=["Playlists"])
 
 
 @app.get("/metrics")

--- a/backend/models/playlist.py
+++ b/backend/models/playlist.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Playlist:
+    """Simple playlist model keeping track of songs."""
+
+    id: int
+    name: str
+    song_ids: List[int] = field(default_factory=list)
+    is_public: bool = False
+
+    def add_song(self, song_id: int) -> None:
+        """Add a song to the playlist if not already present."""
+        if song_id not in self.song_ids:
+            self.song_ids.append(song_id)
+
+    def remove_song(self, song_id: int) -> None:
+        """Remove a song from the playlist if it exists."""
+        if song_id in self.song_ids:
+            self.song_ids.remove(song_id)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "song_ids": self.song_ids,
+            "is_public": self.is_public,
+        }

--- a/backend/routes/playlist_routes.py
+++ b/backend/routes/playlist_routes.py
@@ -1,0 +1,102 @@
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.models.playlist import Playlist
+
+router = APIRouter()
+
+# In-memory storage for playlists
+playlists: Dict[int, Playlist] = {}
+_next_id = 1
+
+
+class PlaylistCreate(BaseModel):
+    name: str
+    is_public: bool = False
+
+
+class PlaylistUpdate(BaseModel):
+    name: Optional[str] = None
+    is_public: Optional[bool] = None
+
+
+class PlaylistOut(BaseModel):
+    id: int
+    name: str
+    song_ids: List[int]
+    is_public: bool = False
+
+
+class SongIn(BaseModel):
+    song_id: int
+
+
+@router.post("/playlists", response_model=PlaylistOut)
+def create_playlist(payload: PlaylistCreate) -> PlaylistOut:
+    global _next_id
+    pl = Playlist(id=_next_id, name=payload.name, is_public=payload.is_public)
+    playlists[_next_id] = pl
+    _next_id += 1
+    return PlaylistOut(**pl.to_dict())
+
+
+@router.get("/playlists", response_model=List[PlaylistOut])
+def list_playlists() -> List[PlaylistOut]:
+    return [PlaylistOut(**p.to_dict()) for p in playlists.values()]
+
+
+@router.get("/playlists/{playlist_id}", response_model=PlaylistOut)
+def get_playlist(playlist_id: int) -> PlaylistOut:
+    pl = playlists.get(playlist_id)
+    if not pl:
+        raise HTTPException(status_code=404, detail="Playlist not found")
+    return PlaylistOut(**pl.to_dict())
+
+
+@router.put("/playlists/{playlist_id}", status_code=204)
+def update_playlist(playlist_id: int, payload: PlaylistUpdate) -> None:
+    pl = playlists.get(playlist_id)
+    if not pl:
+        raise HTTPException(status_code=404, detail="Playlist not found")
+    if payload.name is not None:
+        pl.name = payload.name
+    if payload.is_public is not None:
+        pl.is_public = payload.is_public
+
+
+@router.delete("/playlists/{playlist_id}", status_code=204)
+def delete_playlist(playlist_id: int) -> None:
+    if playlist_id not in playlists:
+        raise HTTPException(status_code=404, detail="Playlist not found")
+    del playlists[playlist_id]
+
+
+@router.post("/playlists/{playlist_id}/songs", status_code=204)
+def add_song_to_playlist(playlist_id: int, song: SongIn) -> None:
+    pl = playlists.get(playlist_id)
+    if not pl:
+        raise HTTPException(status_code=404, detail="Playlist not found")
+    pl.add_song(song.song_id)
+
+
+@router.delete("/playlists/{playlist_id}/songs/{song_id}", status_code=204)
+def remove_song_from_playlist(playlist_id: int, song_id: int) -> None:
+    pl = playlists.get(playlist_id)
+    if not pl:
+        raise HTTPException(status_code=404, detail="Playlist not found")
+    pl.remove_song(song_id)
+
+
+@router.get("/playlists/public", response_model=List[PlaylistOut])
+def list_public_playlists() -> List[PlaylistOut]:
+    return [PlaylistOut(**p.to_dict()) for p in playlists.values() if p.is_public]
+
+
+@router.get("/playlists/public/{playlist_id}", response_model=PlaylistOut)
+def get_public_playlist(playlist_id: int) -> PlaylistOut:
+    pl = playlists.get(playlist_id)
+    if not pl or not pl.is_public:
+        raise HTTPException(status_code=404, detail="Playlist not found")
+    return PlaylistOut(**pl.to_dict())

--- a/frontend/pages/music_library.html
+++ b/frontend/pages/music_library.html
@@ -15,6 +15,7 @@
       <option value="duration">Duration</option>
       <option value="plays">Plays</option>
     </select>
+    <select id="playlistSelect"></select>
   </div>
   <div id="tabs">
     <button onclick="showTab('songs')">Songs</button>
@@ -36,6 +37,19 @@
   </script>
   <script>
   const BAND_ID = 1;
+  const playlistSelect = document.getElementById('playlistSelect');
+
+  async function loadPlaylists() {
+    const res = await fetch('/playlists');
+    const data = await res.json();
+    playlistSelect.innerHTML = '';
+    data.forEach(p => {
+      const opt = document.createElement('option');
+      opt.value = p.id;
+      opt.textContent = p.name;
+      playlistSelect.appendChild(opt);
+    });
+  }
 
   async function loadSongs(search = '', sort = 'title') {
     const res = await fetch(`/songs/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
@@ -45,6 +59,14 @@
     data.forEach(song => {
       const li = document.createElement('li');
       li.textContent = `${song.title} (${song.genre})`;
+      const addBtn = document.createElement('button');
+      addBtn.textContent = 'Add';
+      addBtn.onclick = () => addToPlaylist(song.id);
+      const remBtn = document.createElement('button');
+      remBtn.textContent = 'Remove';
+      remBtn.onclick = () => removeFromPlaylist(song.id);
+      li.appendChild(addBtn);
+      li.appendChild(remBtn);
       list.appendChild(li);
     });
     filterList();
@@ -78,9 +100,26 @@
     filterList();
   }
 
+  async function addToPlaylist(songId) {
+    const pid = playlistSelect.value;
+    if (!pid) return;
+    await fetch(`/playlists/${pid}/songs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ song_id: songId })
+    });
+  }
+
+  async function removeFromPlaylist(songId) {
+    const pid = playlistSelect.value;
+    if (!pid) return;
+    await fetch(`/playlists/${pid}/songs/${songId}`, { method: 'DELETE' });
+  }
+
   window.addEventListener('DOMContentLoaded', () => {
     document.getElementById('searchInput').addEventListener('input', handleInput);
     document.getElementById('sortSelect').addEventListener('change', handleInput);
+    loadPlaylists();
     handleInput();
   });
   </script>

--- a/frontend/pages/playlist_manager.html
+++ b/frontend/pages/playlist_manager.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Playlist Manager</title>
+  <link rel="stylesheet" href="../index.css" />
+</head>
+<body>
+  <h2>Playlist Manager</h2>
+  <form id="newPlaylistForm">
+    <input type="text" id="playlistName" placeholder="Playlist name" required />
+    <label><input type="checkbox" id="isPublic" /> Public</label>
+    <button type="submit">Create Playlist</button>
+  </form>
+  <ul id="playlistList"></ul>
+
+  <script>
+  async function loadPlaylists() {
+    const res = await fetch('/playlists');
+    const data = await res.json();
+    const list = document.getElementById('playlistList');
+    list.innerHTML = '';
+    data.forEach(p => {
+      const li = document.createElement('li');
+      li.innerHTML = `<strong>${p.name}</strong> ${p.is_public ? '(Public)' : ''}`;
+
+      const songUl = document.createElement('ul');
+      p.song_ids.forEach(id => {
+        const sLi = document.createElement('li');
+        sLi.textContent = `Song ${id}`;
+        const remBtn = document.createElement('button');
+        remBtn.textContent = 'Remove';
+        remBtn.onclick = () => removeSong(p.id, id);
+        sLi.appendChild(remBtn);
+        songUl.appendChild(sLi);
+      });
+      li.appendChild(songUl);
+
+      const addInput = document.createElement('input');
+      addInput.placeholder = 'Song ID';
+      const addBtn = document.createElement('button');
+      addBtn.textContent = 'Add Song';
+      addBtn.onclick = () => { addSong(p.id, addInput.value); };
+      li.appendChild(addInput);
+      li.appendChild(addBtn);
+
+      const delBtn = document.createElement('button');
+      delBtn.textContent = 'Delete Playlist';
+      delBtn.onclick = () => deletePlaylist(p.id);
+      li.appendChild(delBtn);
+
+      list.appendChild(li);
+    });
+  }
+
+  document.getElementById('newPlaylistForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const name = document.getElementById('playlistName').value;
+    const is_public = document.getElementById('isPublic').checked;
+    await fetch('/playlists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, is_public })
+    });
+    e.target.reset();
+    loadPlaylists();
+  });
+
+  async function addSong(playlistId, songId) {
+    if (!songId) return;
+    await fetch(`/playlists/${playlistId}/songs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ song_id: parseInt(songId) })
+    });
+    loadPlaylists();
+  }
+
+  async function removeSong(playlistId, songId) {
+    await fetch(`/playlists/${playlistId}/songs/${songId}`, { method: 'DELETE' });
+    loadPlaylists();
+  }
+
+  async function deletePlaylist(id) {
+    await fetch(`/playlists/${id}`, { method: 'DELETE' });
+    loadPlaylists();
+  }
+
+  window.addEventListener('DOMContentLoaded', loadPlaylists);
+  </script>
+  <script src="../components/themeToggle.js"></script>
+</body>
+</html>

--- a/frontend/pages/playlist_view.html
+++ b/frontend/pages/playlist_view.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>View Playlist</title>
+  <link rel="stylesheet" href="../index.css" />
+</head>
+<body>
+  <h2 id="playlistName">Playlist</h2>
+  <ul id="songList"></ul>
+  <script>
+  async function load() {
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    if (!id) return;
+    const res = await fetch(`/playlists/public/${id}`);
+    if (res.status !== 200) {
+      document.getElementById('playlistName').textContent = 'Playlist unavailable';
+      return;
+    }
+    const pl = await res.json();
+    document.getElementById('playlistName').textContent = pl.name;
+    const list = document.getElementById('songList');
+    list.innerHTML = '';
+    pl.song_ids.forEach(sid => {
+      const li = document.createElement('li');
+      li.textContent = `Song ${sid}`;
+      list.appendChild(li);
+    });
+  }
+  window.addEventListener('DOMContentLoaded', load);
+  </script>
+  <script src="../components/themeToggle.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `Playlist` model and FastAPI routes for CRUD and song management
- wire playlists into API app and expose public playlists
- create playlist manager and view pages; integrate playlist controls in music library

## Testing
- `ruff check backend/models/playlist.py backend/routes/playlist_routes.py backend/main.py`
- `pytest` *(fails: NoReferencedTableError, missing tables)*

------
https://chatgpt.com/codex/tasks/task_e_68b81b36e62483259095524dd9129a09