### PR TITLE
Validate themes in draft updates and test invalid route updates

### DIFF
--- a/backend/routes/songwriting_routes.py
+++ b/backend/routes/songwriting_routes.py
@@ -1,7 +1,7 @@
 """Routes for AI-assisted songwriting features."""
 from __future__ import annotations
 
-from typing import Dict, List, Set
+from typing import Dict, Set
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, validator
@@ -31,12 +31,12 @@ class PromptPayload(BaseModel):
 
 class DraftUpdate(BaseModel):
     lyrics: str | None = None
-    themes: List[str] | None = None
+    themes: list[str] | None = None
     chord_progression: str | None = None
     album_art_url: str | None = None
 
     @validator("themes")
-    def validate_themes(cls, v: List[str] | None) -> List[str] | None:
+    def validate_themes(cls, v: list[str] | None) -> list[str] | None:
         if v is None:
             return None
         if len(v) != 3:


### PR DESCRIPTION
## Summary
- ensure `DraftUpdate` uses list typing and validates themes with the same rules as prompt generation
- add API route test confirming invalid theme updates are rejected

## Testing
- `pytest backend/tests/songwriting/test_songwriting_service.py::test_update_draft_invalid_themes -q`
- `pytest backend/tests/routes/test_songwriting_routes.py::test_edit_draft_invalid_themes_route -q`
- `pytest -q` *(fails: email-validator and boto3 not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68b98e66d8048325ac7ea26576dc47a4