### PR TITLE
Add schedule template presets with apply functionality

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -412,6 +412,26 @@ def init_db():
         )
         """)
 
+        # Named default schedule templates
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS default_schedule_templates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """)
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS default_schedule_entries (
+            template_id INTEGER NOT NULL,
+            hour INTEGER NOT NULL,
+            activity_id INTEGER NOT NULL,
+            PRIMARY KEY (template_id, hour),
+            FOREIGN KEY(template_id) REFERENCES default_schedule_templates(id),
+            FOREIGN KEY(activity_id) REFERENCES activities(id)
+        )
+        """)
+
         # Recurring schedule templates
         cur.execute("""
         CREATE TABLE IF NOT EXISTS recurring_schedule (

--- a/backend/models/default_schedule_templates.py
+++ b/backend/models/default_schedule_templates.py
@@ -1,0 +1,84 @@
+import sqlite3
+import sqlite3
+from typing import Iterable, List, Dict, Tuple
+
+from backend.database import DB_PATH
+
+
+def create_template(user_id: int, name: str, entries: Iterable[Tuple[int, int]]) -> int:
+    """Create a new schedule template with the provided entries."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO default_schedule_templates (user_id, name) VALUES (?, ?)",
+            (user_id, name),
+        )
+        template_id = cur.lastrowid
+        for hour, activity_id in entries:
+            cur.execute(
+                "INSERT INTO default_schedule_entries (template_id, hour, activity_id) VALUES (?, ?, ?)",
+                (template_id, hour, activity_id),
+            )
+        conn.commit()
+    return template_id
+
+
+def set_entries(template_id: int, entries: Iterable[Tuple[int, int]]) -> None:
+    """Replace all entries for a template."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "DELETE FROM default_schedule_entries WHERE template_id = ?",
+            (template_id,),
+        )
+        for hour, activity_id in entries:
+            cur.execute(
+                "INSERT INTO default_schedule_entries (template_id, hour, activity_id) VALUES (?, ?, ?)",
+                (template_id, hour, activity_id),
+            )
+        conn.commit()
+
+
+def delete_template(template_id: int) -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "DELETE FROM default_schedule_entries WHERE template_id = ?",
+            (template_id,),
+        )
+        cur.execute(
+            "DELETE FROM default_schedule_templates WHERE id = ?",
+            (template_id,),
+        )
+        conn.commit()
+
+
+def list_templates(user_id: int) -> List[Dict]:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT id, name FROM default_schedule_templates WHERE user_id = ? ORDER BY id",
+            (user_id,),
+        )
+        rows = cur.fetchall()
+    return [{"id": r[0], "name": r[1]} for r in rows]
+
+
+def get_entries(template_id: int) -> List[Tuple[int, int]]:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT hour, activity_id FROM default_schedule_entries WHERE template_id = ? ORDER BY hour",
+            (template_id,),
+        )
+        rows = cur.fetchall()
+    return [(r[0], r[1]) for r in rows]
+
+
+__all__ = [
+    "create_template",
+    "set_entries",
+    "delete_template",
+    "list_templates",
+    "get_entries",
+]

--- a/backend/routes/schedule_routes.py
+++ b/backend/routes/schedule_routes.py
@@ -118,3 +118,33 @@ def export_schedule_ics(user_id: int, date: str):
         media_type="text/calendar",
         headers={"Content-Disposition": 'attachment; filename="schedule.ics"'},
     )
+
+
+class TemplateEntry(BaseModel):
+    hour: int
+    activity_id: int
+
+
+class TemplateCreate(BaseModel):
+    name: str
+    entries: List[TemplateEntry]
+
+
+@router.post("/templates/{user_id}")
+def create_template(user_id: int, data: TemplateCreate):
+    template_id = schedule_service.create_template(
+        user_id, data.name, [e.dict() for e in data.entries]
+    )
+    return {"id": template_id}
+
+
+@router.get("/templates/{user_id}")
+def list_templates(user_id: int):
+    templates = schedule_service.list_templates(user_id)
+    return {"templates": templates}
+
+
+@router.post("/apply-template/{user_id}/{date}/{template_id}")
+def apply_template(user_id: int, date: str, template_id: int):
+    schedule_service.apply_template(user_id, date, template_id)
+    return {"status": "ok"}

