### PR TITLE
Expand songwriting draft visibility

### DIFF
--- a/backend/routes/songwriting_routes.py
+++ b/backend/routes/songwriting_routes.py
@@ -51,6 +51,11 @@ async def submit_prompt(payload: PromptPayload, user_id: int = Depends(get_curre
     return draft
 
 
+@router.get("/drafts")
+def list_drafts(user_id: int = Depends(get_current_user_id)):
+    return songwriting_service.list_drafts(user_id)
+
+
 @router.get("/drafts/{draft_id}")
 def get_draft(draft_id: int, user_id: int = Depends(get_current_user_id)):
     draft = songwriting_service.get_draft(draft_id)

--- a/backend/services/songwriting_service.py
+++ b/backend/services/songwriting_service.py
@@ -164,8 +164,12 @@ class SongwritingService:
     def get_draft(self, draft_id: int) -> Optional[LyricDraft]:
         return self._drafts.get(draft_id)
 
-    def list_drafts(self, creator_id: int) -> List[LyricDraft]:
-        return [d for d in self._drafts.values() if d.creator_id == creator_id]
+    def list_drafts(self, user_id: int) -> List[LyricDraft]:
+        return [
+            d
+            for d in self._drafts.values()
+            if d.creator_id == user_id or user_id in self._co_writers.get(d.id, set())
+        ]
 
     def update_draft(
         self,

--- a/backend/tests/routes/test_songwriting_routes.py
+++ b/backend/tests/routes/test_songwriting_routes.py
@@ -1,0 +1,34 @@
+import asyncio
+from fastapi import FastAPI
+from backend.routes import songwriting_routes
+from backend.services.songwriting_service import SongwritingService
+from backend.services.originality_service import OriginalityService
+
+
+class FakeLLM:
+    async def complete(self, history):
+        return "la"
+
+
+def test_get_drafts_creator_and_co_writer(client_factory):
+    svc = SongwritingService(llm_client=FakeLLM(), originality=OriginalityService())
+    d1 = asyncio.run(
+        svc.generate_draft(
+            creator_id=1,
+            title="A",
+            genre="rock",
+            themes=["x", "y", "z"],
+        )
+    )
+    svc.add_co_writer(d1.id, user_id=1, co_writer_id=2)
+    songwriting_routes.songwriting_service = svc
+    app = FastAPI()
+    app.include_router(songwriting_routes.router)
+
+    c1 = client_factory(app, {songwriting_routes.get_current_user_id: lambda: 1})
+    r1 = c1.get("/songwriting/drafts")
+    assert {d["id"] for d in r1.json()} == {d1.id}
+
+    c2 = client_factory(app, {songwriting_routes.get_current_user_id: lambda: 2})
+    r2 = c2.get("/songwriting/drafts")
+    assert {d["id"] for d in r2.json()} == {d1.id}

--- a/backend/tests/songwriting/test_songwriting_service.py
+++ b/backend/tests/songwriting/test_songwriting_service.py
@@ -41,6 +41,29 @@ async def _generate(svc: SongwritingService):
     )
 
 
+def test_list_drafts_includes_co_writers():
+    async def run():
+        svc = SongwritingService(llm_client=FakeLLM(), originality=OriginalityService())
+        d1 = await svc.generate_draft(
+            creator_id=1,
+            title="A",
+            genre="rock",
+            themes=["x", "y", "z"],
+        )
+        svc.add_co_writer(d1.id, user_id=1, co_writer_id=2)
+        d2 = await svc.generate_draft(
+            creator_id=3,
+            title="B",
+            genre="rock",
+            themes=["x", "y", "z"],
+        )
+        assert {d.id for d in svc.list_drafts(1)} == {d1.id}
+        assert {d.id for d in svc.list_drafts(2)} == {d1.id}
+        assert {d.id for d in svc.list_drafts(3)} == {d2.id}
+
+    asyncio.run(run())
+
+
 def test_theme_validation():
     async def run():
         svc = SongwritingService(llm_client=FakeLLM(), originality=OriginalityService())


### PR DESCRIPTION
## Summary
- include drafts where user is a co-writer in SongwritingService.list_drafts
- expose GET /songwriting/drafts to fetch all drafts for current user
- add tests covering creators and co-writers

## Testing
- `pytest backend/tests/songwriting/test_songwriting_service.py::test_list_drafts_includes_co_writers backend/tests/routes/test_songwriting_routes.py::test_get_drafts_creator_and_co_writer -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9876e48b48325b8ead09108419d6b