### PR TITLE
Support percentage-based schedule planning

### DIFF
--- a/backend/routes/schedule_routes.py
+++ b/backend/routes/schedule_routes.py
@@ -11,10 +11,10 @@ from backend.services.schedule_service import schedule_service
 router = APIRouter(prefix="/schedule", tags=["schedule"])
 
 
-class PlanSelections(BaseModel):
-    social: bool = False
-    career: bool = False
-    band: bool = False
+class PlanPercentages(BaseModel):
+    social_pct: int = 0
+    career_pct: int = 0
+    band_pct: int = 0
 
 
 class RecommendationRequest(BaseModel):
@@ -23,9 +23,11 @@ class RecommendationRequest(BaseModel):
 
 
 @router.post("/plan")
-def generate_plan(data: PlanSelections):
+def generate_plan(data: PlanPercentages):
     schedule = plan_service.create_plan(
-        social=data.social, career=data.career, band=data.band
+        social_pct=data.social_pct,
+        career_pct=data.career_pct,
+        band_pct=data.band_pct,
     )
     return {"schedule": schedule}
 

--- a/backend/tests/schedule/test_percentage_plan.py
+++ b/backend/tests/schedule/test_percentage_plan.py
@@ -1,0 +1,26 @@
+from backend.services.plan_service import PlanService
+
+
+def test_percentage_distribution():
+    svc = PlanService()
+    plan = svc.create_plan(social_pct=50, career_pct=25, band_pct=25)
+    expected = [
+        "network",
+        "promote",
+        "network",
+        "promote",
+        "practice",
+        "songwriting",
+        "rehearsal",
+        "gig_prep",
+    ]
+    assert plan == expected
+
+
+def test_percentage_rest_filled():
+    svc = PlanService()
+    plan = svc.create_plan(social_pct=25, career_pct=25, band_pct=0)
+    assert plan[0:2] == ["network", "promote"]
+    assert plan[2:4] == ["practice", "songwriting"]
+    assert plan.count("rest") == svc.slots - 4
+    assert len(plan) == svc.slots

--- a/backend/tests/schedule/test_plan_service.py
+++ b/backend/tests/schedule/test_plan_service.py
@@ -3,14 +3,14 @@ from backend.services.plan_service import PlanService
 
 def test_category_mapping():
     svc = PlanService()
-    plan = svc.create_plan(social=True, career=True, band=False)
+    plan = svc.create_plan(social_pct=25, career_pct=25, band_pct=0)
     expected = PlanService.CATEGORY_MAP["social"] + PlanService.CATEGORY_MAP["career"]
     assert plan[: len(expected)] == expected
 
 
 def test_rest_insertion():
     svc = PlanService()
-    plan = svc.create_plan(social=True, career=False, band=False)
+    plan = svc.create_plan(social_pct=25, career_pct=0, band_pct=0)
     # first entries from social category
     assert plan[0:2] == PlanService.CATEGORY_MAP["social"]
     # rest fills remaining slots

--- a/frontend/components/quickPlan.js
+++ b/frontend/components/quickPlan.js
@@ -22,14 +22,17 @@ export function initQuickPlan() {
   const container = document.getElementById('quickPlan');
   if (!container) return;
 
-  const categories = ['practice', 'rest', 'travel'];
+  const categories = ['social_pct', 'career_pct', 'band_pct'];
   const form = document.createElement('form');
 
   categories.forEach((cat) => {
     const label = document.createElement('label');
     const input = document.createElement('input');
-    input.type = 'checkbox';
+    input.type = 'number';
     input.name = cat;
+    input.min = '0';
+    input.max = '100';
+    input.value = '0';
     label.appendChild(input);
     label.append(` ${cat}`);
     form.appendChild(label);
@@ -45,7 +48,7 @@ export function initQuickPlan() {
     .then((plan) => {
       categories.forEach((cat) => {
         const input = form.querySelector(`input[name="${cat}"]`);
-        if (input) input.checked = !!plan[cat];
+        if (input) input.value = plan[cat] ?? 0;
       });
     })
     .catch(() => {});
@@ -55,7 +58,7 @@ export function initQuickPlan() {
     const plan = {};
     categories.forEach((cat) => {
       const input = form.querySelector(`input[name="${cat}"]`);
-      plan[cat] = !!(input && input.checked);
+      plan[cat] = input ? parseInt(input.value, 10) || 0 : 0;
     });
     await saveDefaultPlan(plan).catch(() => {});
   });

--- a/frontend/tests/schedule/fixtures/defaultPlan.json
+++ b/frontend/tests/schedule/fixtures/defaultPlan.json
@@ -1,5 +1,5 @@
 {
-  "practice": true,
-  "rest": false,
-  "travel": true
+  "social_pct": 10,
+  "career_pct": 20,
+  "band_pct": 30
 }

--- a/frontend/tests/schedule/quickPlan.test.ts
+++ b/frontend/tests/schedule/quickPlan.test.ts
@@ -22,11 +22,11 @@ describe('quick plan', () => {
     initQuickPlan();
     await new Promise((r) => setTimeout(r, 0));
 
-    const practice = document.querySelector('input[name="practice"]') as HTMLInputElement;
-    expect(practice.checked).toBe(true);
+    const social = document.querySelector('input[name="social_pct"]') as HTMLInputElement;
+    expect(social.value).toBe('10');
 
-    const rest = document.querySelector('input[name="rest"]') as HTMLInputElement;
-    rest.checked = true;
+    const band = document.querySelector('input[name="band_pct"]') as HTMLInputElement;
+    band.value = '40';
     document.querySelector('#quickPlan form')!.dispatchEvent(
       new Event('submit', { bubbles: true, cancelable: true })
     );
@@ -34,7 +34,7 @@ describe('quick plan', () => {
 
     expect(fetchMock.mock.calls[1][0]).toBe('/api/default-plan');
     const body = fetchMock.mock.calls[1][1]?.body as string;
-    expect(JSON.parse(body)).toEqual({ practice: true, rest: true, travel: true });
+    expect(JSON.parse(body)).toEqual({ social_pct: 10, career_pct: 20, band_pct: 40 });
 
     (global as any).fetch = originalFetch;
   });


### PR DESCRIPTION
## Summary
- Distribute day slots proportionally based on social, career, and band percentages
- Allow schedule plan endpoint to accept percentage inputs
- Expose percentage fields in quick plan UI with numeric controls
- Add tests covering percentage distribution logic

## Testing
- `pytest backend/tests/schedule/test_plan_service.py backend/tests/schedule/test_percentage_plan.py -q`
- `npm test tests/schedule/quickPlan.test.ts --silent` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b96e8567e48325ad32d6650611a94e