### PR TITLE
Refactor audio player to reuse existing element

### DIFF
--- a/frontend/components/audioPlayer.js
+++ b/frontend/components/audioPlayer.js
@@ -1,16 +1,28 @@
-const getAudioPlayer = (() => {
-  let player;
-  return () => {
-    if (!player) {
-      player = document.getElementById('audio-player');
-      if (!player) {
-        player = document.createElement('audio');
-        player.id = 'audio-player';
-        document.body.appendChild(player);
-      }
-    }
-    return player;
-  };
-})();
+let instance;
+
+/**
+ * Retrieve a shared `<audio>` element.
+ *
+ * The function looks for an existing element with the id `audio-player`.
+ * If found, that element is reused; otherwise a new element is created and
+ * appended to the document body. Subsequent calls return the same element.
+ */
+const getAudioPlayer = () => {
+  // Reuse the memoized instance if it still exists in the DOM
+  if (instance && document.body.contains(instance)) {
+    return instance;
+  }
+
+  // Attempt to find an existing element in the DOM
+  instance = document.getElementById('audio-player');
+  if (!instance) {
+    instance = document.createElement('audio');
+    instance.id = 'audio-player';
+    document.body.appendChild(instance);
+  }
+
+  return instance;
+};
 
 export default getAudioPlayer;
+


### PR DESCRIPTION
## Summary
- Ensure `getAudioPlayer` looks for an existing `#audio-player` element before creating one
- Memoize and reuse a single audio element instance to avoid global redefinition

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a941b9788325a1341109b22a76ac