### PR TITLE
Add schedule analytics service and charts

### DIFF
--- a/backend/routes/schedule_routes.py
+++ b/backend/routes/schedule_routes.py
@@ -3,6 +3,7 @@ from typing import List
 from fastapi import APIRouter, Response
 from pydantic import BaseModel
 
+from backend.services.analytics_service import schedule_analytics_service
 from backend.services.calendar_export import daily_schedule_to_ics
 from backend.services.plan_service import plan_service
 from backend.services.schedule_service import schedule_service
@@ -84,6 +85,12 @@ def set_weekly_schedule(user_id: int, week_start: str, entries: List[WeeklyEntry
 def get_weekly_schedule(user_id: int, week_start: str):
     schedule = schedule_service.get_weekly_schedule(user_id, week_start)
     return {"schedule": schedule}
+
+
+@router.get("/analytics/{user_id}/{week_start}")
+def get_schedule_analytics(user_id: int, week_start: str):
+    data = schedule_analytics_service.weekly_totals(user_id, week_start)
+    return data
 
 
 class DailyEntry(BaseModel):

--- a/backend/tests/schedule/test_schedule_analytics.py
+++ b/backend/tests/schedule/test_schedule_analytics.py
@@ -1,0 +1,46 @@
+import importlib
+
+from backend import database
+
+
+def setup_service(tmp_path):
+    db_file = tmp_path / "sched.db"
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+    from backend.models import daily_schedule as schedule_model
+
+    activity_model.DB_PATH = db_file
+    schedule_model.DB_PATH = db_file
+
+    analytics_module = importlib.reload(
+        importlib.import_module("backend.services.analytics_service")
+    )
+    return analytics_module.schedule_analytics_service, activity_model, schedule_model
+
+def test_weekly_totals_and_rest_compliance(tmp_path):
+    svc, activity_model, schedule_model = setup_service(tmp_path)
+    uid = 1
+    week_start = "2024-01-01"
+
+    work = activity_model.create_activity("Work", 2, "work")
+    rest = activity_model.create_activity("Rest", 4, "rest")
+    sleep = activity_model.create_activity("Sleep", 6, "sleep")
+
+    schedule_model.add_entry(uid, week_start, 0, work)
+    schedule_model.add_entry(uid, week_start, 4, rest)
+
+    day2 = "2024-01-02"
+    schedule_model.add_entry(uid, day2, 0, sleep)
+    schedule_model.add_entry(uid, day2, 6, work)
+
+    data = svc.weekly_totals(uid, week_start)
+    assert data["totals"]["work"] == 4
+    assert data["totals"]["rest"] == 4
+    assert data["totals"]["sleep"] == 6
+
+    rest_lookup = {r["date"]: r for r in data["rest"]}
+    assert rest_lookup[week_start]["compliant"] is False
+    assert rest_lookup[day2]["compliant"] is True
+

--- a/frontend/components/chartUtils.js
+++ b/frontend/components/chartUtils.js
@@ -1,0 +1,19 @@
+export function renderBarChart(canvas, labels, data) {
+  if (!canvas) return;
+  if (canvas._chart) canvas._chart.destroy();
+  canvas._chart = new Chart(canvas.getContext('2d'), {
+    type: 'bar',
+    data: { labels, datasets: [{ label: 'Hours', data }] },
+  });
+}
+
+export function renderLineChart(canvas, labels, data) {
+  if (!canvas) return;
+  if (canvas._chart) canvas._chart.destroy();
+  canvas._chart = new Chart(canvas.getContext('2d'), {
+    type: 'line',
+    data: { labels, datasets: [{ label: 'Rest', data }] },
+  });
+}
+
+export default { renderBarChart, renderLineChart };

--- a/frontend/components/scheduleAnalytics.js
+++ b/frontend/components/scheduleAnalytics.js
@@ -1,0 +1,35 @@
+import { renderBarChart, renderLineChart } from './chartUtils.js';
+
+export function initScheduleAnalytics() {
+  const container = document.getElementById('scheduleAnalytics');
+  if (!container) return;
+  const userInput = container.querySelector('#analyticsUserId');
+  const weekInput = container.querySelector('#analyticsWeek');
+  const btn = container.querySelector('#analyticsBtn');
+  const categoryCanvas = container.querySelector('#categoryChart');
+  const restCanvas = container.querySelector('#restChart');
+
+  btn.addEventListener('click', async () => {
+    const uid = userInput.value;
+    const week = weekInput.value;
+    if (!uid || !week) return;
+    try {
+      const res = await fetch(`/schedule/analytics/${uid}/${week}`);
+      const data = await res.json();
+      const labels = Object.keys(data.totals);
+      const values = Object.values(data.totals);
+      renderBarChart(categoryCanvas, labels, values);
+      const restLabels = data.rest.map(r => r.date);
+      const restValues = data.rest.map(r => r.rest_hours);
+      renderLineChart(restCanvas, restLabels, restValues);
+    } catch {
+      // ignore errors
+    }
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initScheduleAnalytics);
+}
+
+export default { initScheduleAnalytics };

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -44,6 +44,14 @@
     <input type="date" id="exportDate" />
     <button id="exportBtn">Download ICS</button>
   </div>
+  <div id="scheduleAnalytics">
+    <h3>Weekly Analytics</h3>
+    <input type="number" id="analyticsUserId" placeholder="User ID" />
+    <input type="date" id="analyticsWeek" />
+    <button id="analyticsBtn">Load</button>
+    <canvas id="categoryChart"></canvas>
+    <canvas id="restChart"></canvas>
+  </div>
   <div class="tabs">
     <button id="quickPlanTab" class="active">Quick Plan</button>
     <button id="advancedPlannerTab">Advanced Planner</button>
@@ -59,6 +67,8 @@
     <button id="proposeBtn">Propose</button>
     <ul id="proposals"></ul>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script type="module" src="../components/scheduleAnalytics.js"></script>
   <script type="module" src="../components/quickPlan.js"></script>
   <script type="module" src="../components/advancedPlanner.js"></script>
   <script type="module" src="../components/scheduleStats.js"></script>


### PR DESCRIPTION
## Summary
- aggregate weekly schedule data and rest compliance in `ScheduleAnalyticsService`
- expose `/schedule/analytics/{user_id}/{week_start}` endpoint
- render weekly analytics charts on schedule page using new chart utilities

## Testing
- `ruff check backend/services/analytics_service.py backend/routes/schedule_routes.py backend/tests/schedule/test_schedule_analytics.py`
- `pytest backend/tests/schedule/test_schedule_analytics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b96c8ca8e483258641a89492e78eb2