### PR TITLE
Use slot-based scheduling with fractional durations

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -388,7 +388,7 @@ def init_db():
         CREATE TABLE IF NOT EXISTS activities (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL,
-            duration_hours INTEGER NOT NULL,
+            duration_hours REAL NOT NULL,
             category TEXT
         )
         """)
@@ -411,9 +411,9 @@ def init_db():
         CREATE TABLE IF NOT EXISTS daily_schedule (
             user_id INTEGER NOT NULL,
             date TEXT NOT NULL,
-            hour INTEGER NOT NULL,
+            slot INTEGER NOT NULL,
             activity_id INTEGER NOT NULL,
-            PRIMARY KEY (user_id, date, hour),
+            PRIMARY KEY (user_id, date, slot),
             FOREIGN KEY(user_id) REFERENCES users(id),
             FOREIGN KEY(activity_id) REFERENCES activities(id)
         )

--- a/backend/models/activity.py
+++ b/backend/models/activity.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Dict
 from backend.database import DB_PATH
 
 
-def create_activity(name: str, duration_hours: int, category: str) -> int:
+def create_activity(name: str, duration_hours: float, category: str) -> int:
     """Insert a new activity and return its id."""
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
@@ -47,7 +47,7 @@ def list_activities() -> List[Dict]:
     ]
 
 
-def update_activity(activity_id: int, name: str, duration_hours: int, category: str) -> None:
+def update_activity(activity_id: int, name: str, duration_hours: float, category: str) -> None:
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(

--- a/backend/models/daily_schedule.py
+++ b/backend/models/daily_schedule.py
@@ -4,37 +4,37 @@ from typing import List, Dict
 from backend.database import DB_PATH
 
 
-def add_entry(user_id: int, date: str, hour: int, activity_id: int) -> None:
-    """Insert a schedule entry for a user."""
+def add_entry(user_id: int, date: str, slot: int, activity_id: int) -> None:
+    """Insert or update a schedule entry for a user."""
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(
             """
-            INSERT INTO daily_schedule (user_id, date, hour, activity_id)
+            INSERT INTO daily_schedule (user_id, date, slot, activity_id)
             VALUES (?, ?, ?, ?)
-            ON CONFLICT(user_id, date, hour) DO UPDATE SET activity_id = excluded.activity_id
+            ON CONFLICT(user_id, date, slot) DO UPDATE SET activity_id = excluded.activity_id
             """,
-            (user_id, date, hour, activity_id),
+            (user_id, date, slot, activity_id),
         )
         conn.commit()
 
 
-def update_entry(user_id: int, date: str, hour: int, activity_id: int) -> None:
+def update_entry(user_id: int, date: str, slot: int, activity_id: int) -> None:
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(
-            "UPDATE daily_schedule SET activity_id = ? WHERE user_id = ? AND date = ? AND hour = ?",
-            (activity_id, user_id, date, hour),
+            "UPDATE daily_schedule SET activity_id = ? WHERE user_id = ? AND date = ? AND slot = ?",
+            (activity_id, user_id, date, slot),
         )
         conn.commit()
 
 
-def remove_entry(user_id: int, date: str, hour: int) -> None:
+def remove_entry(user_id: int, date: str, slot: int) -> None:
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(
-            "DELETE FROM daily_schedule WHERE user_id = ? AND date = ? AND hour = ?",
-            (user_id, date, hour),
+            "DELETE FROM daily_schedule WHERE user_id = ? AND date = ? AND slot = ?",
+            (user_id, date, slot),
         )
         conn.commit()
 
@@ -45,18 +45,18 @@ def get_schedule(user_id: int, date: str) -> List[Dict]:
         cur = conn.cursor()
         cur.execute(
             """
-            SELECT ds.hour, a.id, a.name, a.duration_hours, a.category
+            SELECT ds.slot, a.id, a.name, a.duration_hours, a.category
             FROM daily_schedule ds
             JOIN activities a ON ds.activity_id = a.id
             WHERE ds.user_id = ? AND ds.date = ?
-            ORDER BY ds.hour
+            ORDER BY ds.slot
             """,
             (user_id, date),
         )
         rows = cur.fetchall()
     return [
         {
-            "hour": r[0],
+            "slot": r[0],
             "activity": {
                 "id": r[1],
                 "name": r[2],

--- a/backend/scripts/migrate_daily_schedule_slots.py
+++ b/backend/scripts/migrate_daily_schedule_slots.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""One-time migration script to convert daily_schedule.hour to slot.
+
+Each existing entry's hour is multiplied by four to produce the new slot value
+(0-95 representing 15-minute increments). Run this script once after deploying
+the new schema.
+"""
+
+import sqlite3
+from backend.database import DB_PATH
+
+
+def migrate() -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("PRAGMA table_info(daily_schedule)")
+        columns = [row[1] for row in cur.fetchall()]
+        if "hour" in columns:
+            cur.execute("ALTER TABLE daily_schedule RENAME TO daily_schedule_old")
+            cur.execute(
+                """
+                CREATE TABLE daily_schedule (
+                    user_id INTEGER NOT NULL,
+                    date TEXT NOT NULL,
+                    slot INTEGER NOT NULL,
+                    activity_id INTEGER NOT NULL,
+                    PRIMARY KEY (user_id, date, slot),
+                    FOREIGN KEY(user_id) REFERENCES users(id),
+                    FOREIGN KEY(activity_id) REFERENCES activities(id)
+                )
+                """
+            )
+            cur.execute(
+                """
+                INSERT INTO daily_schedule (user_id, date, slot, activity_id)
+                SELECT user_id, date, hour * 4 AS slot, activity_id
+                FROM daily_schedule_old
+                """
+            )
+            cur.execute("DROP TABLE daily_schedule_old")
+            conn.commit()
+            print("Migration completed: daily_schedule.hour -> slot")
+        else:
+            print("No migration needed; slot column already present")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/backend/services/schedule_service.py
+++ b/backend/services/schedule_service.py
@@ -78,14 +78,14 @@ class ScheduleService:
     """Service layer wrapping activity and daily schedule operations."""
 
     # Activity CRUD -----------------------------------------------------
