### PR TITLE
Add city shop service and admin routes

### DIFF
--- a/backend/routes/admin_city_shop_routes.py
+++ b/backend/routes/admin_city_shop_routes.py
@@ -1,0 +1,97 @@
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.city_shop_service import CityShopService
+
+router = APIRouter(
+    prefix="/city-shops", tags=["AdminCityShops"], dependencies=[Depends(audit_dependency)]
+)
+svc = CityShopService()
+
+
+async def _ensure_admin(req: Request) -> None:
+    admin_id = await get_current_user_id(req)
+    await require_role(["admin"], admin_id)
+
+
+@router.post("/")
+async def create_shop(payload: dict, req: Request):
+    await _ensure_admin(req)
+    city = payload.get("city", "")
+    name = payload.get("name", "")
+    return svc.create_shop(city=city, name=name)
+
+
+@router.get("/")
+async def list_shops(req: Request, city: str | None = None):
+    await _ensure_admin(req)
+    return svc.list_shops(city)
+
+
+@router.put("/{shop_id}")
+async def update_shop(shop_id: int, payload: dict, req: Request):
+    await _ensure_admin(req)
+    shop = svc.update_shop(shop_id, payload)
+    if not shop:
+        raise HTTPException(status_code=404, detail="Shop not found")
+    return shop
+
+
+@router.delete("/{shop_id}")
+async def delete_shop(shop_id: int, req: Request):
+    await _ensure_admin(req)
+    if not svc.delete_shop(shop_id):
+        raise HTTPException(status_code=404, detail="Shop not found")
+    return {"status": "deleted"}
+
+
+@router.post("/{shop_id}/items")
+async def add_item(shop_id: int, payload: dict, req: Request):
+    await _ensure_admin(req)
+    item_id = int(payload.get("item_id"))
+    qty = int(payload.get("quantity", 1))
+    svc.add_item(shop_id, item_id, qty)
+    return {"status": "ok"}
+
+
+@router.get("/{shop_id}/items")
+async def list_items(shop_id: int, req: Request):
+    await _ensure_admin(req)
+    return svc.list_items(shop_id)
+
+
+@router.delete("/{shop_id}/items/{item_id}")
+async def remove_item(shop_id: int, item_id: int, req: Request, quantity: int = 1):
+    await _ensure_admin(req)
+    try:
+        svc.remove_item(shop_id, item_id, quantity)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok"}
+
+
+@router.post("/{shop_id}/books")
+async def add_book(shop_id: int, payload: dict, req: Request):
+    await _ensure_admin(req)
+    book_id = int(payload.get("book_id"))
+    qty = int(payload.get("quantity", 1))
+    svc.add_book(shop_id, book_id, qty)
+    return {"status": "ok"}
+
+
+@router.get("/{shop_id}/books")
+async def list_books(shop_id: int, req: Request):
+    await _ensure_admin(req)
+    return svc.list_books(shop_id)
+
+
+@router.delete("/{shop_id}/books/{book_id}")
+async def remove_book(shop_id: int, book_id: int, req: Request, quantity: int = 1):
+    await _ensure_admin(req)
+    try:
+        svc.remove_book(shop_id, book_id, quantity)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok"}
+

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -8,6 +8,7 @@ from .admin_audit_routes import router as audit_router
 from .admin_book_routes import router as book_router
 from .admin_business_routes import router as business_router
 from .admin_course_routes import router as course_router
+from .admin_city_shop_routes import router as city_shop_router
 from .admin_workshop_routes import router as workshop_router
 from .admin_economy_routes import router as economy_router
 from .admin_item_routes import router as item_router
@@ -33,6 +34,7 @@ router = APIRouter()
 router.include_router(analytics_router)
 router.include_router(audit_router)
 router.include_router(business_router)
+router.include_router(city_shop_router)
 router.include_router(economy_router)
 router.include_router(xp_router)
 router.include_router(xp_event_router)

