### PR TITLE
Add activity prerequisites and reward processing

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -389,7 +389,10 @@ def init_db():
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL,
             duration_hours REAL NOT NULL,
-            category TEXT
+            category TEXT,
+            required_skill TEXT,
+            energy_cost INTEGER NOT NULL DEFAULT 0,
+            rewards_json TEXT
         )
         """)
 
@@ -412,6 +415,7 @@ def init_db():
             user_id INTEGER NOT NULL,
             date TEXT NOT NULL,
             slot INTEGER NOT NULL,
+            hour INTEGER NOT NULL,
             activity_id INTEGER NOT NULL,
             PRIMARY KEY (user_id, date, slot),
             FOREIGN KEY(user_id) REFERENCES users(id),

--- a/backend/models/activity.py
+++ b/backend/models/activity.py
@@ -4,13 +4,23 @@ from typing import List, Optional, Dict
 from backend.database import DB_PATH
 
 
-def create_activity(name: str, duration_hours: float, category: str) -> int:
+def create_activity(
+    name: str,
+    duration_hours: float,
+    category: str,
+    required_skill: str | None = None,
+    energy_cost: int = 0,
+    rewards_json: str | None = None,
+) -> int:
     """Insert a new activity and return its id."""
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(
-            "INSERT INTO activities (name, duration_hours, category) VALUES (?, ?, ?)",
-            (name, duration_hours, category),
+            """
+            INSERT INTO activities (name, duration_hours, category, required_skill, energy_cost, rewards_json)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (name, duration_hours, category, required_skill, energy_cost, rewards_json),
         )
         conn.commit()
         return cur.lastrowid
@@ -21,7 +31,10 @@ def get_activity(activity_id: int) -> Optional[Dict]:
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(
-            "SELECT id, name, duration_hours, category FROM activities WHERE id = ?",
+            """
+            SELECT id, name, duration_hours, category, required_skill, energy_cost, rewards_json
+            FROM activities WHERE id = ?
+            """,
             (activity_id,),
         )
         row = cur.fetchone()
@@ -32,6 +45,9 @@ def get_activity(activity_id: int) -> Optional[Dict]:
         "name": row[1],
         "duration_hours": row[2],
         "category": row[3],
+        "required_skill": row[4],
+        "energy_cost": row[5],
+        "rewards_json": row[6],
     }
 
 
@@ -39,20 +55,45 @@ def list_activities() -> List[Dict]:
     """Return all activities."""
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
-        cur.execute("SELECT id, name, duration_hours, category FROM activities")
+        cur.execute(
+            """
+            SELECT id, name, duration_hours, category, required_skill, energy_cost, rewards_json
+            FROM activities
+            """
+        )
         rows = cur.fetchall()
     return [
-        {"id": r[0], "name": r[1], "duration_hours": r[2], "category": r[3]}
+        {
+            "id": r[0],
+            "name": r[1],
+            "duration_hours": r[2],
+            "category": r[3],
+            "required_skill": r[4],
+            "energy_cost": r[5],
+            "rewards_json": r[6],
+        }
         for r in rows
     ]
 
 
-def update_activity(activity_id: int, name: str, duration_hours: float, category: str) -> None:
+def update_activity(
+    activity_id: int,
+    name: str,
+    duration_hours: float,
+    category: str,
+    required_skill: str | None = None,
+    energy_cost: int = 0,
+    rewards_json: str | None = None,
+) -> None:
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(
-            "UPDATE activities SET name = ?, duration_hours = ?, category = ? WHERE id = ?",
-            (name, duration_hours, category, activity_id),
+            """
+            UPDATE activities
+            SET name = ?, duration_hours = ?, category = ?, required_skill = ?, energy_cost = ?, rewards_json = ?
+            WHERE id = ?
+            """,
+            (name, duration_hours, category, required_skill, energy_cost, rewards_json, activity_id),
         )
         conn.commit()
 

--- a/backend/models/daily_schedule.py
+++ b/backend/models/daily_schedule.py
@@ -1,4 +1,6 @@
 import sqlite3
+import sqlite3
+import sqlite3
 from typing import List, Dict
 
 from backend.database import DB_PATH
@@ -10,11 +12,11 @@ def add_entry(user_id: int, date: str, slot: int, activity_id: int) -> None:
         cur = conn.cursor()
         cur.execute(
             """
-            INSERT INTO daily_schedule (user_id, date, slot, activity_id)
-            VALUES (?, ?, ?, ?)
-            ON CONFLICT(user_id, date, slot) DO UPDATE SET activity_id = excluded.activity_id
+            INSERT INTO daily_schedule (user_id, date, slot, hour, activity_id)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(user_id, date, slot) DO UPDATE SET activity_id = excluded.activity_id, hour = excluded.hour
             """,
-            (user_id, date, slot, activity_id),
+            (user_id, date, slot, slot, activity_id),
         )
         conn.commit()
 
