### PR TITLE
feat: allow schedule duplication

### DIFF
--- a/backend/routes/schedule_routes.py
+++ b/backend/routes/schedule_routes.py
@@ -153,6 +153,12 @@ class TemplateCreate(BaseModel):
     entries: List[TemplateEntry]
 
 
+class CopyRequest(BaseModel):
+    user_id: int
+    src_date: str
+    dest_dates: List[str]
+
+
 @router.post("/templates/{user_id}")
 def create_template(user_id: int, data: TemplateCreate):
     template_id = schedule_service.create_template(
@@ -170,4 +176,10 @@ def list_templates(user_id: int):
 @router.post("/apply-template/{user_id}/{date}/{template_id}")
 def apply_template(user_id: int, date: str, template_id: int):
     schedule_service.apply_template(user_id, date, template_id)
+    return {"status": "ok"}
+
+
+@router.post("/copy")
+def copy_schedule(data: CopyRequest):
+    schedule_service.copy_schedule(data.user_id, data.src_date, data.dest_dates)
     return {"status": "ok"}

--- a/backend/tests/schedule/test_schedule_copy.py
+++ b/backend/tests/schedule/test_schedule_copy.py
@@ -1,0 +1,49 @@
+import importlib
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend import database
+
+
+def setup_app(tmp_path):
+    db_file = tmp_path / "copy.db"
+    database.DB_PATH = db_file
+    database.init_db()
+
+    from backend.models import activity as activity_model
+    from backend.models import daily_schedule as schedule_model
+
+    activity_model.DB_PATH = db_file
+    schedule_model.DB_PATH = db_file
+
+    import backend.services.schedule_service as schedule_service_module
+    importlib.reload(schedule_service_module)
+    import backend.routes.schedule_routes as routes_module
+    importlib.reload(routes_module)
+
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    client = TestClient(app)
+    return client, schedule_service_module.schedule_service
+
+
+def test_copy_schedule(tmp_path):
+    client, svc = setup_app(tmp_path)
+    act_id = svc.create_activity("Practice", 1, "music")
+    svc.schedule_activity(1, "2024-01-01", 36, act_id)
+
+    resp = client.post(
+        "/schedule/copy",
+        json={
+            "user_id": 1,
+            "src_date": "2024-01-01",
+            "dest_dates": ["2024-01-02", "2024-01-03"],
+        },
+    )
+    assert resp.status_code == 200
+
+    day2 = svc.get_daily_schedule(1, "2024-01-02")
+    day3 = svc.get_daily_schedule(1, "2024-01-03")
+    assert day2 == day3
+    assert day2[0]["slot"] == 36
+    assert day2[0]["activity"]["id"] == act_id

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -44,6 +44,14 @@
     <input type="date" id="exportDate" />
     <button id="exportBtn">Download ICS</button>
   </div>
+  <div id="scheduleCopy">
+    <h3>Copy Schedule</h3>
+    <input type="number" id="copyUserId" placeholder="User ID" />
+    <input type="date" id="copySrcDate" />
+    <input type="date" id="copyDestStart" />
+    <input type="date" id="copyDestEnd" />
+    <button id="copyBtn">Copy</button>
+  </div>
   <div id="scheduleAnalytics">
     <h3>Weekly Analytics</h3>
     <input type="number" id="analyticsUserId" placeholder="User ID" />
@@ -140,6 +148,26 @@
       const date = document.getElementById('exportDate').value;
       if (!userId || !date) return;
       window.location = `/schedule/export/ics?user_id=${userId}&date=${date}`;
+    });
+
+    document.getElementById('copyBtn').addEventListener('click', async () => {
+      const uid = document.getElementById('copyUserId').value;
+      const src = document.getElementById('copySrcDate').value;
+      const start = document.getElementById('copyDestStart').value;
+      const end = document.getElementById('copyDestEnd').value;
+      if (!uid || !src || !start) return;
+      const dates = [];
+      let d = new Date(start);
+      const endDate = end ? new Date(end) : new Date(start);
+      while (d <= endDate) {
+        dates.push(d.toISOString().slice(0,10));
+        d.setDate(d.getDate() + 1);
+      }
+      await fetch('/schedule/copy', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({user_id: parseInt(uid), src_date: src, dest_dates: dates})
+      });
     });
 
     const tmplSelect = document.getElementById('tmplSelect');


### PR DESCRIPTION
## Summary
- add copy_schedule to replicate schedule entries between days
- expose POST /schedule/copy API
- extend schedule planner UI with Copy controls and date range support
- cover schedule duplication with unit test

## Testing
- `pytest backend/tests/schedule/test_schedule_copy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b96fd500c08325bcdcf5d3195ddc74