### PR TITLE
Track schedule completion and expose stats

### DIFF
--- a/backend/models/activity_log.py
+++ b/backend/models/activity_log.py
@@ -1,0 +1,80 @@
+import json
+import sqlite3
+from typing import Dict, List
+
+from backend.database import DB_PATH
+
+
+def _ensure_table(cur: sqlite3.Cursor) -> None:
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS activity_log (
+            user_id INTEGER NOT NULL,
+            date TEXT NOT NULL,
+            slot INTEGER NOT NULL,
+            activity_id INTEGER NOT NULL,
+            outcome_json TEXT NOT NULL,
+            PRIMARY KEY (user_id, date, slot),
+            FOREIGN KEY(user_id, date, slot) REFERENCES daily_schedule(user_id, date, slot),
+            FOREIGN KEY(activity_id) REFERENCES activities(id)
+        )
+        """
+    )
+    cur.execute("PRAGMA table_info(activity_log)")
+    columns = [row[1] for row in cur.fetchall()]
+    if "slot" not in columns:
+        cur.execute("ALTER TABLE activity_log RENAME TO activity_log_old")
+        cur.execute(
+            """
+            CREATE TABLE activity_log (
+                user_id INTEGER NOT NULL,
+                date TEXT NOT NULL,
+                slot INTEGER NOT NULL,
+                activity_id INTEGER NOT NULL,
+                outcome_json TEXT NOT NULL,
+                PRIMARY KEY (user_id, date, slot),
+                FOREIGN KEY(user_id, date, slot) REFERENCES daily_schedule(user_id, date, slot),
+                FOREIGN KEY(activity_id) REFERENCES activities(id)
+            )
+            """
+        )
+        cur.execute(
+            "INSERT INTO activity_log (user_id, date, slot, activity_id, outcome_json) SELECT user_id, date, 0, activity_id, outcome_json FROM activity_log_old"
+        )
+        cur.execute("DROP TABLE activity_log_old")
+
+
+def record_outcome(
+    user_id: int, date: str, slot: int, activity_id: int, outcome: Dict
+) -> None:
+    """Persist an activity outcome linked to the schedule entry."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        _ensure_table(cur)
+        cur.execute(
+            """
+            INSERT OR REPLACE INTO activity_log
+                (user_id, date, slot, activity_id, outcome_json)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (user_id, date, slot, activity_id, json.dumps(outcome)),
+        )
+        conn.commit()
+
+
+def get_day_logs(user_id: int, date: str) -> List[Dict]:
+    """Return all logged outcomes for a given day."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        _ensure_table(cur)
+        cur.execute(
+            "SELECT slot, activity_id, outcome_json FROM activity_log WHERE user_id=? AND date=?",
+            (user_id, date),
+        )
+        rows = cur.fetchall()
+    return [
+        {"slot": r[0], "activity_id": r[1], "outcome": json.loads(r[2])} for r in rows
+    ]
+
+
+__all__ = ["record_outcome", "get_day_logs"]

--- a/backend/routes/schedule_routes.py
+++ b/backend/routes/schedule_routes.py
@@ -1,7 +1,9 @@
-from fastapi import APIRouter
-from pydantic import BaseModel
 from typing import List
 
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from backend.services.activity_processor import evaluate_schedule_completion
 from backend.services.plan_service import plan_service
 from backend.services.schedule_service import schedule_service
 
@@ -91,3 +93,8 @@ def schedule_daily_activity(user_id: int, date: str, entry: DailyEntry):
         return {"status": "partial", "conflicts": conflicts}
 
     return {"status": "ok"}
+
+
+@router.get("/stats/{user_id}/{date}")
+def get_schedule_stats(user_id: int, date: str):
+    return evaluate_schedule_completion(user_id, date)

--- a/backend/tests/schedule/test_schedule_completion.py
+++ b/backend/tests/schedule/test_schedule_completion.py
@@ -1,0 +1,66 @@
+import importlib
+import sqlite3
+from datetime import date
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend import database
+
+
+def setup_app(tmp_path):
+    db_file = tmp_path / "sched.db"
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+    from backend.models import activity_log as log_model
+    from backend.models import daily_schedule as schedule_model
+
+    activity_model.DB_PATH = db_file
+    schedule_model.DB_PATH = db_file
+    log_model.DB_PATH = db_file
+
+    import backend.services.schedule_service as schedule_module
+    importlib.reload(schedule_module)
+
+    import backend.services.activity_processor as processor_module
+    processor_module.DB_PATH = db_file
+    importlib.reload(processor_module)
+
+    import backend.routes.schedule_routes as routes_module
+    importlib.reload(routes_module)
+
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    client = TestClient(app)
+    return client, schedule_module.schedule_service, processor_module, log_model
+
+
+def test_schedule_completion_and_bonus(tmp_path):
+    client, svc, processor, log_model = setup_app(tmp_path)
+    uid = 1
+    day = date.today().isoformat()
+
+    act1 = svc.create_activity("Practice", 1, "music")
+    act2 = svc.create_activity("Workout", 1, "health")
+    svc.schedule_activity(uid, day, 0, act1)
+    svc.schedule_activity(uid, day, 4, act2)
+
+    log_model.record_outcome(uid, day, 0, act1, {"xp": 10})
+    stats = processor.evaluate_schedule_completion(uid, day)
+    assert stats["completion"] == 50.0
+    with sqlite3.connect(database.DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT xp FROM user_xp WHERE user_id=?", (uid,))
+        assert cur.fetchone() is None
+
+    log_model.record_outcome(uid, day, 4, act2, {"xp": 10})
+    resp = client.get(f"/schedule/stats/{uid}/{day}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["completion"] == 100.0
+    with sqlite3.connect(database.DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT xp FROM user_xp WHERE user_id=?", (uid,))
+        assert cur.fetchone()[0] == 50

--- a/frontend/components/scheduleStats.js
+++ b/frontend/components/scheduleStats.js
@@ -1,0 +1,27 @@
+export function initScheduleStats() {
+  const container = document.getElementById('scheduleStats');
+  if (!container) return;
+  const userInput = container.querySelector('#statsUserId');
+  const dateInput = container.querySelector('#statsDate');
+  const btn = container.querySelector('#statsBtn');
+  const output = container.querySelector('#statsOutput');
+
+  btn.addEventListener('click', async () => {
+    const uid = userInput.value;
+    const day = dateInput.value;
+    if (!uid || !day) return;
+    try {
+      const res = await fetch(`/api/schedule/stats/${uid}/${day}`);
+      const data = await res.json();
+      output.textContent = `Completion: ${data.completion}%`;
+    } catch {
+      output.textContent = 'Error loading stats';
+    }
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initScheduleStats);
+}
+
+export default { initScheduleStats };

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -14,6 +14,13 @@
 </head>
 <body>
   <h2>Schedule Planner</h2>
+  <div id="scheduleStats">
+    <h3>Daily Stats</h3>
+    <input type="number" id="statsUserId" placeholder="User ID" />
+    <input type="date" id="statsDate" />
+    <button id="statsBtn">Load</button>
+    <span id="statsOutput"></span>
+  </div>
   <div class="tabs">
     <button id="quickPlanTab" class="active">Quick Plan</button>
     <button id="advancedPlannerTab">Advanced Planner</button>
@@ -31,6 +38,7 @@
   </div>
   <script type="module" src="../components/quickPlan.js"></script>
   <script type="module" src="../components/advancedPlanner.js"></script>
+  <script type="module" src="../components/scheduleStats.js"></script>
   <script>
     const quickTab = document.getElementById('quickPlanTab');
     const advTab = document.getElementById('advancedPlannerTab');


### PR DESCRIPTION
## Summary
- log activity outcomes with schedule slot references
- compute daily schedule completion and reward full completion
- expose `/schedule/stats` endpoint and frontend widget for completion stats

## Testing
- `ruff check backend/models/activity_log.py backend/services/activity_processor.py backend/routes/schedule_routes.py backend/tests/schedule/test_schedule_completion.py`
- `pytest backend/tests/schedule/test_schedule_completion.py`


------
https://chatgpt.com/codex/tasks/task_e_68b94274f7008325b78a87a021f71c19