@@ -23,8 +25,8 @@ def update_entry(user_id: int, date: str, slot: int, activity_id: int) -> None:
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(
-            "UPDATE daily_schedule SET activity_id = ? WHERE user_id = ? AND date = ? AND slot = ?",
-            (activity_id, user_id, date, slot),
+            "UPDATE daily_schedule SET activity_id = ?, hour = ? WHERE user_id = ? AND date = ? AND slot = ?",
+            (activity_id, slot, user_id, date, slot),
         )
         conn.commit()
 

--- a/backend/tests/schedule/test_activity_requirements.py
+++ b/backend/tests/schedule/test_activity_requirements.py
@@ -1,0 +1,134 @@
+import importlib
+import json
+import sqlite3
+from datetime import date, timedelta
+
+import pytest
+
+
+def setup_db(tmp_path):
+    db_file = tmp_path / "activity.db"
+    from backend import database
+
+    database.DB_PATH = db_file
+    database.init_db()
+
+    # ensure user_skills table for tests
+    with sqlite3.connect(db_file) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_skills (
+                user_id INTEGER NOT NULL,
+                skill TEXT NOT NULL,
+                level INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(user_id, skill)
+            )
+            """
+        )
+        conn.commit()
+
+    from backend.models import activity as activity_model
+    from backend.models import daily_schedule as schedule_model
+
+    activity_model.DB_PATH = db_file
+    schedule_model.DB_PATH = db_file
+
+    import backend.services.schedule_service as schedule_module
+    importlib.reload(schedule_module)
+    import backend.services.activity_processor as processor_module
+    processor_module.DB_PATH = db_file
+    importlib.reload(processor_module)
+
+    return schedule_module.schedule_service, processor_module, db_file
+
+
+def test_rejects_without_skill(tmp_path):
+    schedule_svc, _, _ = setup_db(tmp_path)
+    user_id = 1
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+
+    act_id = schedule_svc.create_activity(
+        "Solo",
+        1,
+        "music",
+        required_skill="guitar",
+        energy_cost=0,
+    )
+
+    with pytest.raises(ValueError):
+        schedule_svc.schedule_activity(user_id, yesterday, 10, act_id)
+
+
+def test_rejects_on_low_energy(tmp_path):
+    schedule_svc, _, db_file = setup_db(tmp_path)
+    user_id = 1
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+
+    with sqlite3.connect(db_file) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO user_skills(user_id, skill, level) VALUES (?,?,?)",
+            (user_id, "guitar", 1),
+        )
+        cur.execute(
+            "INSERT INTO user_energy(user_id, energy) VALUES (?, ?)",
+            (user_id, 5),
+        )
+        conn.commit()
+
+    act_id = schedule_svc.create_activity(
+        "Jam",
+        1,
+        "music",
+        required_skill="guitar",
+        energy_cost=10,
+    )
+
+    with pytest.raises(ValueError):
+        schedule_svc.schedule_activity(user_id, yesterday, 9, act_id)
+
+
+def test_rewards_applied(tmp_path):
+    schedule_svc, processor, db_file = setup_db(tmp_path)
+    user_id = 1
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+
+    with sqlite3.connect(db_file) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO user_skills(user_id, skill, level) VALUES (?,?,?)",
+            (user_id, "guitar", 1),
+        )
+        conn.commit()
+
+    rewards = {"xp": 40, "energy": 5, "skills": {"guitar": 3}}
+    act_id = schedule_svc.create_activity(
+        "Practice Solo",
+        1,
+        "music",
+        required_skill="guitar",
+        energy_cost=10,
+        rewards_json=json.dumps(rewards),
+    )
+
+    schedule_svc.schedule_activity(user_id, yesterday, 8, act_id)
+    processor.process_previous_day()
+
+    with sqlite3.connect(db_file) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT xp FROM user_xp WHERE user_id = ?", (user_id,))
+        assert cur.fetchone()[0] == rewards["xp"]
+        cur.execute("SELECT energy FROM user_energy WHERE user_id = ?", (user_id,))
+        assert cur.fetchone()[0] == 95  # 100 - 10 + 5
+        cur.execute(
+            "SELECT level FROM user_skills WHERE user_id = ? AND skill = ?",
+            (user_id, "guitar"),
+        )
+        assert cur.fetchone()[0] == 4
+        cur.execute(
+            "SELECT outcome_json FROM activity_log WHERE user_id = ? AND date = ?",
+            (user_id, yesterday),
+        )
+        outcome = json.loads(cur.fetchone()[0])
+        assert outcome == {"xp": 40, "energy": 5, "skills": {"guitar": 3}}


### PR DESCRIPTION
## Summary
- extend activities table with required_skill, energy_cost and rewards_json
- validate user skills and energy when scheduling activities
- apply rewards_json to XP, energy and skills during activity processing
- add tests for scheduling requirements and rewards

## Testing
- `pytest backend/tests/schedule/test_activity_requirements.py backend/tests/schedule/test_activity_processing.py backend/tests/schedule/test_schedule_crud.py backend/tests/schedule/test_default_plan.py backend/tests/schedule/test_rest_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8baa107888325bd2c5c8669d73688