### PR TITLE
feat: add audio player singleton

### DIFF
--- a/frontend/components/audioPlayer.js
+++ b/frontend/components/audioPlayer.js
@@ -1,0 +1,16 @@
+const getAudioPlayer = (() => {
+  let player;
+  return () => {
+    if (!player) {
+      player = document.getElementById('audio-player');
+      if (!player) {
+        player = document.createElement('audio');
+        player.id = 'audio-player';
+        document.body.appendChild(player);
+      }
+    }
+    return player;
+  };
+})();
+
+export default getAudioPlayer;

--- a/frontend/tests/audioPlayer.test.ts
+++ b/frontend/tests/audioPlayer.test.ts
@@ -1,0 +1,23 @@
+import getAudioPlayer from '../components/audioPlayer.js';
+
+describe('audioPlayer singleton', () => {
+  test('reuses existing #audio-player element', () => {
+    const existing = document.createElement('audio');
+    existing.id = 'audio-player';
+    document.body.appendChild(existing);
+
+    const player1 = getAudioPlayer();
+    expect(player1).toBe(existing);
+    const player2 = getAudioPlayer();
+    expect(player2).toBe(existing);
+  });
+
+  test('creates element when missing', () => {
+    const found = document.getElementById('audio-player');
+    if (found) found.remove();
+
+    const player = getAudioPlayer();
+    expect(player.id).toBe('audio-player');
+    expect(document.getElementById('audio-player')).toBe(player);
+  });
+});


### PR DESCRIPTION
## Summary
- create reusable audio player element with singleton factory
- test audio player creation and reuse behavior

## Testing
- `npm test` (fails: vitest not found)
- `npm install --registry=https://registry.npmjs.org` (fails: 403 Forbidden)
- `pytest backend/tests/auth/test_admin_mfa.py` (fails: email-validator missing)


------
https://chatgpt.com/codex/tasks/task_e_68b8276a18e083258cf3d69698c57e0f