### PR TITLE
Add pricing support to city shop inventory

### DIFF
--- a/backend/routes/admin_city_shop_routes.py
+++ b/backend/routes/admin_city_shop_routes.py
@@ -51,7 +51,20 @@ async def add_item(shop_id: int, payload: dict, req: Request):
     await _ensure_admin(req)
     item_id = int(payload.get("item_id"))
     qty = int(payload.get("quantity", 1))
-    svc.add_item(shop_id, item_id, qty)
+    price = int(payload.get("price_cents", 0))
+    svc.add_item(shop_id, item_id, qty, price)
+    return {"status": "ok"}
+
+
+@router.put("/{shop_id}/items/{item_id}")
+async def update_item(shop_id: int, item_id: int, payload: dict, req: Request):
+    await _ensure_admin(req)
+    qty = payload.get("quantity")
+    price = payload.get("price_cents")
+    try:
+        svc.update_item(shop_id, item_id, quantity=qty, price_cents=price)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     return {"status": "ok"}
 
 
@@ -76,7 +89,20 @@ async def add_book(shop_id: int, payload: dict, req: Request):
     await _ensure_admin(req)
     book_id = int(payload.get("book_id"))
     qty = int(payload.get("quantity", 1))
-    svc.add_book(shop_id, book_id, qty)
+    price = int(payload.get("price_cents", 0))
+    svc.add_book(shop_id, book_id, qty, price)
+    return {"status": "ok"}
+
+
+@router.put("/{shop_id}/books/{book_id}")
+async def update_book(shop_id: int, book_id: int, payload: dict, req: Request):
+    await _ensure_admin(req)
+    qty = payload.get("quantity")
+    price = payload.get("price_cents")
+    try:
+        svc.update_book(shop_id, book_id, quantity=qty, price_cents=price)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     return {"status": "ok"}
 
 

--- a/frontend/src/admin/economy/CityShopsAdmin.tsx
+++ b/frontend/src/admin/economy/CityShopsAdmin.tsx
@@ -10,11 +10,13 @@ interface Shop {
 interface Item {
   item_id: number;
   quantity: number;
+  price_cents: number;
 }
 
 interface Book {
   book_id: number;
   quantity: number;
+  price_cents: number;
 }
 
 const CityShopsAdmin: React.FC = () => {
@@ -55,14 +57,42 @@ const CityShopsAdmin: React.FC = () => {
   ) => {
     e.preventDefault();
     const form = e.target as HTMLFormElement;
-    const itemId = Number((form.elements.namedItem('itemId') as HTMLInputElement).value);
-    const quantity = Number((form.elements.namedItem('quantity') as HTMLInputElement).value);
+    const itemId = Number(
+      (form.elements.namedItem('itemId') as HTMLInputElement).value,
+    );
+    const quantity = Number(
+      (form.elements.namedItem('quantity') as HTMLInputElement).value,
+    );
+    const price = Number(
+      (form.elements.namedItem('priceCents') as HTMLInputElement).value,
+    );
     await fetch(`/admin/economy/city-shops/${shopId}/items`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ item_id: itemId, quantity }),
+      body: JSON.stringify({ item_id: itemId, quantity, price_cents: price }),
     });
     form.reset();
+    loadInventory(shopId);
+  };
+
+  const handleUpdateItem = async (
+    shopId: number,
+    itemId: number,
+    e: React.FormEvent<HTMLFormElement>,
+  ) => {
+    e.preventDefault();
+    const form = e.target as HTMLFormElement;
+    const quantity = Number(
+      (form.elements.namedItem('quantity') as HTMLInputElement).value,
+    );
+    const price = Number(
+      (form.elements.namedItem('priceCents') as HTMLInputElement).value,
+    );
+    await fetch(`/admin/economy/city-shops/${shopId}/items/${itemId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ quantity, price_cents: price }),
+    });
     loadInventory(shopId);
   };
 
@@ -84,14 +114,42 @@ const CityShopsAdmin: React.FC = () => {
   ) => {
     e.preventDefault();
     const form = e.target as HTMLFormElement;
-    const bookId = Number((form.elements.namedItem('bookId') as HTMLInputElement).value);
-    const quantity = Number((form.elements.namedItem('quantity') as HTMLInputElement).value);
+    const bookId = Number(
+      (form.elements.namedItem('bookId') as HTMLInputElement).value,
+    );
+    const quantity = Number(
+      (form.elements.namedItem('quantity') as HTMLInputElement).value,
+    );
+    const price = Number(
+      (form.elements.namedItem('priceCents') as HTMLInputElement).value,
+    );
     await fetch(`/admin/economy/city-shops/${shopId}/books`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ book_id: bookId, quantity }),
+      body: JSON.stringify({ book_id: bookId, quantity, price_cents: price }),
     });
     form.reset();
+    loadInventory(shopId);
+  };
+
+  const handleUpdateBook = async (
+    shopId: number,
+    bookId: number,
+    e: React.FormEvent<HTMLFormElement>,
+  ) => {
+    e.preventDefault();
+    const form = e.target as HTMLFormElement;
+    const quantity = Number(
+      (form.elements.namedItem('quantity') as HTMLInputElement).value,
+    );
+    const price = Number(
+      (form.elements.namedItem('priceCents') as HTMLInputElement).value,
+    );
+    await fetch(`/admin/economy/city-shops/${shopId}/books/${bookId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ quantity, price_cents: price }),
+    });
     loadInventory(shopId);
   };
 
