### PR TITLE
Add activity recommendations

### DIFF
--- a/backend/routes/schedule_routes.py
+++ b/backend/routes/schedule_routes.py
@@ -14,12 +14,23 @@ class PlanSelections(BaseModel):
     band: bool = False
 
 
+class RecommendationRequest(BaseModel):
+    user_id: int
+    goals: List[str]
+
+
 @router.post("/plan")
 def generate_plan(data: PlanSelections):
     schedule = plan_service.create_plan(
         social=data.social, career=data.career, band=data.band
     )
     return {"schedule": schedule}
+
+
+@router.post("/recommend")
+def recommend_activities(data: RecommendationRequest):
+    suggestions = plan_service.recommend_activities(data.user_id, data.goals)
+    return {"recommendations": suggestions}
 
 
 class DefaultEntry(BaseModel):

--- a/backend/services/plan_service.py
+++ b/backend/services/plan_service.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List
 
+from backend.services.skill_service import skill_service
+
 
 # Default mapping of category -> list of activity names.
 CATEGORY_MAP: Dict[str, List[str]] = {
@@ -53,6 +55,29 @@ class PlanService:
             schedule.append("rest")
 
         return schedule[: self.slots]
+
+    def recommend_activities(self, user_id: int, goals: List[str]) -> List[str]:
+        """Recommend activities based on the user's skill levels.
+
+        For each goal (a skill name) the user's current level is inspected
+        using :mod:`backend.services.skill_service`.  Low level skills
+        receive "practice" recommendations while higher level skills are
+        encouraged with "perform" suggestions.
+        """
+
+        suggestions: List[str] = []
+        for goal in goals:
+            skill = None
+            for (uid, _), s in skill_service._skills.items():
+                if uid == user_id and s.name == goal:
+                    skill = s
+                    break
+            level = skill.level if skill else 1
+            if level < 5:
+                suggestions.append(f"practice {goal}")
+            else:
+                suggestions.append(f"perform {goal}")
+        return suggestions
 
 
 plan_service = PlanService()

--- a/backend/tests/schedule/test_recommendations.py
+++ b/backend/tests/schedule/test_recommendations.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.models.skill import Skill
+from backend.routes import schedule_routes
+from backend.services.plan_service import PlanService
+from backend.services.skill_service import skill_service
+
+
+def setup_function(_):
+    skill_service._skills.clear()
+
+
+def test_recommendations_use_skill_levels():
+    user_id = 1
+    skill_service._skills[(user_id, 1)] = Skill(id=1, name='guitar', category='music', xp=200, level=3)
+    skill_service._skills[(user_id, 2)] = Skill(id=2, name='songwriting', category='creative', xp=600, level=7)
+    svc = PlanService()
+    recs = svc.recommend_activities(user_id, ['guitar', 'songwriting'])
+    assert recs == ['practice guitar', 'perform songwriting']
+
+
+def test_recommendation_endpoint():
+    user_id = 2
+    skill_service._skills[(user_id, 1)] = Skill(id=1, name='guitar', category='music', xp=50, level=1)
+    app = FastAPI()
+    app.include_router(schedule_routes.router)
+    client = TestClient(app)
+    resp = client.post('/schedule/recommend', json={'user_id': user_id, 'goals': ['guitar']})
+    assert resp.status_code == 200
+    assert resp.json()['recommendations'] == ['practice guitar']

--- a/frontend/components/recommendationPanel.js
+++ b/frontend/components/recommendationPanel.js
@@ -1,0 +1,61 @@
+export async function fetchRecommendations(userId, goals) {
+  const res = await fetch('/api/schedule/recommend', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: userId, goals })
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch recommendations');
+  }
+  return res.json();
+}
+
+export function initRecommendationPanel() {
+  const container = document.getElementById('recommendationPanel');
+  if (!container) return;
+
+  const form = document.createElement('form');
+  const userInput = document.createElement('input');
+  userInput.type = 'number';
+  userInput.placeholder = 'User ID';
+  const goalsInput = document.createElement('input');
+  goalsInput.placeholder = 'Goals (comma separated)';
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.textContent = 'Get Recommendations';
+
+  form.appendChild(userInput);
+  form.appendChild(goalsInput);
+  form.appendChild(submit);
+  container.appendChild(form);
+
+  const list = document.createElement('ul');
+  container.appendChild(list);
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const userId = parseInt(userInput.value || '0', 10);
+    const goals = goalsInput.value
+      .split(',')
+      .map((g) => g.trim())
+      .filter((g) => g);
+    let data;
+    try {
+      data = await fetchRecommendations(userId, goals);
+    } catch {
+      data = { recommendations: [] };
+    }
+    list.innerHTML = '';
+    data.recommendations.forEach((rec) => {
+      const li = document.createElement('li');
+      li.textContent = rec;
+      list.appendChild(li);
+    });
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initRecommendationPanel);
+}
+
+export default { initRecommendationPanel, fetchRecommendations };


### PR DESCRIPTION
## Summary
- recommend activities based on user skills
- expose POST /schedule/recommend
- add recommendation panel in frontend

## Testing
- `pytest backend/tests/schedule/test_recommendations.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b941a6a0708325a1879543c9bc9f20