### PR TITLE
Validate themes on draft updates

### DIFF
--- a/backend/routes/songwriting_routes.py
+++ b/backend/routes/songwriting_routes.py
@@ -41,9 +41,8 @@ class DraftUpdate(BaseModel):
             return None
         if len(v) != 3:
             raise ValueError("exactly_three_themes_required")
-        for t in v:
-            if t not in THEMES:
-                raise ValueError("unknown_theme")
+        if any(t not in THEMES for t in v):
+            raise ValueError("unknown_theme")
         return v
 
 

--- a/backend/services/songwriting_service.py
+++ b/backend/services/songwriting_service.py
@@ -195,9 +195,8 @@ class SongwritingService:
         if themes is not None:
             if len(themes) != 3:
                 raise ValueError("exactly_three_themes_required")
-            for t in themes:
-                if t not in THEMES:
-                    raise ValueError("unknown_theme")
+            if any(t not in THEMES for t in themes):
+                raise ValueError("unknown_theme")
             draft.themes = themes
             self._songs[draft_id].themes = themes
 

--- a/backend/tests/routes/test_songwriting_routes.py
+++ b/backend/tests/routes/test_songwriting_routes.py
@@ -108,8 +108,10 @@ def test_edit_draft_invalid_themes_route(client_factory):
         json={"themes": ["only", "two"]},
     )
     assert resp.status_code == 422
+    assert resp.json()["detail"][0]["msg"].endswith("exactly_three_themes_required")
     resp2 = client.put(
         f"/songwriting/drafts/{draft.id}",
         json={"themes": ["x", "y", "invalid"]},
     )
     assert resp2.status_code == 422
+    assert resp2.json()["detail"][0]["msg"].endswith("unknown_theme")

--- a/backend/tests/songwriting/test_songwriting_service.py
+++ b/backend/tests/songwriting/test_songwriting_service.py
@@ -249,9 +249,9 @@ def test_update_draft_invalid_themes():
             llm_client=FakeLLM(), art_service=FakeArt(), originality=OriginalityService()
         )
         draft = await _generate(svc)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="exactly_three_themes_required"):
             svc.update_draft(draft.id, user_id=1, themes=["only", "two"])
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="unknown_theme"):
             svc.update_draft(
                 draft.id,
                 user_id=1,


### PR DESCRIPTION
## Summary
- validate themes in `DraftUpdate` just like `PromptPayload`
- guard `SongwritingService.update_draft` against invalid theme lists
- test that service and route reject invalid themes

## Testing
- `pytest backend/tests/songwriting/test_songwriting_service.py::test_update_draft_invalid_themes backend/tests/routes/test_songwriting_routes.py::test_edit_draft_invalid_themes_route -q`


------
https://chatgpt.com/codex/tasks/task_e_68b98fc40768832597e226cd973d3055