### PR TITLE
Add chemistry pair tests and mock high/low chemistry in services

### DIFF
--- a/backend/tests/chemistry/test_player_chemistry.py
+++ b/backend/tests/chemistry/test_player_chemistry.py
@@ -1,0 +1,34 @@
+import random
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.services.chemistry_service import ChemistryService, Base
+
+
+def _service():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    return ChemistryService(SessionLocal)
+
+
+def test_pair_initialization_with_seeded_rng():
+    svc = _service()
+    random.seed(0)
+    assert svc.initialize_pair(1, 2).score == 50
+    random.seed(31)
+    high = svc.initialize_pair(3, 4).score
+    assert 81 <= high <= 100
+    random.seed(2)
+    low = svc.initialize_pair(5, 6).score
+    assert 0 <= low <= 19
+
+
+def test_adjust_pair_increases_score():
+    svc = _service()
+    pair = svc.initialize_pair(1, 2)
+    start = pair.score
+    pair = svc.adjust_pair(1, 2, 1)
+    pair = svc.adjust_pair(1, 2, 2)
+    assert pair.score == start + 3

--- a/backend/tests/test_recording_service.py
+++ b/backend/tests/test_recording_service.py
@@ -1,0 +1,38 @@
+import pytest
+
+from backend.services.recording_service import RecordingService
+
+
+class DummyEconomy:
+    def ensure_schema(self) -> None:
+        pass
+
+    def withdraw(self, *args, **kwargs) -> None:
+        pass
+
+
+class StubChem:
+    def __init__(self, score):
+        self.score = score
+
+    def initialize_pair(self, a, b):
+        return type("P", (), {"score": self.score})()
+
+    def adjust_pair(self, a, b, d):
+        return self.initialize_pair(a, b)
+
+
+def _run_session(score):
+    svc = RecordingService(economy=DummyEconomy(), chemistry_service=StubChem(score))
+    session = svc.schedule_session(1, "Studio", "2024-01-01", "2024-01-02", [1], 0)
+    svc.assign_personnel(session.id, 1)
+    svc.assign_personnel(session.id, 2)
+    svc.update_track_status(session.id, 1, "recorded")
+    return session
+
+
+def test_environment_quality_scales_with_chemistry():
+    high = _run_session(90)
+    low = _run_session(10)
+    assert high.environment_quality == pytest.approx(1.4)
+    assert low.environment_quality == pytest.approx(0.6)


### PR DESCRIPTION
## Summary
- add dedicated player chemistry tests for seeded outcomes and score adjustments
- validate environment quality and songwriting quality modifiers using mocked chemistry pairs
- update gig simulation tests to account for high and low chemistry effects on fame and skill gain

## Testing
- `pytest backend/tests/chemistry/test_player_chemistry.py backend/tests/songwriting/test_songwriting_service.py::test_chemistry_quality_modifier backend/tests/test_recording_service.py backend/tests/live_performance/test_crowd_reaction.py backend/tests/live_performance/test_setlist_structure.py::test_simulate_gig_parses_structured_setlist`

------
https://chatgpt.com/codex/tasks/task_e_68b981df7c9c832580e5b80482ddad23