-    def create_activity(self, name: str, duration_hours: int, category: str) -> int:
+    def create_activity(self, name: str, duration_hours: float, category: str) -> int:
         return activity_model.create_activity(name, duration_hours, category)
 
     def get_activity(self, activity_id: int) -> Dict | None:
         return activity_model.get_activity(activity_id)
 
     def update_activity(
-        self, activity_id: int, name: str, duration_hours: int, category: str
+        self, activity_id: int, name: str, duration_hours: float, category: str
     ) -> None:
         activity_model.update_activity(activity_id, name, duration_hours, category)
 
@@ -94,17 +94,17 @@ class ScheduleService:
 
     # Schedule logic ----------------------------------------------------
     def schedule_activity(
-        self, user_id: int, date: str, hour: int, activity_id: int
+        self, user_id: int, date: str, slot: int, activity_id: int
     ) -> None:
-        schedule_model.add_entry(user_id, date, hour, activity_id)
+        schedule_model.add_entry(user_id, date, slot, activity_id)
 
     def update_schedule_entry(
-        self, user_id: int, date: str, hour: int, activity_id: int
+        self, user_id: int, date: str, slot: int, activity_id: int
     ) -> None:
-        schedule_model.update_entry(user_id, date, hour, activity_id)
+        schedule_model.update_entry(user_id, date, slot, activity_id)
 
-    def remove_schedule_entry(self, user_id: int, date: str, hour: int) -> None:
-        schedule_model.remove_entry(user_id, date, hour)
+    def remove_schedule_entry(self, user_id: int, date: str, slot: int) -> None:
+        schedule_model.remove_entry(user_id, date, slot)
 
     def get_daily_schedule(self, user_id: int, date: str) -> List[Dict]:
         return schedule_model.get_schedule(user_id, date)

--- a/backend/tests/schedule/test_schedule_crud.py
+++ b/backend/tests/schedule/test_schedule_crud.py
@@ -22,17 +22,17 @@ def setup_db(tmp_path):
 def test_create_and_retrieve_schedule(tmp_path):
     svc = setup_db(tmp_path)
 
-    act_id = svc.create_activity("Practice", 2, "music")
-    svc.schedule_activity(1, "2024-01-01", 9, act_id)
+    act_id = svc.create_activity("Practice", 1.5, "music")
+    svc.schedule_activity(1, "2024-01-01", 38, act_id)  # 09:30 slot
 
     schedule = svc.get_daily_schedule(1, "2024-01-01")
     assert schedule == [
         {
-            "hour": 9,
+            "slot": 38,
             "activity": {
                 "id": act_id,
                 "name": "Practice",
-                "duration_hours": 2,
+                "duration_hours": 1.5,
                 "category": "music",
             },
         }
@@ -42,11 +42,12 @@ def test_create_and_retrieve_schedule(tmp_path):
 def test_update_schedule_entry(tmp_path):
     svc = setup_db(tmp_path)
 
-    act1 = svc.create_activity("Practice", 2, "music")
-    act2 = svc.create_activity("Workout", 1, "fitness")
+    act1 = svc.create_activity("Practice", 2.0, "music")
+    act2 = svc.create_activity("Workout", 0.5, "fitness")
 
-    svc.schedule_activity(1, "2024-01-01", 9, act1)
-    svc.update_schedule_entry(1, "2024-01-01", 9, act2)
+    svc.schedule_activity(1, "2024-01-01", 36, act1)
+    svc.update_schedule_entry(1, "2024-01-01", 36, act2)
 
     schedule = svc.get_daily_schedule(1, "2024-01-01")
+    assert schedule[0]["slot"] == 36
     assert schedule[0]["activity"]["id"] == act2


### PR DESCRIPTION
## Summary
- replace `hour` with 15-minute `slot` field in `daily_schedule` schema and allow fractional activity durations
- update daily schedule models and service to work with slots and float `duration_hours`
- add migration script and tests covering fractional scheduling

## Testing
- `pytest backend/tests/schedule/test_schedule_crud.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8b83727748325ac5415c405f368b7