--- a/backend/services/city_shop_service.py
+++ b/backend/services/city_shop_service.py
@@ -1,0 +1,235 @@
+"""Service for managing city shops and their inventories."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class CityShopService:
+    """Persistent store for shops per city with item and book inventories."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    # ------------------------------------------------------------------
+    # schema helpers
+    # ------------------------------------------------------------------
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS city_shops (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    city TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    created_at TEXT DEFAULT (datetime('now')),
+                    updated_at TEXT
+                )
+                """,
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS shop_items (
+                    shop_id INTEGER NOT NULL,
+                    item_id INTEGER NOT NULL,
+                    quantity INTEGER NOT NULL,
+                    PRIMARY KEY (shop_id, item_id),
+                    FOREIGN KEY (shop_id) REFERENCES city_shops(id) ON DELETE CASCADE
+                )
+                """,
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS shop_books (
+                    shop_id INTEGER NOT NULL,
+                    book_id INTEGER NOT NULL,
+                    quantity INTEGER NOT NULL,
+                    PRIMARY KEY (shop_id, book_id),
+                    FOREIGN KEY (shop_id) REFERENCES city_shops(id) ON DELETE CASCADE
+                )
+                """,
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+    def _fetch(self, shop_id: int) -> Optional[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("SELECT * FROM city_shops WHERE id = ?", (shop_id,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def create_shop(self, city: str, name: str) -> Dict[str, Any]:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO city_shops (city, name) VALUES (?, ?)",
+                (city, name),
+            )
+            conn.commit()
+            sid = int(cur.lastrowid or 0)
+        return {"id": sid, "city": city, "name": name}
+
+    def list_shops(self, city: str | None = None) -> List[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            q = "SELECT * FROM city_shops"
+            params: List[Any] = []
+            if city:
+                q += " WHERE city = ?"
+                params.append(city)
+            cur.execute(q, params)
+            return [dict(r) for r in cur.fetchall()]
+
+    def update_shop(self, shop_id: int, updates: Dict[str, Any]) -> Dict[str, Any]:
+        if not updates:
+            return self._fetch(shop_id) or {}
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            set_clause = ", ".join(f"{k} = ?" for k in updates)
+            values = list(updates.values()) + [shop_id]
+            cur.execute(
+                f"UPDATE city_shops SET {set_clause}, updated_at = datetime('now') WHERE id = ?",
+                values,
+            )
+            if cur.rowcount == 0:
+                return {}
+            conn.commit()
+        return self._fetch(shop_id) or {}
+
+    def delete_shop(self, shop_id: int) -> bool:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM city_shops WHERE id = ?", (shop_id,))
+            deleted = cur.rowcount
+            if deleted:
+                cur.execute("DELETE FROM shop_items WHERE shop_id = ?", (shop_id,))
+                cur.execute("DELETE FROM shop_books WHERE shop_id = ?", (shop_id,))
+            conn.commit()
+        return bool(deleted)
+
+    def get_shop(self, shop_id: int) -> Optional[Dict[str, Any]]:
+        return self._fetch(shop_id)
+
+    # ------------------------------------------------------------------
+    # inventory operations - items
+    # ------------------------------------------------------------------
+    def add_item(self, shop_id: int, item_id: int, quantity: int = 1) -> None:
+        if quantity <= 0:
+            raise ValueError("quantity must be positive")
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO shop_items (shop_id, item_id, quantity)
+                VALUES (?, ?, ?)
+                ON CONFLICT(shop_id, item_id) DO UPDATE SET quantity = quantity + excluded.quantity
+                """,
+                (shop_id, item_id, quantity),
+            )
+            conn.commit()
+
+    def remove_item(self, shop_id: int, item_id: int, quantity: int = 1) -> None:
+        if quantity <= 0:
+            raise ValueError("quantity must be positive")
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT quantity FROM shop_items WHERE shop_id = ? AND item_id = ?",
+                (shop_id, item_id),
+            )
+            row = cur.fetchone()
+            if not row or row[0] < quantity:
+                raise ValueError("not enough items")
+            new_qty = row[0] - quantity
+            if new_qty > 0:
+                cur.execute(
+                    "UPDATE shop_items SET quantity = ? WHERE shop_id = ? AND item_id = ?",
+                    (new_qty, shop_id, item_id),
+                )
+            else:
+                cur.execute(
+                    "DELETE FROM shop_items WHERE shop_id = ? AND item_id = ?",
+                    (shop_id, item_id),
+                )
+            conn.commit()
+
+    def list_items(self, shop_id: int) -> List[Dict[str, int]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT item_id, quantity FROM shop_items WHERE shop_id = ?",
+                (shop_id,),
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+    # ------------------------------------------------------------------
+    # inventory operations - books
+    # ------------------------------------------------------------------
+    def add_book(self, shop_id: int, book_id: int, quantity: int = 1) -> None:
+        if quantity <= 0:
+            raise ValueError("quantity must be positive")
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO shop_books (shop_id, book_id, quantity)
+                VALUES (?, ?, ?)
+                ON CONFLICT(shop_id, book_id) DO UPDATE SET quantity = quantity + excluded.quantity
+                """,
+                (shop_id, book_id, quantity),
+            )
+            conn.commit()
+
+    def remove_book(self, shop_id: int, book_id: int, quantity: int = 1) -> None:
+        if quantity <= 0:
+            raise ValueError("quantity must be positive")
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT quantity FROM shop_books WHERE shop_id = ? AND book_id = ?",
+                (shop_id, book_id),
+            )
+            row = cur.fetchone()
+            if not row or row[0] < quantity:
+                raise ValueError("not enough books")
+            new_qty = row[0] - quantity
+            if new_qty > 0:
+                cur.execute(
+                    "UPDATE shop_books SET quantity = ? WHERE shop_id = ? AND book_id = ?",
+                    (new_qty, shop_id, book_id),
+                )
+            else:
+                cur.execute(
+                    "DELETE FROM shop_books WHERE shop_id = ? AND book_id = ?",
+                    (shop_id, book_id),
+                )
+            conn.commit()
+
+    def list_books(self, shop_id: int) -> List[Dict[str, int]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT book_id, quantity FROM shop_books WHERE shop_id = ?",
+                (shop_id,),
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+
+city_shop_service = CityShopService()
+
+__all__ = ["CityShopService", "city_shop_service"]


### PR DESCRIPTION
## Summary
- implement `CityShopService` with SQLite persistence and item/book inventories
- add admin REST endpoints for managing city shops and their inventories
- register city shop routes within the aggregated admin router

## Testing
- `pytest` *(fails: sqlite3.OperationalError unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68b992a9d5848325874f3542ffe557cb