### PR TITLE
Add daily activity processing service and logging

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -406,4 +406,34 @@ def init_db():
         )
         """)
 
+        # Logs and progression for scheduled activities
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS activity_log (
+                user_id INTEGER NOT NULL,
+                date TEXT NOT NULL,
+                activity_id INTEGER NOT NULL,
+                outcome_json TEXT NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_xp (
+                user_id INTEGER PRIMARY KEY,
+                xp INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY(user_id) REFERENCES users(id)
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_energy (
+                user_id INTEGER PRIMARY KEY,
+                energy INTEGER NOT NULL DEFAULT 100,
+                FOREIGN KEY(user_id) REFERENCES users(id)
+            )
+            """
+        )
+
         conn.commit()

--- a/backend/services/activity_processor.py
+++ b/backend/services/activity_processor.py
@@ -1,0 +1,110 @@
+"""Daily activity resolution service."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date, timedelta
+from typing import Dict, List
+
+from backend.database import DB_PATH
+
+
+def _ensure_tables(cur: sqlite3.Cursor) -> None:
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_xp (
+            user_id INTEGER PRIMARY KEY,
+            xp INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_energy (
+            user_id INTEGER PRIMARY KEY,
+            energy INTEGER NOT NULL DEFAULT 100,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS activity_log (
+            user_id INTEGER NOT NULL,
+            date TEXT NOT NULL,
+            activity_id INTEGER NOT NULL,
+            outcome_json TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _apply_effects(cur: sqlite3.Cursor, user_id: int, activity_id: int) -> Dict[str, int]:
+    cur.execute(
+        "SELECT duration_hours FROM activities WHERE id = ?",
+        (activity_id,),
+    )
+    row = cur.fetchone()
+    duration = row[0] if row else 1
+    xp_gain = int(duration * 10)
+    energy_change = int(-duration * 5)
+    skill_gain = xp_gain  # simplified
+
+    cur.execute(
+        "INSERT OR IGNORE INTO user_xp(user_id, xp) VALUES (?, 0)",
+        (user_id,),
+    )
+    cur.execute(
+        "UPDATE user_xp SET xp = xp + ? WHERE user_id = ?",
+        (xp_gain, user_id),
+    )
+    cur.execute(
+        "INSERT OR IGNORE INTO user_energy(user_id, energy) VALUES (?, 100)",
+        (user_id,),
+    )
+    cur.execute(
+        "UPDATE user_energy SET energy = energy + ? WHERE user_id = ?",
+        (energy_change, user_id),
+    )
+
+    outcome = {"xp": xp_gain, "energy": energy_change, "skill_gain": skill_gain}
+    cur.execute(
+        "INSERT INTO activity_log(user_id, date, activity_id, outcome_json) VALUES (?, ?, ?, ?)",
+        (user_id, _current_date, activity_id, json.dumps(outcome)),
+    )
+    return outcome
+
+
+# Helper variable used inside _apply_effects
+_current_date: str
+
+
+def process_day(target_date: str) -> Dict[str, int]:
+    """Process all scheduled activities for ``target_date``."""
+    global _current_date
+    _current_date = target_date
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        _ensure_tables(cur)
+        cur.execute(
+            "SELECT user_id, activity_id FROM daily_schedule WHERE date = ?",
+            (target_date,),
+        )
+        rows: List[tuple[int, int]] = cur.fetchall()
+        processed = 0
+        for user_id, activity_id in rows:
+            _apply_effects(cur, user_id, activity_id)
+            processed += 1
+        conn.commit()
+    return {"status": "ok", "processed": processed}
+
+
+def process_previous_day() -> Dict[str, int]:
+    """Convenience wrapper to process yesterday's activities."""
+    target_date = (date.today() - timedelta(days=1)).isoformat()
+    return process_day(target_date)
+
+
+__all__ = ["process_day", "process_previous_day"]

--- a/backend/tests/schedule/test_activity_processing.py
+++ b/backend/tests/schedule/test_activity_processing.py
@@ -1,0 +1,53 @@
+import importlib
+import json
+import sqlite3
+from datetime import date, timedelta
+
+
+def setup_db(tmp_path):
+    db_file = tmp_path / "activity.db"
+    from backend import database
+
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+    from backend.models import daily_schedule as schedule_model
+
+    activity_model.DB_PATH = db_file
+    schedule_model.DB_PATH = db_file
+
+    import backend.services.schedule_service as schedule_module
+    importlib.reload(schedule_module)
+
+    import backend.services.activity_processor as processor_module
+    processor_module.DB_PATH = db_file
+    importlib.reload(processor_module)
+
+    return schedule_module.schedule_service, processor_module
+
+
+def test_activity_processing_persists_outcomes(tmp_path):
+    schedule_svc, processor = setup_db(tmp_path)
+
+    user_id = 1
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+
+    act_id = schedule_svc.create_activity("Practice", 2, "music")
+    schedule_svc.schedule_activity(user_id, yesterday, 9, act_id)
+
+    result = processor.process_previous_day()
+    assert result["processed"] == 1
+
+    with sqlite3.connect(processor.DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT xp FROM user_xp WHERE user_id = ?", (user_id,))
+        assert cur.fetchone()[0] == 20
+        cur.execute("SELECT energy FROM user_energy WHERE user_id = ?", (user_id,))
+        assert cur.fetchone()[0] == 90
+        cur.execute(
+            "SELECT outcome_json FROM activity_log WHERE user_id = ? AND date = ?",
+            (user_id, yesterday),
+        )
+        outcome = json.loads(cur.fetchone()[0])
+        assert outcome == {"xp": 20, "energy": -10, "skill_gain": 20}


### PR DESCRIPTION
## Summary
- process scheduled activities from previous day and apply XP and energy effects
- log activity outcomes and track user progression
- run nightly job to invoke activity processor

## Testing
- `ruff check backend/services/activity_processor.py backend/services/scheduler_service.py backend/database.py backend/tests/schedule/test_activity_processing.py`
- `pytest backend/tests/schedule/test_activity_processing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b6dcc8308325b25b8c724aacbf62