### PR TITLE
Validate themes on draft update

### DIFF
--- a/backend/routes/songwriting_routes.py
+++ b/backend/routes/songwriting_routes.py
@@ -35,6 +35,17 @@ class DraftUpdate(BaseModel):
     chord_progression: str | None = None
     album_art_url: str | None = None
 
+    @validator("themes")
+    def validate_themes(cls, v: List[str] | None) -> List[str] | None:
+        if v is None:
+            return None
+        if len(v) != 3:
+            raise ValueError("exactly_three_themes_required")
+        for t in v:
+            if t not in THEMES:
+                raise ValueError("unknown_theme")
+        return v
+
 
 class CoWriterPayload(BaseModel):
     co_writer_id: int

--- a/backend/services/songwriting_service.py
+++ b/backend/services/songwriting_service.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Set
 from backend.models.song import Song
 from backend.models.song_draft_version import SongDraftVersion
 from backend.models.songwriting import GenerationMetadata, LyricDraft
+from backend.models.theme import THEMES
 from backend.services.ai_art_service import AIArtService, ai_art_service
 from backend.services.band_service import BandService
 from backend.services.chemistry_service import ChemistryService
@@ -192,6 +193,11 @@ class SongwritingService:
             draft.lyrics = lyrics
             self._songs[draft_id].lyrics = lyrics
         if themes is not None:
+            if len(themes) != 3:
+                raise ValueError("exactly_three_themes_required")
+            for t in themes:
+                if t not in THEMES:
+                    raise ValueError("unknown_theme")
             draft.themes = themes
             self._songs[draft_id].themes = themes
 

--- a/backend/tests/songwriting/test_songwriting_service.py
+++ b/backend/tests/songwriting/test_songwriting_service.py
@@ -232,13 +232,31 @@ def test_theme_updates_persist_and_versioned():
             llm_client=FakeLLM(), art_service=FakeArt(), originality=OriginalityService()
         )
         draft = await _generate(svc)
-        new_themes = ["fire", "water", "earth"]
+        new_themes = ["peace", "joy", "truth"]
         svc.update_draft(draft.id, user_id=1, themes=new_themes)
         assert svc.get_draft(draft.id).themes == new_themes
         assert svc.get_song(draft.id).themes == new_themes
         versions = svc.list_versions(draft.id)
         assert len(versions) == 2
         assert versions[-1].themes == new_themes
+
+    asyncio.run(run())
+
+
+def test_update_draft_invalid_themes():
+    async def run():
+        svc = SongwritingService(
+            llm_client=FakeLLM(), art_service=FakeArt(), originality=OriginalityService()
+        )
+        draft = await _generate(svc)
+        with pytest.raises(ValueError):
+            svc.update_draft(draft.id, user_id=1, themes=["only", "two"])
+        with pytest.raises(ValueError):
+            svc.update_draft(
+                draft.id,
+                user_id=1,
+                themes=["love", "hope", "invalid"],
+            )
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- ensure `DraftUpdate` enforces three valid themes
- validate themes in `SongwritingService.update_draft`
- test that invalid theme updates raise errors

## Testing
- `pytest backend/tests/songwriting/test_songwriting_service.py backend/tests/routes/test_songwriting_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b98da01f748325b5ac3d00870309ec