### PR TITLE
Use SQLite for item management

### DIFF
--- a/backend/migrations/sql/130_items_and_xp_items.sql
+++ b/backend/migrations/sql/130_items_and_xp_items.sql
@@ -1,0 +1,41 @@
+-- Adds tables for generic items, XP items, and user inventories
+
+CREATE TABLE IF NOT EXISTS item_categories (
+    name TEXT PRIMARY KEY,
+    description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    category TEXT NOT NULL,
+    stats_json TEXT DEFAULT '{}',
+    price_cents INTEGER DEFAULT 0,
+    stock INTEGER DEFAULT 0,
+    FOREIGN KEY (category) REFERENCES item_categories(name)
+);
+
+CREATE TABLE IF NOT EXISTS user_items (
+    user_id INTEGER NOT NULL,
+    item_id INTEGER NOT NULL,
+    quantity INTEGER NOT NULL,
+    PRIMARY KEY (user_id, item_id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+
+CREATE TABLE IF NOT EXISTS xp_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    effect_type TEXT NOT NULL,
+    amount REAL NOT NULL,
+    duration INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS user_xp_items (
+    user_id INTEGER NOT NULL,
+    item_id INTEGER NOT NULL,
+    quantity INTEGER NOT NULL,
+    PRIMARY KEY (user_id, item_id),
+    FOREIGN KEY (item_id) REFERENCES xp_items(id)
+);
+

--- a/backend/routes/admin_item_routes.py
+++ b/backend/routes/admin_item_routes.py
@@ -4,13 +4,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from backend.auth.dependencies import get_current_user_id, require_role
 from backend.models.item import Item
 from backend.services.admin_audit_service import audit_dependency
-from backend.services.item_service import ItemService, item_service
+from backend.services.item_service import ItemService
 from pydantic import BaseModel
 
 router = APIRouter(
     prefix="/items", tags=["AdminItems"], dependencies=[Depends(audit_dependency)]
 )
-svc: ItemService = item_service
+svc = ItemService()
 
 
 class ItemIn(BaseModel):

--- a/backend/routes/admin_xp_item_routes.py
+++ b/backend/routes/admin_xp_item_routes.py
@@ -6,12 +6,12 @@ from pydantic import BaseModel, Field
 from backend.auth.dependencies import get_current_user_id, require_role
 from backend.models.xp_item import XPItem
 from backend.services.admin_audit_service import audit_dependency
-from backend.services.xp_item_service import XPItemService, xp_item_service
+from backend.services.xp_item_service import XPItemService
 
 router = APIRouter(
     prefix="/xp/items", tags=["AdminXPItems"], dependencies=[Depends(audit_dependency)]
 )
-svc: XPItemService = xp_item_service
+svc = XPItemService()
 
 
 class XPItemIn(BaseModel):


### PR DESCRIPTION
## Summary
- Persist item categories, items, and user inventories using SQLite
- Add XP item persistence and user XP inventories
- Provide migration to create item and XP item tables and update admin routes

## Testing
- `pytest` *(fails: OperationalError unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68b995dd846c83259364aa4755afacf6