### PR TITLE
Add schedule plan simulation and summary panel

### DIFF
--- a/backend/routes/schedule_routes.py
+++ b/backend/routes/schedule_routes.py
@@ -1,13 +1,11 @@
 from typing import List
 
-from typing import List
-
 from fastapi import APIRouter, Response
 from pydantic import BaseModel
 
+from backend.services.calendar_export import daily_schedule_to_ics
 from backend.services.plan_service import plan_service
 from backend.services.schedule_service import schedule_service
-from backend.services.calendar_export import daily_schedule_to_ics
 
 router = APIRouter(prefix="/schedule", tags=["schedule"])
 
@@ -35,6 +33,22 @@ def generate_plan(data: PlanSelections):
 def recommend_activities(data: RecommendationRequest):
     suggestions = plan_service.recommend_activities(data.user_id, data.goals)
     return {"recommendations": suggestions}
+
+
+class SimulationEntry(BaseModel):
+    activity_id: int
+
+
+class PlanSimulation(BaseModel):
+    user_id: int
+    entries: List[SimulationEntry]
+
+
+@router.post("/simulate")
+def simulate_schedule(data: PlanSimulation):
+    from backend.services.activity_processor import simulate_plan
+
+    return simulate_plan(data.user_id, [e.model_dump() for e in data.entries])
 
 
 class DefaultEntry(BaseModel):

--- a/backend/tests/schedule/test_plan_simulation.py
+++ b/backend/tests/schedule/test_plan_simulation.py
@@ -1,0 +1,48 @@
+import importlib
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend import database
+
+
+def setup_app(tmp_path):
+    db_file = tmp_path / "sim.db"
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+
+    activity_model.DB_PATH = db_file
+
+    import backend.services.activity_processor as ap_module
+    importlib.reload(ap_module)
+
+    import backend.routes.schedule_routes as routes_module
+    importlib.reload(routes_module)
+
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    client = TestClient(app)
+    return client, ap_module, activity_model
+
+
+def test_plan_simulation(tmp_path):
+    client, ap_module, activity_model = setup_app(tmp_path)
+    act1 = activity_model.create_activity(
+        "Practice", 1, "music", rewards_json=json.dumps({"xp": 20, "energy": -5})
+    )
+    act2 = activity_model.create_activity(
+        "Rest", 1, "rest", rewards_json=json.dumps({"xp": 0, "energy": 10})
+    )
+
+    result = ap_module.simulate_plan(1, [{"activity_id": act1}, {"activity_id": act2}])
+    assert result == {"xp": 20, "energy": 5}
+
+    resp = client.post(
+        "/schedule/simulate",
+        json={"user_id": 1, "entries": [{"activity_id": act1}, {"activity_id": act2}]},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"xp": 20, "energy": 5}


### PR DESCRIPTION
## Summary
- predict XP and energy for planned activities with new `simulate_plan`
- expose `POST /schedule/simulate` endpoint
- show projected gains and fatigue in advanced planner UI
- test schedule plan simulation

## Testing
- `ruff check backend/services/activity_processor.py backend/routes/schedule_routes.py backend/tests/schedule/test_plan_simulation.py`
- `pytest backend/tests/schedule/test_plan_simulation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b96b14d3d88325892d6cc0b8d4541e