--- a/backend/tests/schedule/test_schedule_templates.py
+++ b/backend/tests/schedule/test_schedule_templates.py
@@ -1,0 +1,61 @@
+import importlib
+import importlib
+import sqlite3
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend import database
+
+
+def setup_app(tmp_path):
+    db_file = tmp_path / "templates.db"
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+    from backend.models import daily_schedule as ds_model
+    from backend.models import default_schedule as def_model
+    from backend.models import default_schedule_templates as tmpl_model
+
+    activity_model.DB_PATH = db_file
+    ds_model.DB_PATH = db_file
+    def_model.DB_PATH = db_file
+    tmpl_model.DB_PATH = db_file
+
+    import backend.services.schedule_service as schedule_service_module
+    importlib.reload(schedule_service_module)
+    import backend.routes.schedule_routes as routes_module
+    importlib.reload(routes_module)
+
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    client = TestClient(app)
+    return client, schedule_service_module.schedule_service
+
+
+def test_create_and_apply_template(tmp_path):
+    client, svc = setup_app(tmp_path)
+    act_id = svc.create_activity("Practice", 1, "music")
+
+    resp = client.post(
+        "/schedule/templates/1",
+        json={"name": "morning", "entries": [{"hour": 9, "activity_id": act_id}]},
+    )
+    assert resp.status_code == 200
+    template_id = resp.json()["id"]
+
+    resp = client.get("/schedule/templates/1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(t["id"] == template_id for t in data["templates"])
+
+    resp = client.post(f"/schedule/apply-template/1/2024-01-01/{template_id}")
+    assert resp.status_code == 200
+
+    with sqlite3.connect(database.DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT activity_id FROM daily_schedule WHERE user_id=1 AND date='2024-01-01' AND slot=36"
+        )
+        row = cur.fetchone()
+        assert row and row[0] == act_id

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -27,6 +27,17 @@
     <button id="historyBtn">Load</button>
     <ul id="historyList"></ul>
   </div>
+  <div id="templateManager">
+    <h3>Templates</h3>
+    <input type="number" id="tmplUser" placeholder="User ID" />
+    <input type="text" id="tmplDay" placeholder="Day of Week" />
+    <input type="text" id="tmplName" placeholder="Template Name" />
+    <button id="saveTemplateBtn">Save Default as Template</button>
+    <br/>
+    <select id="tmplSelect"></select>
+    <input type="date" id="tmplDate" />
+    <button id="applyTemplateBtn">Apply Template</button>
+  </div>
   <div id="scheduleExport">
     <h3>Export Schedule</h3>
     <input type="number" id="exportUserId" placeholder="User ID" />
@@ -119,6 +130,45 @@
       const date = document.getElementById('exportDate').value;
       if (!userId || !date) return;
       window.location = `/schedule/export/ics?user_id=${userId}&date=${date}`;
+    });
+
+    const tmplSelect = document.getElementById('tmplSelect');
+    async function loadTemplates() {
+      const uid = document.getElementById('tmplUser').value;
+      if (!uid) return;
+      const res = await fetch(`/schedule/templates/${uid}`);
+      const data = await res.json();
+      tmplSelect.innerHTML = '';
+      for (const t of data.templates) {
+        const opt = document.createElement('option');
+        opt.value = t.id;
+        opt.textContent = t.name;
+        tmplSelect.appendChild(opt);
+      }
+    }
+    document.getElementById('tmplUser').addEventListener('change', loadTemplates);
+
+    document.getElementById('saveTemplateBtn').addEventListener('click', async () => {
+      const uid = document.getElementById('tmplUser').value;
+      const day = document.getElementById('tmplDay').value;
+      const name = document.getElementById('tmplName').value;
+      if (!uid || !day || !name) return;
+      const res = await fetch(`/schedule/default-plan/${uid}/${day}`);
+      const plan = await res.json();
+      await fetch(`/schedule/templates/${uid}`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({name, entries: plan.plan})
+      });
+      await loadTemplates();
+    });
+
+    document.getElementById('applyTemplateBtn').addEventListener('click', async () => {
+      const uid = document.getElementById('tmplUser').value;
+      const date = document.getElementById('tmplDate').value;
+      const tid = tmplSelect.value;
+      if (!uid || !date || !tid) return;
+      await fetch(`/schedule/apply-template/${uid}/${date}/${tid}`, {method: 'POST'});
     });
   </script>
   <script src="../components/themeToggle.js"></script>


### PR DESCRIPTION
## Summary
- Add `default_schedule_templates` and `default_schedule_entries` tables to persist named schedule presets
- Provide model and service helpers to manage templates and apply them to daily schedules
- Expose API endpoints and frontend controls for saving and applying templates
- Test template creation and application

## Testing
- `pytest backend/tests/schedule/test_schedule_templates.py -q`
- `pytest backend/tests/schedule/test_default_plan.py backend/tests/schedule/test_recurring_templates.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b969f007608325a990a9301c8a4486