### PR TITLE
Add schedule planner page with API modules and tests

### DIFF
--- a/frontend/components/schedule.js
+++ b/frontend/components/schedule.js
@@ -1,0 +1,84 @@
+import { fetchSchedule, saveSchedule } from './scheduleApi.js';
+import { renderSchedule } from './scheduleRenderer.js';
+
+export function initSchedulePage() {
+  const form = document.getElementById('scheduleForm');
+  const hourlyFields = document.getElementById('hourlyFields');
+  const categoryField = document.getElementById('categoryField');
+  const display = document.getElementById('scheduleDisplay');
+
+  function buildHourlyInputs() {
+    hourlyFields.innerHTML = '';
+    for (let i = 0; i < 24; i++) {
+      const label = document.createElement('label');
+      label.textContent = `${String(i).padStart(2, '0')}:00 `;
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.name = `h${i}`;
+      label.appendChild(input);
+      hourlyFields.appendChild(label);
+    }
+  }
+
+  function switchMode(mode) {
+    if (mode === 'hourly') {
+      hourlyFields.style.display = '';
+      categoryField.style.display = 'none';
+    } else {
+      hourlyFields.style.display = 'none';
+      categoryField.style.display = '';
+    }
+  }
+
+  form.mode.forEach((radio) => {
+    radio.addEventListener('change', () => switchMode(radio.value));
+  });
+
+  buildHourlyInputs();
+  switchMode(form.mode.value);
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = new FormData(form);
+    const mode = data.get('mode');
+    let payload;
+    if (mode === 'hourly') {
+      const entries = {};
+      for (let i = 0; i < 24; i++) {
+        const val = data.get(`h${i}`);
+        if (val) entries[`${String(i).padStart(2, '0')}:00`] = val;
+      }
+      payload = { mode: 'hourly', entries };
+    } else {
+      payload = { mode: 'category', category: data.get('category') };
+    }
+    const result = await saveSchedule(payload).catch(() => null);
+    renderSchedule(display, result || payload);
+  });
+
+  fetchSchedule()
+    .then((sched) => {
+      if (sched.mode === 'hourly') {
+        form.mode.value = 'hourly';
+        switchMode('hourly');
+        Object.entries(sched.entries || {}).forEach(([h, val]) => {
+          const idx = parseInt(h);
+          const input = form.querySelector(`[name="h${idx}"]`);
+          if (input) input.value = val;
+        });
+      } else if (sched.mode === 'category') {
+        form.mode.value = 'category';
+        switchMode('category');
+        const select = document.getElementById('categorySelect');
+        if (select) select.value = sched.category;
+      }
+      renderSchedule(display, sched);
+    })
+    .catch(() => {});
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initSchedulePage);
+}
+
+export default { initSchedulePage };

--- a/frontend/components/scheduleApi.js
+++ b/frontend/components/scheduleApi.js
@@ -1,0 +1,21 @@
+export async function fetchSchedule() {
+  const res = await fetch('/api/schedule');
+  if (!res.ok) {
+    throw new Error('Failed to fetch schedule');
+  }
+  return res.json();
+}
+
+export async function saveSchedule(data) {
+  const res = await fetch('/api/schedule', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) {
+    throw new Error('Failed to save schedule');
+  }
+  return res.json();
+}
+
+export default { fetchSchedule, saveSchedule };

--- a/frontend/components/scheduleRenderer.js
+++ b/frontend/components/scheduleRenderer.js
@@ -1,0 +1,20 @@
+export function renderSchedule(container, sched) {
+  container.innerHTML = '';
+  if (!sched) return;
+  if (sched.mode === 'hourly') {
+    const ul = document.createElement('ul');
+    const entries = sched.entries || {};
+    Object.keys(entries).sort().forEach(hour => {
+      const li = document.createElement('li');
+      li.textContent = `${hour}: ${entries[hour]}`;
+      ul.appendChild(li);
+    });
+    container.appendChild(ul);
+  } else if (sched.mode === 'category') {
+    const p = document.createElement('p');
+    p.textContent = `Category: ${sched.category}`;
+    container.appendChild(p);
+  }
+}
+
+export default { renderSchedule };

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Schedule Planner</title>
+  <link rel="stylesheet" href="../index.css" />
+</head>
+<body>
+  <h2>Schedule Planner</h2>
+  <form id="scheduleForm">
+    <label><input type="radio" name="mode" value="hourly" checked> Hourly Planner</label>
+    <label><input type="radio" name="mode" value="category"> Category</label>
+    <div id="hourlyFields"></div>
+    <div id="categoryField" style="display:none;">
+      <select id="categorySelect" name="category">
+        <option value="practice">Practice</option>
+        <option value="rest">Rest</option>
+        <option value="travel">Travel</option>
+      </select>
+    </div>
+    <button type="submit">Save</button>
+  </form>
+  <div id="scheduleDisplay"></div>
+  <script type="module" src="../components/schedule.js"></script>
+  <script src="../components/themeToggle.js"></script>
+</body>
+</html>

--- a/frontend/tests/schedule.test.ts
+++ b/frontend/tests/schedule.test.ts
@@ -1,0 +1,45 @@
+import { renderSchedule } from '../components/scheduleRenderer.js';
+import { initSchedulePage } from '../components/schedule.js';
+import { vi } from 'vitest';
+
+describe('schedule components', () => {
+  test('renders hourly entries', () => {
+    const container = document.createElement('div');
+    renderSchedule(container, { mode: 'hourly', entries: { '08:00': 'Practice' } });
+    expect(container.textContent).toContain('08:00');
+  });
+
+  test('submits hourly schedule', async () => {
+    document.body.innerHTML = `
+      <form id="scheduleForm">
+        <label><input type="radio" name="mode" value="hourly" checked></label>
+        <label><input type="radio" name="mode" value="category"></label>
+        <div id="hourlyFields"></div>
+        <div id="categoryField" style="display:none;">
+          <select id="categorySelect" name="category">
+            <option value="practice">Practice</option>
+          </select>
+        </div>
+        <button type="submit">Save</button>
+      </form>
+      <div id="scheduleDisplay"></div>
+    `;
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ mode: 'hourly', entries: { '01:00': 'Jam' } }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const originalFetch = global.fetch;
+    vi.stubGlobal('fetch', fetchMock);
+
+    initSchedulePage();
+
+    const input = document.querySelector('[name="h1"]') as HTMLInputElement;
+    input.value = 'Jam';
+    document.getElementById('scheduleForm')!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/schedule', expect.objectContaining({ method: 'POST' }));
+    expect(document.getElementById('scheduleDisplay')!.textContent).toContain('01:00');
+
+    (global as any).fetch = originalFetch;
+  });
+});


### PR DESCRIPTION
## Summary
- add schedule planner page with hourly and category modes
- implement schedule API and rendering modules
- cover schedule rendering and submission with tests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b47c7298832597dfd1905432f926