@@ -174,16 +232,45 @@ const CityShopsAdmin: React.FC = () => {
                       defaultValue={1}
                       className="border px-1"
                     />
+                    <input
+                      name="priceCents"
+                      type="number"
+                      placeholder="Price (¢)"
+                      className="border px-1"
+                    />
                     <button type="submit" className="text-green-500">
                       Add
                     </button>
                   </form>
                   <ul className="mt-2 space-y-1">
                     {(items[shop.id] || []).map((it) => (
-                      <li key={it.item_id} className="flex justify-between">
-                        <span>
-                          Item {it.item_id} x {it.quantity}
-                        </span>
+                      <li
+                        key={it.item_id}
+                        className="flex justify-between items-center space-x-2"
+                      >
+                        <form
+                          onSubmit={(e) =>
+                            handleUpdateItem(shop.id, it.item_id, e)
+                          }
+                          className="flex space-x-2 items-center"
+                        >
+                          <span>Item {it.item_id}</span>
+                          <input
+                            name="quantity"
+                            type="number"
+                            defaultValue={it.quantity}
+                            className="border px-1 w-16"
+                          />
+                          <input
+                            name="priceCents"
+                            type="number"
+                            defaultValue={it.price_cents}
+                            className="border px-1 w-24"
+                          />
+                          <button type="submit" className="text-blue-500">
+                            Update
+                          </button>
+                        </form>
                         <button
                           className="text-red-500"
                           onClick={() =>
@@ -215,16 +302,45 @@ const CityShopsAdmin: React.FC = () => {
                       defaultValue={1}
                       className="border px-1"
                     />
+                    <input
+                      name="priceCents"
+                      type="number"
+                      placeholder="Price (¢)"
+                      className="border px-1"
+                    />
                     <button type="submit" className="text-green-500">
                       Add
                     </button>
                   </form>
                   <ul className="mt-2 space-y-1">
                     {(books[shop.id] || []).map((b) => (
-                      <li key={b.book_id} className="flex justify-between">
-                        <span>
-                          Book {b.book_id} x {b.quantity}
-                        </span>
+                      <li
+                        key={b.book_id}
+                        className="flex justify-between items-center space-x-2"
+                      >
+                        <form
+                          onSubmit={(e) =>
+                            handleUpdateBook(shop.id, b.book_id, e)
+                          }
+                          className="flex space-x-2 items-center"
+                        >
+                          <span>Book {b.book_id}</span>
+                          <input
+                            name="quantity"
+                            type="number"
+                            defaultValue={b.quantity}
+                            className="border px-1 w-16"
+                          />
+                          <input
+                            name="priceCents"
+                            type="number"
+                            defaultValue={b.price_cents}
+                            className="border px-1 w-24"
+                          />
+                          <button type="submit" className="text-blue-500">
+                            Update
+                          </button>
+                        </form>
                         <button
                           className="text-red-500"
                           onClick={() =>


### PR DESCRIPTION
## Summary
- store item and book prices in city shop inventory tables
- support inventory price updates via admin endpoints
- manage item and book prices in admin UI forms

## Testing
- `PYTHONPATH=. pytest tests/test_books_service.py::test_queue_reading -q`
- `npm test --silent` *(fails: npm not installed)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b998e0ba888325b7be6f13e92c2814