### PR TITLE
Add recurring schedule templates and daily scheduler integration

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -409,6 +409,20 @@ def init_db():
         )
         """)
 
+        # Recurring schedule templates
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS recurring_schedule (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            pattern TEXT NOT NULL,
+            hour INTEGER NOT NULL,
+            activity_id INTEGER NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1,
+            FOREIGN KEY(user_id) REFERENCES users(id),
+            FOREIGN KEY(activity_id) REFERENCES activities(id)
+        )
+        """)
+
         # Weekly schedule entries linking users to activities
         cur.execute(
             """

--- a/backend/models/recurring_schedule.py
+++ b/backend/models/recurring_schedule.py
@@ -1,0 +1,75 @@
+import sqlite3
+from typing import List, Dict
+
+from backend.database import DB_PATH
+
+
+def add_template(user_id: int, pattern: str, hour: int, activity_id: int, active: bool = True) -> int:
+    """Create a recurring schedule template."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO recurring_schedule (user_id, pattern, hour, activity_id, active)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (user_id, pattern, hour, activity_id, int(active)),
+        )
+        conn.commit()
+        return cur.lastrowid
+
+
+def update_template(template_id: int, pattern: str, hour: int, activity_id: int, active: bool = True) -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            UPDATE recurring_schedule
+            SET pattern = ?, hour = ?, activity_id = ?, active = ?
+            WHERE id = ?
+            """,
+            (pattern, hour, activity_id, int(active), template_id),
+        )
+        conn.commit()
+
+
+def remove_template(template_id: int) -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("DELETE FROM recurring_schedule WHERE id = ?", (template_id,))
+        conn.commit()
+
+
+def get_templates(user_id: int) -> List[Dict]:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT rs.id, rs.pattern, rs.hour, rs.active,
+                   a.id, a.name, a.duration_hours, a.category
+            FROM recurring_schedule rs
+            JOIN activities a ON rs.activity_id = a.id
+            WHERE rs.user_id = ?
+            ORDER BY rs.id
+            """,
+            (user_id,),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "id": r[0],
+            "pattern": r[1],
+            "hour": r[2],
+            "active": bool(r[3]),
+            "activity": {
+                "id": r[4],
+                "name": r[5],
+                "duration_hours": r[6],
+                "category": r[7],
+            },
+        }
+        for r in rows
+    ]
+
+
+__all__ = ["add_template", "update_template", "remove_template", "get_templates"]

--- a/backend/services/schedule_service.py
+++ b/backend/services/schedule_service.py
@@ -74,6 +74,7 @@ from backend.models import band_schedule as band_schedule_model
 from backend.models import daily_schedule as schedule_model
 from backend.models import default_schedule as default_model
 from backend.models import weekly_schedule as weekly_model
+from backend.models import recurring_schedule as recurring_model
 
 
 class ScheduleService:
@@ -262,6 +263,30 @@ class ScheduleService:
         self, user_id: int, week_start: str, day: str, slot: int
     ) -> None:
         weekly_model.remove_entry(user_id, week_start, day, slot)
+
+    # Recurring templates ---------------------------------------------
+    def add_recurring_template(
+        self, user_id: int, pattern: str, hour: int, activity_id: int, active: bool = True
+    ) -> int:
+        return recurring_model.add_template(user_id, pattern, hour, activity_id, active)
+
+    def update_recurring_template(
+        self,
+        template_id: int,
+        pattern: str,
+        hour: int,
+        activity_id: int,
+        active: bool = True,
+    ) -> None:
+        recurring_model.update_template(
+            template_id, pattern, hour, activity_id, active
+        )
+
+    def remove_recurring_template(self, template_id: int) -> None:
+        recurring_model.remove_template(template_id)
+
+    def get_recurring_templates(self, user_id: int) -> List[Dict]:
+        return recurring_model.get_templates(user_id)
 
     # Default plan logic ----------------------------------------------
     def set_default_plan(self, user_id: int, day_of_week: str, plan: List[Dict]) -> None:

--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -13,12 +13,35 @@ from backend.services.skill_service import skill_service
 from backend.services.social_sentiment_service import social_sentiment_service
 from backend.services.song_popularity_forecast import forecast_service
 
+
+def _pattern_matches(pattern: str, today: date) -> bool:
+    """Return True if a template pattern matches the given date."""
+    p = pattern.lower()
+    if p in {
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    }:
+        return p == today.strftime("%A").lower()
+    if p.startswith("interval:"):
+        try:
+            interval = int(p.split(":", 1)[1])
+        except ValueError:
+            return False
+        return today.toordinal() % interval == 0
+    return False
+
 # Map event_type to handler functions
 def _daily_loop_reset_wrapper() -> None:
     """Rotate challenge and seed schedules for inactive users."""
     daily_loop.rotate_daily_challenge()
