### PR TITLE
Add weekly schedule and reporting

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -409,6 +409,22 @@ def init_db():
         )
         """)
 
+        # Weekly schedule entries linking users to activities
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS weekly_schedule (
+                user_id INTEGER NOT NULL,
+                week_start TEXT NOT NULL,
+                day TEXT NOT NULL,
+                slot INTEGER NOT NULL,
+                activity_id INTEGER NOT NULL,
+                PRIMARY KEY (user_id, week_start, day, slot),
+                FOREIGN KEY(user_id) REFERENCES users(id),
+                FOREIGN KEY(activity_id) REFERENCES activities(id)
+            )
+            """
+        )
+
         # Daily schedule entries linking users to activities
         cur.execute("""
         CREATE TABLE IF NOT EXISTS daily_schedule (

--- a/backend/models/weekly_schedule.py
+++ b/backend/models/weekly_schedule.py
@@ -1,0 +1,95 @@
+import sqlite3
+from typing import List, Dict, Iterable, Tuple
+
+from backend.database import DB_PATH
+
+
+def add_entry(user_id: int, week_start: str, day: str, slot: int, activity_id: int) -> None:
+    """Insert or update a weekly schedule entry."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO weekly_schedule (user_id, week_start, day, slot, activity_id)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(user_id, week_start, day, slot)
+            DO UPDATE SET activity_id = excluded.activity_id
+            """,
+            (user_id, week_start, day, slot, activity_id),
+        )
+        conn.commit()
+
+
+def update_entry(user_id: int, week_start: str, day: str, slot: int, activity_id: int) -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE weekly_schedule SET activity_id = ? WHERE user_id = ? AND week_start = ? AND day = ? AND slot = ?",
+            (activity_id, user_id, week_start, day, slot),
+        )
+        conn.commit()
+
+
+def remove_entry(user_id: int, week_start: str, day: str, slot: int) -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "DELETE FROM weekly_schedule WHERE user_id = ? AND week_start = ? AND day = ? AND slot = ?",
+            (user_id, week_start, day, slot),
+        )
+        conn.commit()
+
+
+def set_schedule(user_id: int, week_start: str, entries: Iterable[Tuple[str, int, int]]) -> None:
+    """Replace the entire schedule for a given week."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "DELETE FROM weekly_schedule WHERE user_id = ? AND week_start = ?",
+            (user_id, week_start),
+        )
+        for day, slot, activity_id in entries:
+            cur.execute(
+                "INSERT INTO weekly_schedule (user_id, week_start, day, slot, activity_id) VALUES (?, ?, ?, ?, ?)",
+                (user_id, week_start, day, slot, activity_id),
+            )
+        conn.commit()
+
+
+def get_schedule(user_id: int, week_start: str) -> List[Dict]:
+    """Return all scheduled activities for a given week."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT ws.day, ws.slot, a.id, a.name, a.duration_hours, a.category
+            FROM weekly_schedule ws
+            JOIN activities a ON ws.activity_id = a.id
+            WHERE ws.user_id = ? AND ws.week_start = ?
+            ORDER BY ws.day, ws.slot
+            """,
+            (user_id, week_start),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "day": r[0],
+            "slot": r[1],
+            "activity": {
+                "id": r[2],
+                "name": r[3],
+                "duration_hours": r[4],
+                "category": r[5],
+            },
+        }
+        for r in rows
+    ]
+
+
+__all__ = [
+    "add_entry",
+    "update_entry",
+    "remove_entry",
+    "set_schedule",
+    "get_schedule",
+]

--- a/backend/routes/schedule_routes.py
+++ b/backend/routes/schedule_routes.py
@@ -1,7 +1,6 @@
-from typing import List
-
 from fastapi import APIRouter
 from pydantic import BaseModel
+from typing import List
 
 from backend.services.plan_service import plan_service
 from backend.services.schedule_service import schedule_service
@@ -38,3 +37,21 @@ def set_default_plan(user_id: int, day: str, entries: List[DefaultEntry]):
 def get_default_plan(user_id: int, day: str):
     plan = schedule_service.get_default_plan(user_id, day)
     return {"plan": plan}
+
+
+class WeeklyEntry(BaseModel):
+    day: str
+    slot: int
+    activity_id: int
+
+
+@router.post("/weekly/{user_id}/{week_start}")
+def set_weekly_schedule(user_id: int, week_start: str, entries: List[WeeklyEntry]):
+    schedule_service.set_weekly_schedule(user_id, week_start, [e.dict() for e in entries])
+    return {"status": "ok"}
+
+
+@router.get("/weekly/{user_id}/{week_start}")
+def get_weekly_schedule(user_id: int, week_start: str):
+    schedule = schedule_service.get_weekly_schedule(user_id, week_start)
+    return {"schedule": schedule}

