### PR TITLE
Add schedule audit logging and history

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -453,6 +453,21 @@ def init_db():
         )
         """)
 
+        # Audit log for schedule changes capturing before/after states
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schedule_audit (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                date TEXT NOT NULL,
+                slot INTEGER NOT NULL,
+                before_state TEXT,
+                after_state TEXT,
+                changed_at TEXT DEFAULT (datetime('now'))
+            )
+            """,
+        )
+
         # Band schedule entries linking bands to activities
         cur.execute("""
         CREATE TABLE IF NOT EXISTS band_schedule (

--- a/backend/routes/schedule_routes.py
+++ b/backend/routes/schedule_routes.py
@@ -98,3 +98,9 @@ def schedule_daily_activity(user_id: int, date: str, entry: DailyEntry):
 @router.get("/stats/{user_id}/{date}")
 def get_schedule_stats(user_id: int, date: str):
     return evaluate_schedule_completion(user_id, date)
+
+
+@router.get("/history/{date}")
+def get_schedule_history(date: str):
+    history = schedule_service.get_schedule_history(date)
+    return {"history": history}

--- a/backend/tests/schedule/test_schedule_history.py
+++ b/backend/tests/schedule/test_schedule_history.py
@@ -1,0 +1,48 @@
+import importlib
+import sqlite3
+from pathlib import Path
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend import database
+
+
+def setup_app(tmp_path):
+    db_file = tmp_path / "history.db"
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+    from backend.models import daily_schedule as schedule_model
+
+    activity_model.DB_PATH = db_file
+    schedule_model.DB_PATH = db_file
+
+    import backend.services.schedule_service as service_module
+    importlib.reload(service_module)
+    import backend.routes.schedule_routes as routes_module
+    importlib.reload(routes_module)
+
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    client = TestClient(app)
+    return client, service_module.schedule_service
+
+
+def test_history_endpoint(tmp_path):
+    client, svc = setup_app(tmp_path)
+
+    act1 = svc.create_activity("Practice", 1.0, "music")
+    act2 = svc.create_activity("Workout", 1.0, "fitness")
+
+    svc.schedule_activity(1, "2024-01-01", 0, act1)
+    svc.update_schedule_entry(1, "2024-01-01", 0, act2)
+    svc.remove_schedule_entry(1, "2024-01-01", 0)
+
+    resp = client.get("/schedule/history/2024-01-01")
+    assert resp.status_code == 200
+    data = resp.json()["history"]
+    assert len(data) == 3
+    assert data[0]["before"] is None and data[0]["after"]["activity_id"] == act1
+    assert data[1]["before"]["activity_id"] == act1 and data[1]["after"]["activity_id"] == act2
+    assert data[2]["before"]["activity_id"] == act2 and data[2]["after"] is None

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -21,6 +21,12 @@
     <button id="statsBtn">Load</button>
     <span id="statsOutput"></span>
   </div>
+  <div id="scheduleHistory">
+    <h3>Schedule History</h3>
+    <input type="date" id="historyDate" />
+    <button id="historyBtn">Load</button>
+    <ul id="historyList"></ul>
+  </div>
   <div class="tabs">
     <button id="quickPlanTab" class="active">Quick Plan</button>
     <button id="advancedPlannerTab">Advanced Planner</button>
@@ -87,6 +93,20 @@
       });
       li.appendChild(voteBtn);
       proposals.appendChild(li);
+    });
+
+    document.getElementById('historyBtn').addEventListener('click', async () => {
+      const date = document.getElementById('historyDate').value;
+      if (!date) return;
+      const res = await fetch(`/schedule/history/${date}`);
+      const data = await res.json();
+      const list = document.getElementById('historyList');
+      list.innerHTML = '';
+      for (const h of data.history) {
+        const li = document.createElement('li');
+        li.textContent = `slot ${h.slot}: ${JSON.stringify(h.before)} -> ${JSON.stringify(h.after)}`;
+        list.appendChild(li);
+      }
     });
   </script>
   <script src="../components/themeToggle.js"></script>


### PR DESCRIPTION
## Summary
- record schedule mutations in new `schedule_audit` table
- expose schedule change history via service, API, and frontend view
- test schedule history endpoint

## Testing
- `ruff check backend/database.py backend/services/schedule_service.py backend/routes/schedule_routes.py backend/tests/schedule/test_schedule_history.py frontend/pages/schedule.html`
- `pytest backend/tests/schedule/test_schedule_history.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b948c021f48325b795dd79dad29ab6