### PR TITLE
Add persistent user profiles and navigation

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -373,4 +373,14 @@ def init_db():
         )
         """)
 
+        # User settings table for profile preferences
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS user_settings (
+            user_id INTEGER PRIMARY KEY,
+            theme TEXT DEFAULT 'light',
+            bio TEXT,
+            links TEXT
+        )
+        """)
+
         conn.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from middleware.rate_limit import RateLimitMiddleware
 from routes import (
     admin_routes,
     apprenticeship_routes,
+    avatar,
     daily_loop_routes,
     event_routes,
     legacy_routes,
@@ -97,6 +98,7 @@ app.include_router(tour_planner_routes.router, prefix="/api", tags=["TourPlanner
 app.include_router(university_routes.router, prefix="/api", tags=["University"])
 app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])
 app.include_router(user_settings_routes.router, prefix="/api", tags=["UserSettings"])
+app.include_router(avatar.router, prefix="/api", tags=["Avatars"])
 app.include_router(playlist_routes.router, prefix="/api", tags=["Playlists"])
 
 

--- a/backend/models/user_settings.py
+++ b/backend/models/user_settings.py
@@ -1,0 +1,49 @@
+import json
+import sqlite3
+from typing import Dict, List
+
+from backend.database import DB_PATH
+
+def _ensure_row(cur: sqlite3.Cursor, user_id: int) -> None:
+    cur.execute(
+        """
+        INSERT OR IGNORE INTO user_settings (user_id, theme, bio, links)
+        VALUES (?, 'light', '', '[]')
+        """,
+        (user_id,)
+    )
+
+
+def get_settings(user_id: int) -> Dict:
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    _ensure_row(cur, user_id)
+    cur.execute(
+        "SELECT theme, bio, links FROM user_settings WHERE user_id = ?",
+        (user_id,)
+    )
+    theme, bio, links = cur.fetchone()
+    conn.close()
+    return {
+        "theme": theme,
+        "bio": bio or "",
+        "links": json.loads(links or "[]"),
+    }
+
+
+def set_settings(user_id: int, theme: str, bio: str, links: List[str]) -> None:
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO user_settings (user_id, theme, bio, links)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(user_id) DO UPDATE SET
+            theme = excluded.theme,
+            bio = excluded.bio,
+            links = excluded.links
+        """,
+        (user_id, theme, bio, json.dumps(links)),
+    )
+    conn.commit()
+    conn.close()

--- a/frontend/components/header.js
+++ b/frontend/components/header.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const header = document.createElement('header');
+  const nav = document.createElement('nav');
+
+  const home = document.createElement('a');
+  home.href = 'index.html';
+  home.textContent = 'Home';
+  nav.appendChild(home);
+
+  const profile = document.createElement('a');
+  profile.href = 'profile.html';
+  profile.textContent = 'Profile';
+  nav.appendChild(profile);
+
+  header.appendChild(nav);
+  document.body.prepend(header);
+});

--- a/frontend/components/profile.js
+++ b/frontend/components/profile.js
@@ -1,0 +1,41 @@
+const USER_ID = 1;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const form = document.getElementById('profile-form');
+  const bioInput = document.getElementById('bio');
+  const linksInput = document.getElementById('links');
+  const avatarInput = document.getElementById('avatar-input');
+
+  try {
+    const res = await fetch(`/api/user-settings/profile/${USER_ID}`);
+    if (res.ok) {
+      const data = await res.json();
+      bioInput.value = data.bio || '';
+      linksInput.value = (data.links || []).join(', ');
+    }
+  } catch (e) {
+    // ignore load errors
+  }
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const bio = bioInput.value;
+    const links = linksInput.value
+      .split(',')
+      .map((l) => l.trim())
+      .filter((l) => l);
+
+    await fetch(`/api/user-settings/profile/${USER_ID}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ bio, links }),
+    });
+
+    const file = avatarInput.files[0];
+    if (file) {
+      const fd = new FormData();
+      fd.append('file', file);
+      await fetch('/api/avatars', { method: 'POST', body: fd });
+    }
+  });
+});

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -16,6 +16,7 @@
         <button id="claim-btn">Claim Reward</button>
     </div>
     <script src="../components/themeToggle.js"></script>
+    <script src="../components/header.js"></script>
     <script src="../components/notification.js"></script>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Profile</title>
+  <link rel="stylesheet" href="../index.css" />
+</head>
+<body>
+  <header id="main-header"></header>
+  <h1>Profile</h1>
+  <form id="profile-form">
+    <div>
+      <label for="avatar-input">Avatar</label>
+      <input type="file" id="avatar-input" accept="image/*" />
+    </div>
+    <div>
+      <label for="bio">Bio</label>
+      <textarea id="bio"></textarea>
+    </div>
+    <div>
+      <label for="links">Social Links (comma separated)</label>
+      <input type="text" id="links" />
+    </div>
+    <button type="submit">Save</button>
+  </form>
+  <script src="../components/themeToggle.js"></script>
+  <script src="../components/header.js"></script>
+  <script type="module" src="../components/profile.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add database-backed user settings for theme, bio and links
- build profile page with avatar upload and settings save logic
- include avatar API and common header navigation to profile page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'email_validator')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81e0d03c883259a017c6e559c1eeb