### PR TITLE
Add shop restock scheduling and admin controls

### DIFF
--- a/backend/routes/admin_city_shop_routes.py
+++ b/backend/routes/admin_city_shop_routes.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from backend.auth.dependencies import get_current_user_id, require_role
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.city_shop_service import CityShopService
+from backend.services.shop_restock_service import schedule_restock
 
 router = APIRouter(
     prefix="/city-shops", tags=["AdminCityShops"], dependencies=[Depends(audit_dependency)]
@@ -71,6 +72,17 @@ async def remove_item(shop_id: int, item_id: int, req: Request, quantity: int = 
     return {"status": "ok"}
 
 
+@router.put("/{shop_id}/items/{item_id}/restock")
+async def set_item_restock(shop_id: int, item_id: int, payload: dict, req: Request):
+    await _ensure_admin(req)
+    interval = payload.get("interval")
+    qty = payload.get("quantity")
+    svc.set_item_restock(shop_id, item_id, interval, qty)
+    if interval and qty:
+        schedule_restock(shop_id, "item", item_id, int(interval), int(qty))
+    return {"status": "ok"}
+
+
 @router.post("/{shop_id}/books")
 async def add_book(shop_id: int, payload: dict, req: Request):
     await _ensure_admin(req)
@@ -93,5 +105,16 @@ async def remove_book(shop_id: int, book_id: int, req: Request, quantity: int = 
         svc.remove_book(shop_id, book_id, quantity)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok"}
+
+
+@router.put("/{shop_id}/books/{book_id}/restock")
+async def set_book_restock(shop_id: int, book_id: int, payload: dict, req: Request):
+    await _ensure_admin(req)
+    interval = payload.get("interval")
+    qty = payload.get("quantity")
+    svc.set_book_restock(shop_id, book_id, interval, qty)
+    if interval and qty:
+        schedule_restock(shop_id, "book", book_id, int(interval), int(qty))
     return {"status": "ok"}
 

--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -12,6 +12,7 @@ from backend.services.peer_learning_service import run_scheduled_session
 from backend.services.skill_service import skill_service
 from backend.services.social_sentiment_service import social_sentiment_service
 from backend.services.song_popularity_forecast import forecast_service
+from backend.services.shop_restock_service import restock_handler
 from backend.models.notification_models import (
     alert_no_plan,
     alert_pending_outcomes,
@@ -126,6 +127,7 @@ EVENT_HANDLERS = {
     "daily_loop_reset": _daily_loop_reset_wrapper,
     "plan_reminder": _plan_reminder,
     "outcome_reminder": _outcome_reminder,
+    "shop_restock": restock_handler,
     # Add more event handlers here as needed
 }
 

--- a/backend/services/shop_restock_service.py
+++ b/backend/services/shop_restock_service.py
@@ -1,0 +1,54 @@
+"""Shop restocking helpers using :mod:`scheduler_service`."""
+
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Dict
+
+from backend.database import DB_PATH
+
+
+def _update_quantity(table: str, shop_id: int, item_id: int, quantity: int) -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        if table == "items":
+            cur.execute(
+                "UPDATE shop_items SET quantity = quantity + ? WHERE shop_id = ? AND item_id = ?",
+                (quantity, shop_id, item_id),
+            )
+        else:
+            cur.execute(
+                "UPDATE shop_books SET quantity = quantity + ? WHERE shop_id = ? AND book_id = ?",
+                (quantity, shop_id, item_id),
+            )
+        conn.commit()
+
+
+def restock_handler(shop_id: int, kind: str, item_id: int, quantity: int) -> Dict[str, str]:
+    """Scheduled task handler to restock an item or book."""
+    table = "items" if kind == "item" else "books"
+    _update_quantity(table, shop_id, item_id, quantity)
+    return {"status": "restocked"}
+
+
+def schedule_restock(
+    shop_id: int, kind: str, item_id: int, interval: int, quantity: int
+) -> Dict[str, int]:
+    """Schedule recurring restocking for a shop item or book."""
+    from backend.services.scheduler_service import schedule_task
+
+    run_at = (datetime.utcnow() + timedelta(days=interval)).isoformat()
+    return schedule_task(
+        "shop_restock",
+        {
+            "shop_id": shop_id,
+            "kind": kind,
+            "item_id": item_id,
+            "quantity": quantity,
+        },
+        run_at,
+        recurring=True,
+        interval_days=interval,
+    )
+
+
+__all__ = ["restock_handler", "schedule_restock"]

--- a/frontend/src/admin/economy/CityShopsAdmin.tsx
+++ b/frontend/src/admin/economy/CityShopsAdmin.tsx
@@ -10,11 +10,15 @@ interface Shop {
 interface Item {
   item_id: number;
   quantity: number;
+  restock_interval?: number | null;
+  restock_quantity?: number | null;
 }
 
 interface Book {
   book_id: number;
   quantity: number;
+  restock_interval?: number | null;
+  restock_quantity?: number | null;
 }
 
 const CityShopsAdmin: React.FC = () => {
@@ -107,6 +111,42 @@ const CityShopsAdmin: React.FC = () => {
     loadInventory(shopId);
   };
 
+  const handleItemRestock = async (
+    shopId: number,
+    itemId: number,
+    e: React.FormEvent<HTMLFormElement>,
+  ) => {
+    e.preventDefault();
+    const form = e.target as HTMLFormElement;
+    const interval = Number((form.elements.namedItem('interval') as HTMLInputElement).value);
+    const quantity = Number((form.elements.namedItem('quantity') as HTMLInputElement).value);
+    await fetch(`/admin/economy/city-shops/${shopId}/items/${itemId}/restock`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ interval, quantity }),
+    });
+    form.reset();
+    loadInventory(shopId);
+  };
+
+  const handleBookRestock = async (
+    shopId: number,
+    bookId: number,
+    e: React.FormEvent<HTMLFormElement>,
+  ) => {
+    e.preventDefault();
+    const form = e.target as HTMLFormElement;
+    const interval = Number((form.elements.namedItem('interval') as HTMLInputElement).value);
+    const quantity = Number((form.elements.namedItem('quantity') as HTMLInputElement).value);
+    await fetch(`/admin/economy/city-shops/${shopId}/books/${bookId}/restock`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ interval, quantity }),
+    });
+    form.reset();
+    loadInventory(shopId);
+  };
+
   return (
     <div>
       <h2 className="text-xl font-bold mb-4">City Shops Admin</h2>
@@ -180,18 +220,45 @@ const CityShopsAdmin: React.FC = () => {
                   </form>
                   <ul className="mt-2 space-y-1">
                     {(items[shop.id] || []).map((it) => (
-                      <li key={it.item_id} className="flex justify-between">
-                        <span>
-                          Item {it.item_id} x {it.quantity}
-                        </span>
-                        <button
-                          className="text-red-500"
-                          onClick={() =>
-                            handleRemoveItem(shop.id, it.item_id, it.quantity)
-                          }
+                      <li key={it.item_id} className="space-y-1">
+                        <div className="flex justify-between">
+                          <span>
+                            Item {it.item_id} x {it.quantity}
+                            {it.restock_interval && it.restock_quantity && (
+                              <span className="text-sm text-gray-500 ml-1">
+                                (restock {it.restock_quantity} every {it.restock_interval}d)
+                              </span>
+                            )}
+                          </span>
+                          <button
+                            className="text-red-500"
+                            onClick={() =>
+                              handleRemoveItem(shop.id, it.item_id, it.quantity)
+                            }
+                          >
+                            Remove
+                          </button>
+                        </div>
+                        <form
+                          onSubmit={(e) => handleItemRestock(shop.id, it.item_id, e)}
+                          className="space-x-1"
                         >
-                          Remove
-                        </button>
+                          <input
+                            name="interval"
+                            type="number"
+                            placeholder="Interval"
+                            className="border px-1"
+                          />
+                          <input
+                            name="quantity"
+                            type="number"
+                            placeholder="Qty"
+                            className="border px-1"
+                          />
+                          <button type="submit" className="text-blue-500">
+                            Set
+                          </button>
+                        </form>
                       </li>
                     ))}
                   </ul>
@@ -221,18 +288,45 @@ const CityShopsAdmin: React.FC = () => {
                   </form>
                   <ul className="mt-2 space-y-1">
                     {(books[shop.id] || []).map((b) => (
-                      <li key={b.book_id} className="flex justify-between">
-                        <span>
-                          Book {b.book_id} x {b.quantity}
-                        </span>
-                        <button
-                          className="text-red-500"
-                          onClick={() =>
-                            handleRemoveBook(shop.id, b.book_id, b.quantity)
-                          }
+                      <li key={b.book_id} className="space-y-1">
+                        <div className="flex justify-between">
+                          <span>
+                            Book {b.book_id} x {b.quantity}
+                            {b.restock_interval && b.restock_quantity && (
+                              <span className="text-sm text-gray-500 ml-1">
+                                (restock {b.restock_quantity} every {b.restock_interval}d)
+                              </span>
+                            )}
+                          </span>
+                          <button
+                            className="text-red-500"
+                            onClick={() =>
+                              handleRemoveBook(shop.id, b.book_id, b.quantity)
+                            }
+                          >
+                            Remove
+                          </button>
+                        </div>
+                        <form
+                          onSubmit={(e) => handleBookRestock(shop.id, b.book_id, e)}
+                          className="space-x-1"
                         >
-                          Remove
-                        </button>
+                          <input
+                            name="interval"
+                            type="number"
+                            placeholder="Interval"
+                            className="border px-1"
+                          />
+                          <input
+                            name="quantity"
+                            type="number"
+                            placeholder="Qty"
+                            className="border px-1"
+                          />
+                          <button type="submit" className="text-blue-500">
+                            Set
+                          </button>
+                        </form>
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Summary
- add restock configuration fields to city shop inventories
- create shop restock service and scheduler integration
- expose admin endpoints and UI to manage restock schedules

## Testing
- `pytest` (fails: NoReferencedTableError and other DB-related errors during collection)
- `npm --prefix frontend test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68b99a0d28948325a3547545158e095e