### PR TITLE
Add schedule activity models and service

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -383,4 +383,27 @@ def init_db():
         )
         """)
 
+        # Activities table for user tasks
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS activities (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            duration_hours INTEGER NOT NULL,
+            category TEXT
+        )
+        """)
+
+        # Daily schedule entries linking users to activities
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS daily_schedule (
+            user_id INTEGER NOT NULL,
+            date TEXT NOT NULL,
+            hour INTEGER NOT NULL,
+            activity_id INTEGER NOT NULL,
+            PRIMARY KEY (user_id, date, hour),
+            FOREIGN KEY(user_id) REFERENCES users(id),
+            FOREIGN KEY(activity_id) REFERENCES activities(id)
+        )
+        """)
+
         conn.commit()

--- a/backend/models/activity.py
+++ b/backend/models/activity.py
@@ -1,0 +1,73 @@
+import sqlite3
+from typing import List, Optional, Dict
+
+from backend.database import DB_PATH
+
+
+def create_activity(name: str, duration_hours: int, category: str) -> int:
+    """Insert a new activity and return its id."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO activities (name, duration_hours, category) VALUES (?, ?, ?)",
+            (name, duration_hours, category),
+        )
+        conn.commit()
+        return cur.lastrowid
+
+
+def get_activity(activity_id: int) -> Optional[Dict]:
+    """Retrieve an activity by id."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT id, name, duration_hours, category FROM activities WHERE id = ?",
+            (activity_id,),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    return {
+        "id": row[0],
+        "name": row[1],
+        "duration_hours": row[2],
+        "category": row[3],
+    }
+
+
+def list_activities() -> List[Dict]:
+    """Return all activities."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT id, name, duration_hours, category FROM activities")
+        rows = cur.fetchall()
+    return [
+        {"id": r[0], "name": r[1], "duration_hours": r[2], "category": r[3]}
+        for r in rows
+    ]
+
+
+def update_activity(activity_id: int, name: str, duration_hours: int, category: str) -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE activities SET name = ?, duration_hours = ?, category = ? WHERE id = ?",
+            (name, duration_hours, category, activity_id),
+        )
+        conn.commit()
+
+
+def delete_activity(activity_id: int) -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("DELETE FROM activities WHERE id = ?", (activity_id,))
+        conn.commit()
+
+
+__all__ = [
+    "create_activity",
+    "get_activity",
+    "list_activities",
+    "update_activity",
+    "delete_activity",
+]

--- a/backend/services/schedule_service.py
+++ b/backend/services/schedule_service.py
@@ -1,0 +1,45 @@
+from typing import List, Dict
+
+from backend.models import activity as activity_model
+from backend.models import daily_schedule as schedule_model
+
+
+class ScheduleService:
+    """Service layer wrapping activity and daily schedule operations."""
+
+    # Activity CRUD -----------------------------------------------------
+    def create_activity(self, name: str, duration_hours: int, category: str) -> int:
+        return activity_model.create_activity(name, duration_hours, category)
+
+    def get_activity(self, activity_id: int) -> Dict | None:
+        return activity_model.get_activity(activity_id)
+
+    def update_activity(
+        self, activity_id: int, name: str, duration_hours: int, category: str
+    ) -> None:
+        activity_model.update_activity(activity_id, name, duration_hours, category)
+
+    def delete_activity(self, activity_id: int) -> None:
+        activity_model.delete_activity(activity_id)
+
+    # Schedule logic ----------------------------------------------------
+    def schedule_activity(
+        self, user_id: int, date: str, hour: int, activity_id: int
+    ) -> None:
+        schedule_model.add_entry(user_id, date, hour, activity_id)
+
+    def update_schedule_entry(
+        self, user_id: int, date: str, hour: int, activity_id: int
+    ) -> None:
+        schedule_model.update_entry(user_id, date, hour, activity_id)
+
+    def remove_schedule_entry(self, user_id: int, date: str, hour: int) -> None:
+        schedule_model.remove_entry(user_id, date, hour)
+
+    def get_daily_schedule(self, user_id: int, date: str) -> List[Dict]:
+        return schedule_model.get_schedule(user_id, date)
+
+
+schedule_service = ScheduleService()
+
+__all__ = ["ScheduleService", "schedule_service"]

--- a/backend/tests/schedule/test_schedule_crud.py
+++ b/backend/tests/schedule/test_schedule_crud.py
@@ -1,0 +1,52 @@
+import importlib
+from pathlib import Path
+
+
+def setup_db(tmp_path):
+    db_file = tmp_path / "schedule.db"
+    from backend import database
+
+    database.DB_PATH = db_file
+    database.init_db()
+
+    # reload models to pick up patched DB_PATH
+    from backend.models import activity as activity_model
+    from backend.models import daily_schedule as schedule_model
+    activity_model.DB_PATH = db_file
+    schedule_model.DB_PATH = db_file
+    import backend.services.schedule_service as service_module
+    importlib.reload(service_module)
+    return service_module.schedule_service
+
+
+def test_create_and_retrieve_schedule(tmp_path):
+    svc = setup_db(tmp_path)
+
+    act_id = svc.create_activity("Practice", 2, "music")
+    svc.schedule_activity(1, "2024-01-01", 9, act_id)
+
+    schedule = svc.get_daily_schedule(1, "2024-01-01")
+    assert schedule == [
+        {
+            "hour": 9,
+            "activity": {
+                "id": act_id,
+                "name": "Practice",
+                "duration_hours": 2,
+                "category": "music",
+            },
+        }
+    ]
+
+
+def test_update_schedule_entry(tmp_path):
+    svc = setup_db(tmp_path)
+
+    act1 = svc.create_activity("Practice", 2, "music")
+    act2 = svc.create_activity("Workout", 1, "fitness")
+
+    svc.schedule_activity(1, "2024-01-01", 9, act1)
+    svc.update_schedule_entry(1, "2024-01-01", 9, act2)
+
+    schedule = svc.get_daily_schedule(1, "2024-01-01")
+    assert schedule[0]["activity"]["id"] == act2


### PR DESCRIPTION
## Summary
- add activities and daily_schedule tables
- implement CRUD models and schedule service
- test schedule creation and updating

## Testing
- `pytest backend/tests/schedule/test_schedule_crud.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8af6e9d4c8325b0c5898f7e1ed8ed