### PR TITLE
Add touch-friendly mobile schedule planner

### DIFF
--- a/frontend/components/mobilePlanner.js
+++ b/frontend/components/mobilePlanner.js
@@ -1,0 +1,52 @@
+import { fetchSchedule, saveSchedule } from './scheduleApi.js';
+import { renderSchedule } from './scheduleRenderer.js';
+
+export function buildMobileForm() {
+  const form = document.createElement('form');
+  const time = document.createElement('input');
+  time.type = 'time';
+  time.name = 'time';
+  const value = document.createElement('input');
+  value.type = 'text';
+  value.name = 'value';
+  value.placeholder = 'Activity';
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.textContent = 'Add';
+  form.append(time, value, submit);
+  return form;
+}
+
+export function initMobilePlanner() {
+  const container = document.getElementById('mobilePlanner');
+  if (!container) return;
+
+  const form = buildMobileForm();
+  const display = document.createElement('div');
+  display.id = 'mobileDisplay';
+  container.append(form, display);
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = new FormData(form);
+    const time = data.get('time');
+    const value = data.get('value');
+    if (!time || !value) return;
+    const payload = { mode: 'hourly', entries: { [time]: value } };
+    const result = await saveSchedule(payload).catch(() => null);
+    renderSchedule(display, result || payload);
+    form.reset();
+  });
+
+  fetchSchedule()
+    .then((sched) => {
+      if (sched) renderSchedule(display, sched);
+    })
+    .catch(() => {});
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initMobilePlanner);
+}
+
+export default { initMobilePlanner, buildMobileForm };

--- a/frontend/pages/schedule_mobile.html
+++ b/frontend/pages/schedule_mobile.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mobile Schedule Planner</title>
+  <link rel="stylesheet" href="../index.css" />
+  <link rel="stylesheet" href="../styles/schedule.css" />
+</head>
+<body>
+  <h2>Mobile Schedule Planner</h2>
+  <div id="mobilePlanner"></div>
+  <script type="module" src="../components/mobilePlanner.js"></script>
+</body>
+</html>

--- a/frontend/styles/schedule.css
+++ b/frontend/styles/schedule.css
@@ -1,0 +1,19 @@
+#mobilePlanner form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 320px;
+}
+
+#mobilePlanner input,
+#mobilePlanner button {
+  font-size: 1.1rem;
+  padding: 0.5rem;
+}
+
+@media (min-width: 600px) {
+  #mobilePlanner form {
+    flex-direction: row;
+    align-items: center;
+  }
+}

--- a/frontend/tests/schedule/test_mobile_ui.js
+++ b/frontend/tests/schedule/test_mobile_ui.js
@@ -1,0 +1,44 @@
+import { initMobilePlanner } from '../../components/mobilePlanner.js';
+import sched from './fixtures/schedule.json';
+import { vi } from 'vitest';
+
+describe('mobile planner', () => {
+  test('renders and saves via touch controls', async () => {
+    document.body.innerHTML = '<div id="mobilePlanner"></div>';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ mode: 'hourly', entries: sched }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ mode: 'hourly', entries: { '01:00': 'Jam' } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    const originalFetch = global.fetch;
+    vi.stubGlobal('fetch', fetchMock);
+
+    initMobilePlanner();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(document.getElementById('mobileDisplay').textContent).toContain('Sleep');
+
+    const time = document.querySelector('input[name="time"]');
+    const value = document.querySelector('input[name="value"]');
+    time.value = '01:00';
+    value.value = 'Jam';
+    document.querySelector('#mobilePlanner form').dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fetchMock.mock.calls[1][0]).toBe('/api/schedule');
+    expect(document.getElementById('mobileDisplay').textContent).toContain('Jam');
+
+    global.fetch = originalFetch;
+  });
+});

--- a/frontend/tests/vitest.config.ts
+++ b/frontend/tests/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
-    setupFiles: './setup.ts'
+    setupFiles: './setup.ts',
+    include: ['**/*.{test,spec}.{js,ts,jsx,tsx}', '**/test_*.js']
   }
 });


### PR DESCRIPTION
## Summary
- Add `schedule_mobile.html` for touch-friendly schedule planning
- Factor reusable logic into `mobilePlanner.js`
- Include responsive styles in `styles/schedule.css`
- Add mobile UI tests and configure Vitest to run them

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68b94e550d248325ac10b1d6608f052d