### PR TITLE
Add chemistry API and frontend display

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,15 +13,16 @@ from routes import (
     admin_routes,
     apprenticeship_routes,
     avatar,
+    chemistry_routes,
     daily_loop_routes,
     event_routes,
     legacy_routes,
     lifestyle_routes,
     locale_routes,
     music_metrics_routes,
-    schedule_routes,
     onboarding_routes,
     playlist_routes,
+    schedule_routes,
     setlist_routes,
     social_routes,
     song_forecast_routes,
@@ -102,6 +103,7 @@ app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])
 app.include_router(user_settings_routes.router, prefix="/api", tags=["UserSettings"])
 app.include_router(avatar.router, prefix="/api", tags=["Avatars"])
 app.include_router(playlist_routes.router, prefix="/api", tags=["Playlists"])
+app.include_router(chemistry_routes.router)
 
 
 @app.get("/metrics")

--- a/backend/models/recording_session.py
+++ b/backend/models/recording_session.py
@@ -18,6 +18,7 @@ class RecordingSession:
     personnel: List[int] = field(default_factory=list)
     cost_cents: int = 0
     environment_quality: float = 1.0
+    chemistry_avg: float = 50.0
     created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
 
     def to_dict(self) -> dict:
@@ -31,6 +32,7 @@ class RecordingSession:
             "personnel": list(self.personnel),
             "cost_cents": self.cost_cents,
             "environment_quality": self.environment_quality,
+            "chemistry_avg": self.chemistry_avg,
             "created_at": self.created_at,
         }
 

--- a/backend/models/songwriting.py
+++ b/backend/models/songwriting.py
@@ -13,6 +13,7 @@ class GenerationMetadata:
     model: str = "unknown"
     latency_ms: Optional[int] = None
     quality_modifier: float = 1.0
+    chemistry: Optional[float] = None
 
 
 @dataclass

--- a/backend/routes/chemistry_routes.py
+++ b/backend/routes/chemistry_routes.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services.chemistry_service import ChemistryService
+
+router = APIRouter(prefix="/chemistry", tags=["chemistry"])
+svc = ChemistryService()
+
+
+class Adjustment(BaseModel):
+    delta: int = 1
+
+
+@router.get("/{player_id}")
+def list_chemistry(player_id: int, _uid: int = Depends(get_current_user_id)):
+    pairs = svc.list_for_player(player_id)
+    return [
+        {"player_a_id": p.player_a_id, "player_b_id": p.player_b_id, "score": p.score}
+        for p in pairs
+    ]
+
+
+@router.post(
+    "/{player_a_id}/{player_b_id}/adjust",
+    dependencies=[Depends(require_role(["admin"]))],
+)
+def adjust_pair(
+    player_a_id: int,
+    player_b_id: int,
+    payload: Adjustment,
+    _uid: int = Depends(get_current_user_id),
+):
+    pair = svc.adjust_pair(player_a_id, player_b_id, payload.delta)
+    return {"player_a_id": pair.player_a_id, "player_b_id": pair.player_b_id, "score": pair.score}

