### PR TITLE
test: add band member collaboration test

### DIFF
--- a/backend/tests/songwriting/test_songwriting_service.py
+++ b/backend/tests/songwriting/test_songwriting_service.py
@@ -1,9 +1,13 @@
 import asyncio
 import pytest
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
 from backend.services.songwriting_service import SongwritingService
 from backend.services.originality_service import OriginalityService
 from backend.services.skill_service import SkillService, SONGWRITING_SKILL
+from backend.services.band_service import BandService, Base
 
 
 
@@ -42,7 +46,12 @@ def test_theme_validation():
     async def run():
         svc = SongwritingService(llm_client=FakeLLM(), originality=OriginalityService())
         with pytest.raises(ValueError):
-            await svc.generate_draft(1, "t", "rock", ["only", "two"])
+            await svc.generate_draft(
+                creator_id=1,
+                title="t",
+                genre="rock",
+                themes=["only", "two"],
+            )
 
     asyncio.run(run())
 
@@ -143,11 +152,20 @@ def test_xp_gain_and_quality_modifier():
         svc.update_draft(draft.id, 1, lyrics="new lyrics")
         assert skills.get_songwriting_skill(1).xp == 415
 
-def test_versioning_and_co_writers():
+def _get_band_service() -> BandService:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    return BandService(SessionLocal)
+
+
+def test_versioning_and_band_mates():
     async def run():
-        svc = SongwritingService(llm_client=FakeLLM())
+        band_service = _get_band_service()
+        band = band_service.create_band(user_id=1, band_name="AI Band", genre="rock")
+        svc = SongwritingService(llm_client=FakeLLM(), band_service=band_service)
         draft = await svc.generate_draft(
-            creator_id=1,
+            creator_id=band.id,
             title="collab",
             genre="rock",
             themes=["a", "b", "c"],
@@ -155,8 +173,12 @@ def test_versioning_and_co_writers():
         # initial version saved
         assert len(svc.list_versions(draft.id)) == 1
 
-        # add a co-writer and allow edits
-        svc.add_co_writer(draft.id, user_id=1, co_writer_id=2)
+        # unauthorized user cannot edit until added to band
+        with pytest.raises(PermissionError):
+            svc.update_draft(draft.id, user_id=2, lyrics="hack")
+
+        # add a band member and allow edits
+        band_service.add_member(band.id, user_id=2)
         svc.update_draft(draft.id, user_id=2, lyrics="co-write", chords="A B")
         versions = svc.list_versions(draft.id)
         assert len(versions) == 2
@@ -165,5 +187,6 @@ def test_versioning_and_co_writers():
         # unauthorized user
         with pytest.raises(PermissionError):
             svc.update_draft(draft.id, user_id=3, lyrics="hack")
+
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- update songwriting tests to use new generate_draft signature
- add integration test for band-member collaboration permissions

## Testing
- `pytest backend/tests/songwriting/test_songwriting_service.py::test_theme_validation -q`
- `pytest backend/tests/songwriting/test_songwriting_service.py::test_versioning_and_band_mates -q` *(fails: PermissionError: forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9756abb308325862dcd17c13b66b6