### PR TITLE
Add rest validation for daily schedules

### DIFF
--- a/backend/services/lifestyle_scheduler.py
+++ b/backend/services/lifestyle_scheduler.py
@@ -8,9 +8,8 @@ from .xp_event_service import XPEventService
 
 DB_PATH = Path(__file__).resolve().parent.parent / "rockmundo.db"
 
-# Daily decay values
+# Daily decay values (sleep is derived from schedule and not decayed)
 DECAY = {
-    "sleep_hours": 0.2,
     "mental_health": 1.0,
     "stress": 1.5,
     "training_discipline": 0.5,
@@ -41,19 +40,54 @@ def apply_lifestyle_decay_and_xp_effects():
         cur.execute("SELECT * FROM lifestyle")
         rows = cur.fetchall()
 
+        today = datetime.utcnow().date().isoformat()
+        # Ensure schedule table exists for lookups
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schedule (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                day TEXT NOT NULL,
+                tag TEXT NOT NULL,
+                hours REAL NOT NULL
+            )
+            """
+        )
+
         for row in rows:
             user_id = row[1]
-            sleep = max(0, row[2] - DECAY["sleep_hours"])
+
+            # Sum hours tagged as rest or sleep for today
+            cur.execute(
+                """
+                SELECT COALESCE(SUM(hours), 0)
+                FROM schedule
+                WHERE user_id = ? AND day = ? AND tag IN ('rest', 'sleep')
+                """,
+                (user_id, today),
+            )
+            sleep = cur.fetchone()[0]
+
             _drinking = row[3]
             stress = min(100, row[4] + DECAY["stress"])
             discipline = max(0, row[5] - DECAY["training_discipline"])
             mental = max(0, row[6] - DECAY["mental_health"])
 
-            cur.execute("""
+            cur.execute(
+                """
                 UPDATE lifestyle
                 SET sleep_hours = ?, stress = ?, training_discipline = ?, mental_health = ?, last_updated = ?
                 WHERE user_id = ?
-            """, (sleep, stress, discipline, mental, datetime.utcnow().isoformat(), user_id))
+                """,
+                (
+                    sleep,
+                    stress,
+                    discipline,
+                    mental,
+                    datetime.utcnow().isoformat(),
+                    user_id,
+                ),
+            )
 
             modifier = lifestyle_xp_modifier(sleep, stress, discipline, mental)
             modifier *= event_svc.get_active_multiplier()

--- a/backend/services/schedule_service.py
+++ b/backend/services/schedule_service.py
@@ -1,0 +1,67 @@
+# services/schedule_service.py
+
+"""Daily schedule management helpers."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Mapping
+
+DB_PATH = Path(__file__).resolve().parent.parent / "rockmundo.db"
+
+
+def _ensure_table(cur: sqlite3.Cursor) -> None:
+    """Ensure the schedule table exists."""
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schedule (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            day TEXT NOT NULL,
+            tag TEXT NOT NULL,
+            hours REAL NOT NULL
+        )
+        """
+    )
+
+
+def save_daily_plan(
+    user_id: int, day: str, activities: Iterable[Mapping[str, float]]
+) -> dict:
+    """Persist a daily plan after validating required rest.
+
+    Each activity in ``activities`` must provide ``tag`` and ``hours`` keys. The
+    total ``hours`` of activities tagged ``rest`` or ``sleep`` must be at least
+    five; otherwise a ``ValueError`` is raised.
+    """
+
+    rest_hours = sum(
+        act.get("hours", 0)
+        for act in activities
+        if act.get("tag") in {"rest", "sleep"}
+    )
+    if rest_hours < 5:
+        raise ValueError("Daily plan must include ≥5 hours of rest/sleep")
+
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        _ensure_table(cur)
+        # Replace any existing plan for this user/day
+        cur.execute(
+            "DELETE FROM schedule WHERE user_id = ? AND day = ?",
+            (user_id, day),
+        )
+        for act in activities:
+            cur.execute(
+                "INSERT INTO schedule (user_id, day, tag, hours) VALUES (?, ?, ?, ?)",
+                (user_id, day, act["tag"], act["hours"]),
+            )
+        conn.commit()
+
+    return {"status": "ok"}
+
+
+__all__ = ["save_daily_plan"]
+

--- a/backend/tests/schedule/test_rest_validation.py
+++ b/backend/tests/schedule/test_rest_validation.py
@@ -1,0 +1,48 @@
+import sqlite3
+
+import pytest
+
+from backend.services import schedule_service
+
+
+def _init_db(path):
+    schedule_service.DB_PATH = path
+    # touch the database file and ensure a clean schedule table
+    with sqlite3.connect(path) as conn:
+        cur = conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS schedule")
+        conn.commit()
+
+
+def test_rejects_when_rest_under_five(tmp_path):
+    db = tmp_path / "sched.db"
+    _init_db(db)
+
+    plan = [
+        {"tag": "practice", "hours": 10},
+        {"tag": "sleep", "hours": 4},
+    ]
+
+    with pytest.raises(ValueError):
+        schedule_service.save_daily_plan(1, "2024-01-01", plan)
+
+
+def test_accepts_valid_rest(tmp_path):
+    db = tmp_path / "sched.db"
+    _init_db(db)
+
+    plan = [
+        {"tag": "practice", "hours": 8},
+        {"tag": "sleep", "hours": 5},
+    ]
+
+    result = schedule_service.save_daily_plan(1, "2024-01-01", plan)
+    assert result["status"] == "ok"
+
+    with sqlite3.connect(schedule_service.DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT SUM(hours) FROM schedule WHERE user_id=1 AND tag IN ('sleep','rest')"
+        )
+        assert cur.fetchone()[0] == 5
+


### PR DESCRIPTION
## Summary
- enforce at least 5 hours of rest/sleep when saving daily schedules
- derive lifestyle sleep hours from saved schedules
- test schedule rest validation

## Testing
- `ruff check backend/services/schedule_service.py backend/services/lifestyle_scheduler.py backend/tests/schedule/test_rest_validation.py`
- `pytest backend/tests/schedule/test_rest_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b05ac284832583bdd0094429a5bd