### PR TITLE
Handle invalid co-writer invitations

### DIFF
--- a/backend/routes/songwriting_routes.py
+++ b/backend/routes/songwriting_routes.py
@@ -116,6 +116,12 @@ def add_co_writer(
         raise HTTPException(status_code=404, detail="draft_not_found")
     except PermissionError:
         raise HTTPException(status_code=403, detail="forbidden")
+    except ValueError as exc:
+        if str(exc) == "cannot_invite_self":
+            raise HTTPException(status_code=400, detail=str(exc))
+        if str(exc) == "already_invited":
+            raise HTTPException(status_code=409, detail=str(exc))
+        raise HTTPException(status_code=400, detail=str(exc))
     return {"co_writers": list(songwriting_service.get_co_writers(draft_id))}
 @router.get("/themes")
 def list_themes():

--- a/backend/services/songwriting_service.py
+++ b/backend/services/songwriting_service.py
@@ -218,7 +218,12 @@ class SongwritingService:
             raise PermissionError("forbidden")
         if self.band_service and not self.band_service.share_band(user_id, co_writer_id):
             raise PermissionError("forbidden")
-        self._co_writers.setdefault(draft_id, set()).add(co_writer_id)
+        if co_writer_id == user_id:
+            raise ValueError("cannot_invite_self")
+        co_writers = self._co_writers.setdefault(draft_id, set())
+        if co_writer_id in co_writers:
+            raise ValueError("already_invited")
+        co_writers.add(co_writer_id)
 
     def save_version(
         self,

--- a/backend/tests/routes/test_songwriting_routes.py
+++ b/backend/tests/routes/test_songwriting_routes.py
@@ -1,8 +1,13 @@
 import asyncio
+from pathlib import Path
+
 from fastapi import FastAPI
-from backend.routes import songwriting_routes
-from backend.services.songwriting_service import SongwritingService
-from backend.services.originality_service import OriginalityService
+
+Path(__file__).resolve().parents[2].joinpath("database").mkdir(exist_ok=True)
+
+from backend.routes import songwriting_routes  # noqa: E402
+from backend.services.originality_service import OriginalityService  # noqa: E402
+from backend.services.songwriting_service import SongwritingService  # noqa: E402
 
 
 class FakeLLM:
@@ -32,3 +37,52 @@ def test_get_drafts_creator_and_co_writer(client_factory):
     c2 = client_factory(app, {songwriting_routes.get_current_user_id: lambda: 2})
     r2 = c2.get("/songwriting/drafts")
     assert {d["id"] for d in r2.json()} == {d1.id}
+
+
+def test_add_co_writer_self_invite_route(client_factory):
+    svc = SongwritingService(llm_client=FakeLLM(), originality=OriginalityService())
+    draft = asyncio.run(
+        svc.generate_draft(
+            creator_id=1,
+            title="A",
+            genre="rock",
+            themes=["x", "y", "z"],
+        )
+    )
+    songwriting_routes.songwriting_service = svc
+    app = FastAPI()
+    app.include_router(songwriting_routes.router)
+
+    client = client_factory(app, {songwriting_routes.get_current_user_id: lambda: 1})
+    resp = client.post(
+        f"/songwriting/drafts/{draft.id}/co_writers",
+        json={"co_writer_id": 1},
+    )
+    assert resp.status_code == 400
+
+
+def test_add_co_writer_duplicate_route(client_factory):
+    svc = SongwritingService(llm_client=FakeLLM(), originality=OriginalityService())
+    draft = asyncio.run(
+        svc.generate_draft(
+            creator_id=1,
+            title="A",
+            genre="rock",
+            themes=["x", "y", "z"],
+        )
+    )
+    songwriting_routes.songwriting_service = svc
+    app = FastAPI()
+    app.include_router(songwriting_routes.router)
+
+    client = client_factory(app, {songwriting_routes.get_current_user_id: lambda: 1})
+    first = client.post(
+        f"/songwriting/drafts/{draft.id}/co_writers",
+        json={"co_writer_id": 2},
+    )
+    assert first.status_code == 200
+    dup = client.post(
+        f"/songwriting/drafts/{draft.id}/co_writers",
+        json={"co_writer_id": 2},
+    )
+    assert dup.status_code == 409


### PR DESCRIPTION
## Summary
- prevent users from adding themselves as co-writers or re-inviting existing co-writers
- translate co-writer invitation errors into appropriate HTTP responses
- test self-invite and duplicate co-writer scenarios

## Testing
- `ruff check backend/services/songwriting_service.py backend/routes/songwriting_routes.py backend/tests/songwriting/test_songwriting_service.py backend/tests/routes/test_songwriting_routes.py`
- `pytest backend/tests/songwriting/test_songwriting_service.py backend/tests/routes/test_songwriting_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b98c5614d48325a9118bc07e789427