### PR TITLE
Add daily schedule ICS export

### DIFF
--- a/backend/services/calendar_export.py
+++ b/backend/services/calendar_export.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from backend.services.schedule_service import schedule_service
+
+
+def daily_schedule_to_ics(user_id: int, date: str) -> str:
+    """Return an ICS string for a user's schedule on a given date."""
+
+    events = schedule_service.get_daily_schedule(user_id, date)
+    now_stamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Rockmundo//Schedule//EN",
+    ]
+    base = datetime.fromisoformat(date)
+    for entry in events:
+        start_dt = base + timedelta(minutes=entry["slot"] * 15)
+        duration = entry["activity"].get("duration_hours", 0) or 0
+        end_dt = start_dt + timedelta(hours=duration)
+        lines.extend(
+            [
+                "BEGIN:VEVENT",
+                f"UID:{user_id}-{date}-{entry['slot']}",
+                f"DTSTAMP:{now_stamp}",
+                f"DTSTART:{start_dt.strftime('%Y%m%dT%H%M%S')}",
+                f"DTEND:{end_dt.strftime('%Y%m%dT%H%M%S')}",
+                f"SUMMARY:{entry['activity']['name']}",
+                "END:VEVENT",
+            ]
+        )
+    lines.append("END:VCALENDAR")
+    return "\r\n".join(lines) + "\r\n"
+
+
+__all__ = ["daily_schedule_to_ics"]

--- a/backend/tests/schedule/test_calendar_export.py
+++ b/backend/tests/schedule/test_calendar_export.py
@@ -1,0 +1,46 @@
+import importlib
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend import database
+
+
+def setup_app(tmp_path):
+    db_file = tmp_path / "calendar.db"
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+    from backend.models import daily_schedule as schedule_model
+
+    activity_model.DB_PATH = db_file
+    schedule_model.DB_PATH = db_file
+
+    import backend.services.schedule_service as service_module
+    importlib.reload(service_module)
+    import backend.services.calendar_export as export_module
+    importlib.reload(export_module)
+    import backend.routes.schedule_routes as routes_module
+    importlib.reload(routes_module)
+
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    client = TestClient(app)
+    return client, service_module.schedule_service
+
+
+def test_export_ics(tmp_path):
+    client, svc = setup_app(tmp_path)
+
+    act_id = svc.create_activity("Practice", 1.0, "music")
+    svc.schedule_activity(1, "2024-01-01", 4, act_id)
+
+    resp = client.get("/schedule/export/ics", params={"user_id": 1, "date": "2024-01-01"})
+    assert resp.status_code == 200
+    text = resp.text
+    assert "BEGIN:VCALENDAR" in text
+    assert "SUMMARY:Practice" in text
+    assert "DTSTART:20240101T010000" in text
+    assert "DTEND:20240101T020000" in text

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -27,6 +27,12 @@
     <button id="historyBtn">Load</button>
     <ul id="historyList"></ul>
   </div>
+  <div id="scheduleExport">
+    <h3>Export Schedule</h3>
+    <input type="number" id="exportUserId" placeholder="User ID" />
+    <input type="date" id="exportDate" />
+    <button id="exportBtn">Download ICS</button>
+  </div>
   <div class="tabs">
     <button id="quickPlanTab" class="active">Quick Plan</button>
     <button id="advancedPlannerTab">Advanced Planner</button>
@@ -107,6 +113,12 @@
         li.textContent = `slot ${h.slot}: ${JSON.stringify(h.before)} -> ${JSON.stringify(h.after)}`;
         list.appendChild(li);
       }
+    });
+    document.getElementById('exportBtn').addEventListener('click', () => {
+      const userId = document.getElementById('exportUserId').value;
+      const date = document.getElementById('exportDate').value;
+      if (!userId || !date) return;
+      window.location = `/schedule/export/ics?user_id=${userId}&date=${date}`;
     });
   </script>
   <script src="../components/themeToggle.js"></script>


### PR DESCRIPTION
## Summary
- implement service to convert daily schedule entries to an ICS calendar
- expose calendar export via `/schedule/export/ics` route and add front-end download button
- test calendar serialization of schedule entries

## Testing
- `pytest backend/tests/schedule/test_calendar_export.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b94c70e83483258fd87929da995355