### PR TITLE
Unify chord progression field in songwriting tools

### DIFF
--- a/backend/models/song_draft_version.py
+++ b/backend/models/song_draft_version.py
@@ -1,6 +1,6 @@
+"""Version snapshot for song drafts."""
 from __future__ import annotations
 
-"""Version snapshot for song drafts."""
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import List, Optional
@@ -12,6 +12,6 @@ class SongDraftVersion:
 
     author_id: int
     lyrics: str
-    chords: Optional[str] = None
+    chord_progression: Optional[str] = None
     themes: List[str] = field(default_factory=list)
     timestamp: datetime = field(default_factory=datetime.utcnow)

--- a/backend/routes/songwriting_routes.py
+++ b/backend/routes/songwriting_routes.py
@@ -1,15 +1,15 @@
 """Routes for AI-assisted songwriting features."""
 from __future__ import annotations
 
-from typing import Dict, Set, List
+from typing import Dict, List, Set
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, validator
 
 from backend.auth.dependencies import get_current_user_id
 from backend.models.theme import THEMES
-from backend.services.songwriting_service import songwriting_service
 from backend.services.skill_service import skill_service
+from backend.services.songwriting_service import songwriting_service
 
 router = APIRouter(prefix="/songwriting", tags=["songwriting"])
 
@@ -31,9 +31,7 @@ class PromptPayload(BaseModel):
 
 class DraftUpdate(BaseModel):
     lyrics: str | None = None
-    chords: str | None = None
     themes: List[str] | None = None
-
     chord_progression: str | None = None
     album_art_url: str | None = None
 
@@ -63,8 +61,6 @@ def edit_draft(draft_id: int, updates: DraftUpdate, user_id: int = Depends(get_c
         draft_id,
         user_id,
         lyrics=updates.lyrics,
-
-        chords=updates.chords,
         themes=updates.themes,
         chord_progression=updates.chord_progression,
         album_art_url=updates.album_art_url,

--- a/backend/tests/songwriting/test_songwriting_service.py
+++ b/backend/tests/songwriting/test_songwriting_service.py
@@ -1,10 +1,10 @@
 import asyncio
+
 import pytest
 
-from backend.services.songwriting_service import SongwritingService
 from backend.services.originality_service import OriginalityService
-from backend.services.skill_service import SkillService, SONGWRITING_SKILL
-
+from backend.services.skill_service import SONGWRITING_SKILL, SkillService
+from backend.services.songwriting_service import SongwritingService
 
 
 class FakeLLM:
@@ -157,7 +157,7 @@ def test_versioning_and_co_writers():
 
         # add a co-writer and allow edits
         svc.add_co_writer(draft.id, user_id=1, co_writer_id=2)
-        svc.update_draft(draft.id, user_id=2, lyrics="co-write", chords="A B")
+        svc.update_draft(draft.id, user_id=2, lyrics="co-write", chord_progression="A B")
         versions = svc.list_versions(draft.id)
         assert len(versions) == 2
         assert versions[-1].author_id == 2

--- a/frontend/pages/song_form.html
+++ b/frontend/pages/song_form.html
@@ -18,8 +18,8 @@
   <label for="lyrics">Lyrics</label>
   <textarea id="lyrics" name="lyrics" placeholder="Lyrics"></textarea>
 
-  <label for="chords">Chord Progression</label>
-  <input type="text" id="chords" name="chord_progression" placeholder="C G Am F" />
+  <label for="chord_progression">Chord Progression</label>
+  <input type="text" id="chord_progression" name="chord_progression" placeholder="C G Am F" />
 
   <div id="artSection">
     <label for="albumArt">Album Art</label>


### PR DESCRIPTION
## Summary
- standardize on `chord_progression` across drafts, versions, and service methods
- streamline draft generation by removing redundant `genre_id` usage and saving the proper chord progression
- update songwriting routes, HTML form, and tests to match the unified field

## Testing
- `ruff check backend/services/songwriting_service.py backend/routes/songwriting_routes.py backend/models/song_draft_version.py backend/tests/songwriting/test_songwriting_service.py`
- `pytest backend/tests/songwriting/test_songwriting_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b972d4397c8325859843895280a526