--- a/backend/routes/recording_routes.py
+++ b/backend/routes/recording_routes.py
@@ -75,7 +75,7 @@ def assign_personnel(
     if not session or session.band_id != user_id:
         raise HTTPException(status_code=404, detail="session_not_found")
     svc.assign_personnel(session_id, payload.user_id)
-    return {"ok": True}
+    return {"ok": True, "chemistry_avg": session.chemistry_avg}
 
 
 @router.put("/sessions/{session_id}/tracks/{track_id}")
@@ -86,4 +86,8 @@ def update_track(
     if not session or session.band_id != user_id:
         raise HTTPException(status_code=404, detail="session_not_found")
     svc.update_track_status(session_id, track_id, payload.status)
-    return {"ok": True, "track_statuses": session.track_statuses}
+    return {
+        "ok": True,
+        "track_statuses": session.track_statuses,
+        "chemistry_avg": session.chemistry_avg,
+    }

--- a/backend/services/chemistry_service.py
+++ b/backend/services/chemistry_service.py
@@ -84,3 +84,16 @@ class ChemistryService:
                 pair.last_updated = func.now()
             session.refresh(pair)
             return pair
+
+    def list_for_player(self, player_id: int) -> list[PlayerChemistry]:
+        """Return all chemistry records involving ``player_id``."""
+
+        with self.session_factory() as session:
+            return (
+                session.query(PlayerChemistry)
+                .filter(
+                    (PlayerChemistry.player_a_id == player_id)
+                    | (PlayerChemistry.player_b_id == player_id)
+                )
+                .all()
+            )

--- a/backend/services/live_performance_service.py
+++ b/backend/services/live_performance_service.py
@@ -1,9 +1,8 @@
+import json
 import random
 import sqlite3
-import json
 from datetime import datetime
-
-from typing import Generator, Iterable, Optional, Dict
+from typing import Dict, Generator, Iterable, Optional
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
@@ -14,6 +13,7 @@ from backend.services.city_service import city_service
 from backend.services.event_service import is_skill_blocked
 from backend.services.gear_service import gear_service
 from backend.services.setlist_service import get_approved_setlist
+
 try:
     from backend.realtime.polling import poll_hub
 except Exception:  # pragma: no cover - optional realtime module
@@ -336,6 +336,7 @@ def simulate_gig(
         "revenue_earned": revenue_dist[band_id],
         "skill_gain": skill_dist[band_id],
         "merch_sold": merch_dist[band_id],
+        "chemistry_avg": avg_chem,
     }
     if len(participants) > 1:
         result["band_results"] = {

--- a/backend/services/recording_service.py
+++ b/backend/services/recording_service.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
+from backend.models.learning_method import LearningMethod
 from backend.models.recording_session import RecordingSession
+from backend.models.skill import Skill
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.chemistry_service import ChemistryService
 from backend.services.economy_service import EconomyError, EconomyService
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
-from backend.models.learning_method import LearningMethod
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 class RecordingService:
@@ -55,6 +55,7 @@ class RecordingService:
             cost_cents=cost_cents,
             environment_quality=environment_quality,
         )
+        avg = 50.0
         if session.personnel:
             scores = []
             for i, a in enumerate(session.personnel):
@@ -64,6 +65,7 @@ class RecordingService:
             if scores:
                 avg = sum(scores) / len(scores)
                 session.environment_quality *= 1 + (avg - 50) / 100
+        session.chemistry_avg = avg
         self.sessions[session.id] = session
         self._id_seq += 1
         return session
@@ -90,6 +92,7 @@ class RecordingService:
             if scores:
                 avg = sum(scores) / len(scores)
                 session.environment_quality *= 1 + (avg - 50) / 100
+                session.chemistry_avg = avg
 
         # Award practice XP to all personnel based on task difficulty
         difficulty = {"recorded": 1, "mixed": 2, "mastered": 3}.get(status, 1)

--- a/backend/services/songwriting_service.py
+++ b/backend/services/songwriting_service.py
@@ -8,6 +8,7 @@ from backend.models.song import Song
 from backend.models.song_draft_version import SongDraftVersion
 from backend.models.songwriting import GenerationMetadata, LyricDraft
 from backend.services.ai_art_service import AIArtService, ai_art_service
+from backend.services.band_service import BandService
 from backend.services.chemistry_service import ChemistryService
 from backend.services.originality_service import (
     OriginalityService,
@@ -15,9 +16,10 @@ from backend.services.originality_service import (
 )
 from backend.services.skill_service import (
     SkillService,
+)
+from backend.services.skill_service import (
     skill_service as skill_service_instance,
 )
-from backend.services.band_service import BandService
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from backend.services.legal_service import LegalService
@@ -128,7 +130,9 @@ class SongwritingService:
             chord_progression=chord_progression,
             album_art_url=art_url,
             plagiarism_warning=warning,
-            metadata=GenerationMetadata(quality_modifier=quality_mod),
+            metadata=GenerationMetadata(
+                quality_modifier=quality_mod, chemistry=avg_chem
+            ),
         )
         self._drafts[draft.id] = draft
         song = Song(

--- a/frontend/components/profile.js
+++ b/frontend/components/profile.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const bioInput = document.getElementById('bio');
   const linksInput = document.getElementById('links');
   const avatarInput = document.getElementById('avatar-input');
+  const chemTbody = document.querySelector('#chemistry-table tbody');
 
   try {
     const res = await fetch(`/api/user-settings/profile/${USER_ID}`);
@@ -15,6 +16,23 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   } catch (e) {
     // ignore load errors
+  }
+
+  try {
+    const chemRes = await fetch(`/chemistry/${USER_ID}`);
+    if (chemRes.ok) {
+      const pairs = await chemRes.json();
+      pairs.forEach((p) => {
+        const other = p.player_a_id === USER_ID ? p.player_b_id : p.player_a_id;
+        const tr = document.createElement('tr');
+        if (p.score >= 80) tr.classList.add('chem-high');
+        else if (p.score <= 20) tr.classList.add('chem-low');
+        tr.innerHTML = `<td>${other}</td><td>${p.score}</td>`;
+        chemTbody.appendChild(tr);
+      });
+    }
+  } catch (e) {
+    // ignore chemistry errors
   }
 
   form.addEventListener('submit', async (e) => {

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -23,6 +23,17 @@
     </div>
     <button type="submit">Save</button>
   </form>
+  <h2>Chemistry</h2>
+  <table id="chemistry-table">
+    <thead>
+      <tr><th>Band Mate</th><th>Score</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <style>
+    #chemistry-table .chem-high { background-color: #c8e6c9; }
+    #chemistry-table .chem-low { background-color: #ffcdd2; }
+  </style>
   <script src="../components/themeToggle.js"></script>
   <script src="../components/header.js"></script>
   <script type="module" src="../components/profile.js"></script>


### PR DESCRIPTION
## Summary
- add chemistry routes for listing and adjusting player synergy
- expose chemistry averages in songwriting, recording sessions, and gig results
- show chemistry table on profile page with high/low highlights

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'email_validator')*
- `npm test` *(fails: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b98035f0308325bc24c18c792fd3d1