### PR TITLE
Add global search UI with backend fuzzy search

### DIFF
--- a/backend/routes/album_routes.py
+++ b/backend/routes/album_routes.py
@@ -12,6 +12,14 @@ def create_release():
     except ValueError as e:
         return jsonify({'status': 'error', 'message': str(e)}), 400
 
+
+@album_routes.route('/albums', methods=['GET'])
+def search_releases():
+    query = request.args.get('search', '')
+    page = int(request.args.get('page', 1))
+    limit = int(request.args.get('limit', 10))
+    return jsonify(album_service.search_releases(query, page, limit))
+
 @album_routes.route('/albums/band/<int:band_id>', methods=['GET'])
 def get_band_releases(band_id):
     search = request.args.get('search')

--- a/backend/routes/band.py
+++ b/backend/routes/band.py
@@ -57,3 +57,8 @@ def create_collaboration(collab: BandCollaborationCreate):
 @router.get("/{band_id}/collaborations", response_model=list[BandCollaborationResponse])
 def list_collaborations(band_id: int):
     return band_service.list_collaborations(band_id)
+
+
+@router.get("/", response_model=list[BandResponse])
+def search_bands(search: str = "", page: int = 1, limit: int = 10):
+    return band_service.search_bands(search, page, limit)

--- a/backend/routes/song_routes.py
+++ b/backend/routes/song_routes.py
@@ -13,6 +13,14 @@ def create_song():
     except Exception as e:
         return jsonify({'status': 'error', 'message': str(e)}), 400
 
+
+@song_routes.route('/songs', methods=['GET'])
+def search_songs():
+    query = request.args.get('search', '')
+    page = int(request.args.get('page', 1))
+    limit = int(request.args.get('limit', 10))
+    return jsonify(song_service.search_songs(query, page, limit))
+
 @song_routes.route('/songs/band/<int:band_id>', methods=['GET'])
 def get_band_songs(band_id):
     search = request.args.get('search')

--- a/backend/services/album_service.py
+++ b/backend/services/album_service.py
@@ -143,6 +143,23 @@ class AlbumService:
                 )
             return result
 
+    def search_releases(self, query: str, page: int = 1, limit: int = 10) -> list[dict]:
+        """Search albums by title with basic fuzzy matching and pagination."""
+        with self.session_factory() as session:
+            q = (
+                session.query(Release)
+                .filter(Release.title.ilike(f"%{query}%"))
+                .order_by(Release.title.asc())
+            )
+            releases = q.offset((page - 1) * limit).limit(limit).all()
+            return [
+                {
+                    "release_id": r.id,
+                    "title": r.title,
+                }
+                for r in releases
+            ]
+
     # ------------------------------------------------------------------
     def update_release(self, release_id: int, updates: dict) -> dict:
         """Update fields on a release."""

--- a/backend/services/band_service.py
+++ b/backend/services/band_service.py
@@ -199,6 +199,26 @@ class BandService:
                 .all()
             )
 
+    def search_bands(self, query: str, page: int = 1, limit: int = 10) -> list[dict]:
+        """Search bands by name with basic fuzzy matching and pagination."""
+        with self.session_factory() as session:
+            q = (
+                session.query(Band)
+                .filter(Band.name.ilike(f"%{query}%"))
+                .order_by(Band.name.asc())
+            )
+            bands = q.offset((page - 1) * limit).limit(limit).all()
+            return [
+                {
+                    "id": b.id,
+                    "name": b.name,
+                    "founder_id": b.founder_id,
+                    "genre": b.genre,
+                    "formed_at": b.formed_at,
+                }
+                for b in bands
+            ]
+
     # ------------------------------------------------------------------
     def get_band_collaborations(self, band_id: int) -> list[dict]:
         """Compatibility wrapper returning collaborations as dictionaries."""

--- a/backend/services/song_service.py
+++ b/backend/services/song_service.py
@@ -123,6 +123,25 @@ class SongService:
             for row in rows
         ]
 
+    def search_songs(self, query: str, page: int = 1, limit: int = 10) -> List[Dict]:
+        """Search songs by title with basic fuzzy matching and pagination."""
+        conn = sqlite3.connect(self.db)
+        cur = conn.cursor()
+        like = f"%{query}%"
+        offset = (page - 1) * limit
+        cur.execute(
+            """
+            SELECT id, title FROM songs
+            WHERE LOWER(title) LIKE LOWER(?)
+            ORDER BY title ASC
+            LIMIT ? OFFSET ?
+            """,
+            (like, limit, offset),
+        )
+        rows = cur.fetchall()
+        conn.close()
+        return [dict(zip(["song_id", "title"], row)) for row in rows]
+
     def list_covers_of_song(self, song_id: int) -> List[Dict]:
         """Return cover versions referencing ``song_id`` as original."""
         conn = sqlite3.connect(self.db)

