### PR TITLE
feat: add shop purchase endpoints

### DIFF
--- a/backend/models/book.py
+++ b/backend/models/book.py
@@ -22,6 +22,8 @@ class Book:
     genre: str
     rarity: str
     max_skill_level: int
+    price_cents: int = 0
+    stock: int = 0
 
 
 __all__ = ["Book"]

--- a/backend/models/item.py
+++ b/backend/models/item.py
@@ -20,6 +20,8 @@ class Item:
     name: str
     category: str
     stats: Dict[str, float] = field(default_factory=dict)
+    price_cents: int = 0
+    stock: int = 0
 
 
 __all__ = ["ItemCategory", "Item"]

--- a/backend/routes/shop_routes.py
+++ b/backend/routes/shop_routes.py
@@ -1,0 +1,59 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services.economy_service import EconomyService, EconomyError
+from backend.services.item_service import item_service
+from backend.services.books_service import books_service
+
+router = APIRouter(prefix="/shop", tags=["Shop"])
+
+_economy = EconomyService()
+_economy.ensure_schema()
+
+
+async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
+    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    return user_id
+
+
+class PurchaseIn(BaseModel):
+    owner_user_id: int
+    quantity: int = 1
+
+
+@router.post("/items/{item_id}/purchase")
+def purchase_item(item_id: int, payload: PurchaseIn, user_id: int = Depends(_current_user)):
+    try:
+        item = item_service.get_item(item_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Item not found")
+    if item.stock < payload.quantity:
+        raise HTTPException(status_code=400, detail="Insufficient stock")
+    total = item.price_cents * payload.quantity
+    try:
+        _economy.transfer(user_id, payload.owner_user_id, total)
+    except EconomyError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    item_service.decrement_stock(item_id, payload.quantity)
+    item_service.add_to_inventory(user_id, item_id, payload.quantity)
+    return {"status": "ok", "total_cents": total}
+
+
+@router.post("/books/{book_id}/purchase")
+def purchase_book(book_id: int, payload: PurchaseIn, user_id: int = Depends(_current_user)):
+    try:
+        book = books_service.get_book(book_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Book not found")
+    if book.stock < payload.quantity:
+        raise HTTPException(status_code=400, detail="Insufficient stock")
+    total = book.price_cents * payload.quantity
+    try:
+        _economy.transfer(user_id, payload.owner_user_id, total)
+    except EconomyError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    books_service.decrement_stock(book_id, payload.quantity)
+    for _ in range(payload.quantity):
+        books_service.add_to_inventory(user_id, book_id)
+    return {"status": "ok", "total_cents": total}

--- a/backend/services/books_service.py
+++ b/backend/services/books_service.py
@@ -19,16 +19,31 @@ class BooksService:
 
     # ------------------------------------------------------------------
     # Book CRUD / inventory helpers
+    def list_books(self) -> List[Book]:
+        return list(self._books.values())
+
     def create_book(self, book: Book) -> Book:
         book.id = self._id_seq
         self._books[book.id] = book
         self._id_seq += 1
         return book
 
+    def get_book(self, book_id: int) -> Book:
+        book = self._books.get(book_id)
+        if not book:
+            raise ValueError("Book not found")
+        return book
+
     def add_to_inventory(self, user_id: int, book_id: int) -> None:
         if book_id not in self._books:
             raise ValueError("invalid book")
         self._inventories.setdefault(user_id, []).append(book_id)
+
+    def decrement_stock(self, book_id: int, quantity: int = 1) -> None:
+        book = self.get_book(book_id)
+        if book.stock < quantity:
+            raise ValueError("not enough stock")
+        book.stock -= quantity
 
     def list_inventory(self, user_id: int) -> List[Book]:
         return [self._books[i] for i in self._inventories.get(user_id, [])]

--- a/backend/services/item_service.py
+++ b/backend/services/item_service.py
@@ -41,6 +41,12 @@ class ItemService:
         self._id_seq += 1
         return item
 
+    def get_item(self, item_id: int) -> Item:
+        itm = self._items.get(item_id)
+        if not itm:
+            raise ValueError("Item not found")
+        return itm
+
     def update_item(self, item_id: int, **changes) -> Item:
         itm = self._items.get(item_id)
         if not itm:
@@ -54,6 +60,12 @@ class ItemService:
         self._items.pop(item_id, None)
         for inv in self._inventories.values():
             inv.pop(item_id, None)
+
+    def decrement_stock(self, item_id: int, quantity: int = 1) -> None:
+        itm = self.get_item(item_id)
+        if itm.stock < quantity:
+            raise ValueError("not enough stock")
+        itm.stock -= quantity
 
     # ------------------------------------------------------------------
     # Inventory management


### PR DESCRIPTION
## Summary
- add price and stock fields to item and book models
- allow services to expose prices and decrement stock
- add shop routes for purchasing items and books using EconomyService

## Testing
- `python -m pytest backend/tests/avatars/test_avatar_service.py -q` *(fails: Foreign key associated with column 'avatars.character_id' could not find table 'characters')*

------
https://chatgpt.com/codex/tasks/task_e_68b9938b7f34832594c433027ef0a2ba