### PR TITLE
Add band scheduling and collaborative planning

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -439,6 +439,18 @@ def init_db():
         )
         """)
 
+        # Band schedule entries linking bands to activities
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS band_schedule (
+            band_id INTEGER NOT NULL,
+            date TEXT NOT NULL,
+            slot INTEGER NOT NULL,
+            activity_id INTEGER NOT NULL,
+            PRIMARY KEY (band_id, date, slot),
+            FOREIGN KEY(activity_id) REFERENCES activities(id)
+        )
+        """)
+
         # Logs and progression for scheduled activities
         cur.execute(
             """

--- a/backend/models/band_schedule.py
+++ b/backend/models/band_schedule.py
@@ -1,0 +1,52 @@
+import sqlite3
+from typing import List, Dict
+
+from backend.database import DB_PATH
+
+
+def add_entry(band_id: int, date: str, slot: int, activity_id: int) -> None:
+    """Insert or update a band schedule entry."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO band_schedule (band_id, date, slot, activity_id)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(band_id, date, slot)
+            DO UPDATE SET activity_id = excluded.activity_id
+            """,
+            (band_id, date, slot, activity_id),
+        )
+        conn.commit()
+
+
+def get_schedule(band_id: int, date: str) -> List[Dict]:
+    """Return all scheduled band activities for a given date."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT bs.slot, a.id, a.name, a.duration_hours, a.category
+            FROM band_schedule bs
+            JOIN activities a ON bs.activity_id = a.id
+            WHERE bs.band_id = ? AND bs.date = ?
+            ORDER BY bs.slot
+            """,
+            (band_id, date),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "slot": r[0],
+            "activity": {
+                "id": r[1],
+                "name": r[2],
+                "duration_hours": r[3],
+                "category": r[4],
+            },
+        }
+        for r in rows
+    ]
+
+
+__all__ = ["add_entry", "get_schedule"]

--- a/backend/services/schedule_service.py
+++ b/backend/services/schedule_service.py
@@ -67,9 +67,10 @@ def save_daily_plan(
 __all__ = ["save_daily_plan"]
 
 
-from typing import List, Dict
+from typing import List, Dict, Iterable
 
 from backend.models import activity as activity_model
+from backend.models import band_schedule as band_schedule_model
 from backend.models import daily_schedule as schedule_model
 from backend.models import default_schedule as default_model
 from backend.models import weekly_schedule as weekly_model
@@ -222,6 +223,22 @@ class ScheduleService:
 
     def get_daily_schedule(self, user_id: int, date: str) -> List[Dict]:
         return schedule_model.get_schedule(user_id, date)
+
+    # Band schedule logic --------------------------------------------
+    def schedule_band_activity(
+        self,
+        band_id: int,
+        member_ids: Iterable[int],
+        date: str,
+        slot: int,
+        activity_id: int,
+    ) -> None:
+        for uid in member_ids:
+            schedule_model.add_entry(uid, date, slot, activity_id)
+        band_schedule_model.add_entry(band_id, date, slot, activity_id)
+
+    def get_band_schedule(self, band_id: int, date: str) -> List[Dict]:
+        return band_schedule_model.get_schedule(band_id, date)
 
     # Weekly schedule logic -------------------------------------------
     def set_weekly_schedule(self, user_id: int, week_start: str, plan: List[Dict]) -> None:

--- a/backend/tests/schedule/test_band_schedule.py
+++ b/backend/tests/schedule/test_band_schedule.py
@@ -1,0 +1,45 @@
+import importlib
+
+
+def setup_db(tmp_path):
+    db_file = tmp_path / "schedule.db"
+    from backend import database
+
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+    from backend.models import daily_schedule as schedule_model
+    from backend.models import band_schedule as band_model
+
+    activity_model.DB_PATH = db_file
+    schedule_model.DB_PATH = db_file
+    band_model.DB_PATH = db_file
+
+    import backend.services.schedule_service as service_module
+    importlib.reload(service_module)
+    return service_module.schedule_service
+
+
+def test_band_schedule_creation(tmp_path):
+    svc = setup_db(tmp_path)
+
+    act_id = svc.create_activity("Rehearsal", 1.0, "music")
+    svc.schedule_band_activity(1, [10, 20], "2024-02-01", 16, act_id)
+
+    band_sched = svc.get_band_schedule(1, "2024-02-01")
+    assert band_sched == [
+        {
+            "slot": 16,
+            "activity": {
+                "id": act_id,
+                "name": "Rehearsal",
+                "duration_hours": 1.0,
+                "category": "music",
+            },
+        }
+    ]
+
+    for uid in (10, 20):
+        user_sched = svc.get_daily_schedule(uid, "2024-02-01")
+        assert user_sched[0]["slot"] == 16

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -17,27 +17,68 @@
   <div class="tabs">
     <button id="quickPlanTab" class="active">Quick Plan</button>
     <button id="advancedPlannerTab">Advanced Planner</button>
+    <button id="bandPlanTab">Band Plan</button>
   </div>
   <div id="quickPlan" class="tab-content active"></div>
   <div id="advancedPlanner" class="tab-content"></div>
+  <div id="bandPlan" class="tab-content">
+    <h3>Band Plan</h3>
+    <p>Propose a shared slot and vote with your bandmates.</p>
+    <input type="date" id="bandDate" />
+    <input type="number" id="bandSlot" min="0" max="95" placeholder="Slot" />
+    <button id="proposeBtn">Propose</button>
+    <ul id="proposals"></ul>
+  </div>
   <script type="module" src="../components/quickPlan.js"></script>
   <script type="module" src="../components/advancedPlanner.js"></script>
   <script>
     const quickTab = document.getElementById('quickPlanTab');
     const advTab = document.getElementById('advancedPlannerTab');
+    const bandTab = document.getElementById('bandPlanTab');
     const quick = document.getElementById('quickPlan');
     const adv = document.getElementById('advancedPlanner');
+    const band = document.getElementById('bandPlan');
     quickTab.addEventListener('click', () => {
       quickTab.classList.add('active');
       advTab.classList.remove('active');
+      bandTab.classList.remove('active');
       quick.classList.add('active');
       adv.classList.remove('active');
+      band.classList.remove('active');
     });
     advTab.addEventListener('click', () => {
       advTab.classList.add('active');
       quickTab.classList.remove('active');
+      bandTab.classList.remove('active');
       adv.classList.add('active');
       quick.classList.remove('active');
+      band.classList.remove('active');
+    });
+    bandTab.addEventListener('click', () => {
+      bandTab.classList.add('active');
+      quickTab.classList.remove('active');
+      advTab.classList.remove('active');
+      band.classList.add('active');
+      quick.classList.remove('active');
+      adv.classList.remove('active');
+    });
+
+    const proposals = document.getElementById('proposals');
+    document.getElementById('proposeBtn').addEventListener('click', () => {
+      const date = document.getElementById('bandDate').value;
+      const slot = document.getElementById('bandSlot').value;
+      if (!date || slot === '') return;
+      const li = document.createElement('li');
+      li.textContent = `${date} slot ${slot}`;
+      li.dataset.votes = '0';
+      const voteBtn = document.createElement('button');
+      voteBtn.textContent = 'Vote';
+      voteBtn.addEventListener('click', () => {
+        li.dataset.votes = (parseInt(li.dataset.votes) + 1).toString();
+        voteBtn.textContent = `Vote (${li.dataset.votes})`;
+      });
+      li.appendChild(voteBtn);
+      proposals.appendChild(li);
     });
   </script>
   <script src="../components/themeToggle.js"></script>


### PR DESCRIPTION
## Summary
- add `band_schedule` table and model for band activity slots
- extend schedule service with helpers to create joint band entries
- expose "Band Plan" tab in schedule planner for proposing and voting on slots
- cover band scheduling with integration test

## Testing
- `pytest backend/tests/schedule/test_band_schedule.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b93efcb36c832596951f309a60291d