-    today = date.today().isoformat()
-    weekday = date.today().strftime("%A").lower()
+    today_date = date.today()
+    today = today_date.isoformat()
+    weekday = today_date.strftime("%A").lower()
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
     cur.execute("SELECT user_id, last_login FROM daily_loop")
@@ -31,6 +54,19 @@ def _daily_loop_reset_wrapper() -> None:
                 schedule_service.schedule_activity(
                     user_id, today, entry["hour"], entry["activity"]["id"]
                 )
+        # Apply recurring templates for all users
+        templates = schedule_service.get_recurring_templates(user_id)
+        for tpl in templates:
+            if not tpl.get("active"):
+                continue
+            if _pattern_matches(tpl["pattern"], today_date):
+                try:
+                    schedule_service.schedule_activity(
+                        user_id, today, tpl["hour"], tpl["activity"]["id"]
+                    )
+                except ValueError:
+                    # Skip conflicts to avoid crashing the reset job
+                    pass
 
 
 EVENT_HANDLERS = {

--- a/backend/tests/schedule/test_recurring_templates.py
+++ b/backend/tests/schedule/test_recurring_templates.py
@@ -1,0 +1,88 @@
+import importlib
+import sqlite3
+from datetime import date
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend import database
+
+
+def setup_app(tmp_path):
+    db_file = tmp_path / "recurring.db"
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+    from backend.models import daily_schedule as ds_model
+    from backend.models import default_schedule as def_model
+    from backend.models import daily_loop as dl_model
+    from backend.models import recurring_schedule as rec_model
+
+    activity_model.DB_PATH = db_file
+    ds_model.DB_PATH = db_file
+    def_model.DB_PATH = db_file
+    dl_model.DB_PATH = db_file
+    rec_model.DB_PATH = db_file
+
+    import backend.services.schedule_service as schedule_service_module
+    importlib.reload(schedule_service_module)
+    import backend.services.scheduler_service as scheduler_service_module
+    importlib.reload(scheduler_service_module)
+    import backend.routes.schedule_routes as routes_module
+    importlib.reload(routes_module)
+
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    client = TestClient(app)
+    return client, schedule_service_module.schedule_service, scheduler_service_module
+
+
+def test_recurring_template_populates_daily_schedule(tmp_path):
+    client, svc, scheduler_module = setup_app(tmp_path)
+    act_id = svc.create_activity("Practice", 2, "music")
+    weekday = date.today().strftime("%A").lower()
+    svc.add_recurring_template(1, weekday, 9, act_id)
+
+    # Ensure user exists in daily_loop with old login date
+    with sqlite3.connect(database.DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO daily_loop (user_id, login_streak, last_login, current_challenge, challenge_progress, reward_claimed) VALUES (1,0,'2024-01-01','',0,0)"
+        )
+        conn.commit()
+
+    scheduler_module.EVENT_HANDLERS["daily_loop_reset"]()
+    today = date.today().isoformat()
+    with sqlite3.connect(database.DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT activity_id FROM daily_schedule WHERE user_id=1 AND date=? AND hour=9",
+            (today,),
+        )
+        row = cur.fetchone()
+        assert row and row[0] == act_id
+
+
+def test_inactive_template_not_applied(tmp_path):
+    client, svc, scheduler_module = setup_app(tmp_path)
+    act_id = svc.create_activity("Practice", 2, "music")
+    weekday = date.today().strftime("%A").lower()
+    template_id = svc.add_recurring_template(1, weekday, 10, act_id)
+    svc.update_recurring_template(template_id, weekday, 10, act_id, active=False)
+
+    with sqlite3.connect(database.DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO daily_loop (user_id, login_streak, last_login, current_challenge, challenge_progress, reward_claimed) VALUES (1,0,'2024-01-01','',0,0)"
+        )
+        conn.commit()
+
+    scheduler_module.EVENT_HANDLERS["daily_loop_reset"]()
+    today = date.today().isoformat()
+    with sqlite3.connect(database.DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT COUNT(*) FROM daily_schedule WHERE user_id=1 AND date=? AND hour=10",
+            (today,),
+        )
+        count = cur.fetchone()[0]
+        assert count == 0


### PR DESCRIPTION
## Summary
- add `recurring_schedule` table for reusable activity templates
- expose CRUD operations for recurring templates and integrate into daily reset
- include tests covering recurring template application and activation toggling

## Testing
- `pytest backend/tests/schedule/test_recurring_templates.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'email_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68b940917c188325a6fd54015317c147