### PR TITLE
Refactor SongwritingService initializer

### DIFF
--- a/backend/tests/songwriting/test_songwriting_service.py
+++ b/backend/tests/songwriting/test_songwriting_service.py
@@ -146,7 +146,12 @@ def test_xp_gain_and_quality_modifier():
 def test_versioning_and_co_writers():
     async def run():
         svc = SongwritingService(llm_client=FakeLLM())
-        draft = await svc.generate_draft(creator_id=1, prompt="collab", style="rock")
+        draft = await svc.generate_draft(
+            creator_id=1,
+            title="collab",
+            genre="rock",
+            themes=["a", "b", "c"],
+        )
         # initial version saved
         assert len(svc.list_versions(draft.id)) == 1
 


### PR DESCRIPTION
## Summary
- consolidate SongwritingService initialization into a single constructor
- allow injection of skill and band services
- fix draft saving to use chord progression and clean up song creation
- update songwriting service tests for new API

## Testing
- `pytest backend/tests/songwriting/test_songwriting_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9718c29008325a9eb56dbc0cf6450