### PR TITLE
Add schedule plan service and endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from routes import (
     lifestyle_routes,
     locale_routes,
     music_metrics_routes,
+    schedule_routes,
     onboarding_routes,
     playlist_routes,
     setlist_routes,
@@ -92,6 +93,7 @@ app.include_router(
 )
 app.include_router(setlist_routes.router, prefix="/api", tags=["Setlists"])
 app.include_router(music_metrics_routes.router)
+app.include_router(schedule_routes.router, prefix="/api", tags=["Schedule"])
 app.include_router(song_forecast_routes.router)
 app.include_router(tour_collab_routes.router, prefix="/api", tags=["TourCollab"])
 app.include_router(tour_planner_routes.router, prefix="/api", tags=["TourPlanner"])

--- a/backend/routes/schedule_routes.py
+++ b/backend/routes/schedule_routes.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from backend.services.plan_service import plan_service
+
+router = APIRouter(prefix="/schedule", tags=["schedule"])
+
+
+class PlanSelections(BaseModel):
+    social: bool = False
+    career: bool = False
+    band: bool = False
+
+
+@router.post("/plan")
+def generate_plan(data: PlanSelections):
+    schedule = plan_service.create_plan(
+        social=data.social, career=data.career, band=data.band
+    )
+    return {"schedule": schedule}

--- a/backend/services/plan_service.py
+++ b/backend/services/plan_service.py
@@ -1,0 +1,60 @@
+"""High-level planning for daily schedules.
+
+This module maps high level category selections (social, career, band)
+into concrete activity names and fills the remaining day with rest
+activities.  The service is intentionally simple and in-memory so it can
+be used by routes and tests without any external dependencies.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+# Default mapping of category -> list of activity names.
+CATEGORY_MAP: Dict[str, List[str]] = {
+    "social": ["network", "promote"],
+    "career": ["practice", "songwriting"],
+    "band": ["rehearsal", "gig_prep"],
+}
+
+# Number of slots that make up a day in the generated plan.
+DEFAULT_SLOTS = 8
+
+
+@dataclass
+class PlanService:
+    """Generate simple daily plans based on category selections."""
+
+    # expose defaults for easy access in tests or other modules
+    CATEGORY_MAP = CATEGORY_MAP
+    DEFAULT_SLOTS = DEFAULT_SLOTS
+
+    category_map: Dict[str, List[str]] = field(default_factory=lambda: CATEGORY_MAP)
+    slots: int = DEFAULT_SLOTS
+
+    def create_plan(self, social: bool = False, career: bool = False, band: bool = False) -> List[str]:
+        """Return a list of activities for the day.
+
+        Selected categories contribute their activities in the order
+        defined by ``category_map``.  The list is padded with ``"rest"``
+        entries until ``slots`` is reached.
+        """
+
+        schedule: List[str] = []
+        if social:
+            schedule.extend(self.category_map.get("social", []))
+        if career:
+            schedule.extend(self.category_map.get("career", []))
+        if band:
+            schedule.extend(self.category_map.get("band", []))
+
+        while len(schedule) < self.slots:
+            schedule.append("rest")
+
+        return schedule[: self.slots]
+
+
+plan_service = PlanService()
+
+__all__ = ["PlanService", "plan_service"]

--- a/backend/tests/schedule/test_plan_service.py
+++ b/backend/tests/schedule/test_plan_service.py
@@ -1,0 +1,19 @@
+from backend.services.plan_service import PlanService
+
+
+def test_category_mapping():
+    svc = PlanService()
+    plan = svc.create_plan(social=True, career=True, band=False)
+    expected = PlanService.CATEGORY_MAP["social"] + PlanService.CATEGORY_MAP["career"]
+    assert plan[: len(expected)] == expected
+
+
+def test_rest_insertion():
+    svc = PlanService()
+    plan = svc.create_plan(social=True, career=False, band=False)
+    # first entries from social category
+    assert plan[0:2] == PlanService.CATEGORY_MAP["social"]
+    # rest fills remaining slots
+    assert plan.count("rest") == svc.slots - len(PlanService.CATEGORY_MAP["social"])
+    assert len(plan) == svc.slots
+    assert plan[-1] == "rest"


### PR DESCRIPTION
## Summary
- add PlanService to map activity categories and auto-insert rest slots
- expose POST /schedule/plan endpoint
- test planning logic for category mapping and rest insertion

## Testing
- `pytest backend/tests/schedule/test_plan_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b36c7cac83259acab34bcf6f2147