--- a/backend/services/report_service.py
+++ b/backend/services/report_service.py
@@ -1,0 +1,44 @@
+import sqlite3
+from typing import Dict
+
+from backend.database import DB_PATH
+
+
+class ReportService:
+    """Aggregate scheduled and completed activity hours."""
+
+    def weekly_summary(self, user_id: int, week_start: str) -> Dict[str, float]:
+        with sqlite3.connect(DB_PATH) as conn:
+            cur = conn.cursor()
+            # Sum scheduled hours from weekly_schedule
+            cur.execute(
+                """
+                SELECT COALESCE(SUM(a.duration_hours), 0)
+                FROM weekly_schedule ws
+                JOIN activities a ON ws.activity_id = a.id
+                WHERE ws.user_id = ? AND ws.week_start = ?
+                """,
+                (user_id, week_start),
+            )
+            scheduled = cur.fetchone()[0] or 0.0
+            # Sum completed hours from activity_log
+            cur.execute(
+                """
+                SELECT COALESCE(SUM(a.duration_hours), 0)
+                FROM activity_log al
+                JOIN activities a ON al.activity_id = a.id
+                WHERE al.user_id = ? AND al.date BETWEEN ? AND date(?, '+6 days')
+                """,
+                (user_id, week_start, week_start),
+            )
+            completed = cur.fetchone()[0] or 0.0
+        return {
+            "week_start": week_start,
+            "scheduled_hours": scheduled,
+            "completed_hours": completed,
+        }
+
+
+report_service = ReportService()
+
+__all__ = ["ReportService", "report_service"]

--- a/backend/services/schedule_service.py
+++ b/backend/services/schedule_service.py
@@ -72,6 +72,7 @@ from typing import List, Dict
 from backend.models import activity as activity_model
 from backend.models import daily_schedule as schedule_model
 from backend.models import default_schedule as default_model
+from backend.models import weekly_schedule as weekly_model
 
 
 class ScheduleService:
@@ -188,6 +189,29 @@ class ScheduleService:
 
     def get_daily_schedule(self, user_id: int, date: str) -> List[Dict]:
         return schedule_model.get_schedule(user_id, date)
+
+    # Weekly schedule logic -------------------------------------------
+    def set_weekly_schedule(self, user_id: int, week_start: str, plan: List[Dict]) -> None:
+        entries = ((p["day"], p["slot"], p["activity_id"]) for p in plan)
+        weekly_model.set_schedule(user_id, week_start, entries)
+
+    def get_weekly_schedule(self, user_id: int, week_start: str) -> List[Dict]:
+        return weekly_model.get_schedule(user_id, week_start)
+
+    def add_weekly_entry(
+        self, user_id: int, week_start: str, day: str, slot: int, activity_id: int
+    ) -> None:
+        weekly_model.add_entry(user_id, week_start, day, slot, activity_id)
+
+    def update_weekly_entry(
+        self, user_id: int, week_start: str, day: str, slot: int, activity_id: int
+    ) -> None:
+        weekly_model.update_entry(user_id, week_start, day, slot, activity_id)
+
+    def remove_weekly_entry(
+        self, user_id: int, week_start: str, day: str, slot: int
+    ) -> None:
+        weekly_model.remove_entry(user_id, week_start, day, slot)
 
     # Default plan logic ----------------------------------------------
     def set_default_plan(self, user_id: int, day_of_week: str, plan: List[Dict]) -> None:

--- a/backend/tests/schedule/test_weekly_plan.py
+++ b/backend/tests/schedule/test_weekly_plan.py
@@ -1,0 +1,59 @@
+import importlib
+import importlib
+import sqlite3
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend import database
+
+
+def setup_app(tmp_path):
+    db_file = tmp_path / "weekly.db"
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+    from backend.models import weekly_schedule as weekly_model
+
+    activity_model.DB_PATH = db_file
+    weekly_model.DB_PATH = db_file
+
+    import backend.services.schedule_service as schedule_service_module
+    importlib.reload(schedule_service_module)
+    import backend.services.report_service as report_service_module
+    importlib.reload(report_service_module)
+    import backend.routes.schedule_routes as routes_module
+    importlib.reload(routes_module)
+
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    client = TestClient(app)
+    return client, schedule_service_module.schedule_service, report_service_module.report_service
+
+
+def test_weekly_schedule_endpoints(tmp_path):
+    client, svc, report = setup_app(tmp_path)
+    act_id = svc.create_activity("Practice", 2, "music")
+
+    resp = client.post(
+        "/schedule/weekly/1/2024-01-01",
+        json=[{"day": "mon", "slot": 9, "activity_id": act_id}],
+    )
+    assert resp.status_code == 200
+
+    resp = client.get("/schedule/weekly/1/2024-01-01")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["schedule"][0]["activity"]["id"] == act_id
+
+    # simulate completion in activity_log
+    with sqlite3.connect(database.DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO activity_log(user_id, date, activity_id, outcome_json) VALUES (?,?,?,?)",
+            (1, "2024-01-01", act_id, "{}"),
+        )
+        conn.commit()
+
+    summary = report.weekly_summary(1, "2024-01-01")
+    assert summary["scheduled_hours"] == 2
+    assert summary["completed_hours"] == 2


### PR DESCRIPTION
## Summary
- add weekly_schedule table and model with CRUD helpers
- expose weekly schedule management and reporting services
- provide `/schedule/weekly` endpoints and tests

## Testing
- `pytest backend/tests/schedule/test_weekly_plan.py -q -p no:warnings`
- `pytest backend/tests/schedule/test_schedule_crud.py -q -p no:warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b8bc53cdec8325b5dafa3185996e4e