--- a/frontend/components/globalSearch.js
+++ b/frontend/components/globalSearch.js
@@ -1,0 +1,110 @@
+(function(){
+  function highlight(text, query){
+    if(!query) return text;
+    const regex = new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'ig');
+    return text.replace(regex, '<mark>$1</mark>');
+  }
+
+  function initGlobalSearch(container){
+    if(!container) return;
+    if(!document.getElementById('global-search-styles')){
+      const style=document.createElement('style');
+      style.id='global-search-styles';
+      style.textContent=`
+        .global-search-wrapper{position:relative;margin-left:1rem;}
+        .global-search-results{position:absolute;top:100%;left:0;right:0;background:#fff;border:1px solid #ccc;z-index:1000;font-size:14px;max-height:300px;overflow-y:auto;}
+        .global-search-results ul{list-style:none;margin:0;padding:0;}
+        .global-search-results li{padding:4px 8px;}
+        .global-search-results li.active{background:#eee;}
+        .global-search-results .group-title{font-weight:bold;padding:4px 8px;border-top:1px solid #ddd;background:#f9f9f9;}
+        .global-search-results .group-title:first-child{border-top:none;}
+      `;
+      document.head.appendChild(style);
+    }
+
+    const wrapper=document.createElement('div');
+    wrapper.className='global-search-wrapper';
+    const input=document.createElement('input');
+    input.type='search';
+    input.placeholder='Search songs, albums, bands';
+    const results=document.createElement('div');
+    results.className='global-search-results';
+    results.hidden=true;
+    wrapper.appendChild(input);
+    wrapper.appendChild(results);
+    container.appendChild(wrapper);
+
+    let items=[]; // flat list for keyboard navigation
+    let activeIndex=-1;
+
+    async function fetchResults(q){
+      const [songs, albums, bands] = await Promise.all([
+        fetch(`/songs?search=${encodeURIComponent(q)}&limit=5`).then(r=>r.json()).catch(()=>[]),
+        fetch(`/albums?search=${encodeURIComponent(q)}&limit=5`).then(r=>r.json()).catch(()=>[]),
+        fetch(`/bands?search=${encodeURIComponent(q)}&limit=5`).then(r=>r.json()).catch(()=>[])
+      ]);
+      results.innerHTML='';
+      items=[];
+      function renderGroup(title, data, type){
+        if(!data || !data.length) return;
+        const groupTitle=document.createElement('div');
+        groupTitle.className='group-title';
+        groupTitle.textContent=title;
+        results.appendChild(groupTitle);
+        const list=document.createElement('ul');
+        list.setAttribute('role','listbox');
+        data.forEach(d=>{
+          const li=document.createElement('li');
+          li.setAttribute('role','option');
+          const text = d.title || d.name;
+          li.innerHTML=`<a href="/${type}/${d.id || d.song_id || d.release_id}">${highlight(text,q)}</a>`;
+          list.appendChild(li);
+          items.push(li);
+        });
+        results.appendChild(list);
+      }
+      renderGroup('Songs', songs, 'songs');
+      renderGroup('Albums', albums, 'albums');
+      renderGroup('Bands', bands, 'bands');
+      results.hidden=!items.length;
+      activeIndex=-1;
+    }
+
+    input.addEventListener('input', e=>{
+      const q=e.target.value.trim();
+      if(!q){results.hidden=true;results.innerHTML='';return;}
+      fetchResults(q);
+    });
+
+    input.addEventListener('keydown', e=>{
+      if(e.key==='ArrowDown'){
+        if(activeIndex<items.length-1){activeIndex++;updateActive();}
+        e.preventDefault();
+      } else if(e.key==='ArrowUp'){
+        if(activeIndex>0){activeIndex--;updateActive();}
+        e.preventDefault();
+      } else if(e.key==='Enter'){
+        if(activeIndex>=0){
+          const link=items[activeIndex].querySelector('a');
+          if(link){ window.location.href=link.getAttribute('href'); }
+        }
+      } else if(e.key==='Escape'){
+        results.hidden=true;
+      }
+    });
+
+    document.addEventListener('click', (e)=>{
+      if(!wrapper.contains(e.target)){
+        results.hidden=true;
+      }
+    });
+
+    function updateActive(){
+      items.forEach((item,i)=>{
+        if(i===activeIndex){item.classList.add('active'); item.scrollIntoView({block:'nearest'});} else {item.classList.remove('active');}
+      });
+    }
+  }
+
+  window.initGlobalSearch=initGlobalSearch;
+})();

--- a/frontend/components/header.js
+++ b/frontend/components/header.js
@@ -14,4 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   header.appendChild(nav);
   document.body.prepend(header);
+
+  if (window.initGlobalSearch) {
+    window.initGlobalSearch(nav);
+  }
 });

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -16,6 +16,7 @@
         <button id="claim-btn">Claim Reward</button>
     </div>
     <script src="../components/themeToggle.js"></script>
+    <script src="../components/globalSearch.js"></script>
     <script src="../components/header.js"></script>
     <script src="../components/notification.js"></script>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>


### PR DESCRIPTION
## Summary
- Add global search component with grouped results and keyboard navigation
- Support fuzzy search & pagination for songs, albums, and bands endpoints
- Hook global search into shared header

## Testing
- `pytest` *(fails: missing tables during collection)*
- `pytest backend/tests/bands/test_band_service.py -q`
- `npm test --prefix frontend` *(fails: vitest not found; npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b8288602b48325b3612e19b9155f44