### PR TITLE
Add marketplace service, routes, and frontend components

### DIFF
--- a/backend/routes/marketplace_routes.py
+++ b/backend/routes/marketplace_routes.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services.economy_service import EconomyService, EconomyError
+from backend.services.marketplace_service import MarketplaceService, MarketplaceError
+
+router = APIRouter(prefix="/marketplace", tags=["Marketplace"])
+
+_economy = EconomyService()
+_market = MarketplaceService(economy=_economy)
+_market.ensure_schema()
+
+async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
+    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    return user_id
+
+class ListingIn(BaseModel):
+    title: str
+    description: str = ""
+    starting_price_cents: int
+
+@router.get("/listings")
+def list_listings():
+    return _market.list_active()
+
+@router.post("/listings")
+def create_listing(payload: ListingIn, user_id: int = Depends(_current_user)):
+    listing_id = _market.create_listing(
+        user_id, payload.title, payload.description, payload.starting_price_cents
+    )
+    return {"id": listing_id}
+
+@router.get("/listings/{listing_id}")
+def get_listing(listing_id: int):
+    try:
+        return _market.get_listing(listing_id)
+    except MarketplaceError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+@router.delete("/listings/{listing_id}")
+def delete_listing(listing_id: int, user_id: int = Depends(_current_user)):
+    try:
+        _market.delete_listing(listing_id, user_id)
+    except MarketplaceError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return {"status": "ok"}
+
+class BidIn(BaseModel):
+    amount_cents: int
+
+@router.post("/listings/{listing_id}/bid")
+def place_bid(listing_id: int, payload: BidIn, user_id: int = Depends(_current_user)):
+    try:
+        _market.place_bid(listing_id, user_id, payload.amount_cents)
+    except MarketplaceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok"}
+
+@router.post("/listings/{listing_id}/purchase")
+def purchase(listing_id: int, user_id: int = Depends(_current_user)):
+    try:
+        _market.purchase(listing_id, user_id)
+    except (MarketplaceError, EconomyError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok"}

--- a/backend/services/marketplace_service.py
+++ b/backend/services/marketplace_service.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+"""Service layer for a simple item marketplace with bidding."""
+
+import sqlite3
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from backend.services.economy_service import EconomyService, EconomyError
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class MarketplaceError(Exception):
+    pass
+
+
+class MarketplaceService:
+    def __init__(self, db_path: Optional[str] = None, economy: Optional[EconomyService] = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.economy = economy or EconomyService(db_path=self.db_path)
+
+    # --------------------------- schema ---------------------------
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS marketplace_listings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    seller_id INTEGER NOT NULL,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    current_price_cents INTEGER NOT NULL,
+                    highest_bidder_id INTEGER,
+                    status TEXT NOT NULL DEFAULT 'active',
+                    created_at TEXT DEFAULT (datetime('now'))
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS marketplace_bids (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    listing_id INTEGER NOT NULL,
+                    bidder_id INTEGER NOT NULL,
+                    amount_cents INTEGER NOT NULL,
+                    created_at TEXT DEFAULT (datetime('now'))
+                )
+                """
+            )
+            conn.commit()
+
+    # --------------------------- helpers ---------------------------
+    def _get_listing(self, cur: sqlite3.Cursor, listing_id: int) -> Dict:
+        cur.execute("SELECT * FROM marketplace_listings WHERE id = ?", (listing_id,))
+        row = cur.fetchone()
+        if not row:
+            raise MarketplaceError("Listing not found")
+        columns = [d[0] for d in cur.description]
+        return dict(zip(columns, row))
+
+    # --------------------------- listings ---------------------------
+    def create_listing(self, seller_id: int, title: str, description: str, starting_price_cents: int) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO marketplace_listings (seller_id, title, description, current_price_cents)
+                VALUES (?, ?, ?, ?)
+                """,
+                (seller_id, title, description, starting_price_cents),
+            )
+            conn.commit()
+            return int(cur.lastrowid or 0)
+
+    def list_active(self) -> List[Dict]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("SELECT * FROM marketplace_listings WHERE status = 'active' ORDER BY created_at DESC")
+            return [dict(r) for r in cur.fetchall()]
+
+    def get_listing(self, listing_id: int) -> Dict:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("SELECT * FROM marketplace_listings WHERE id = ?", (listing_id,))
+            row = cur.fetchone()
+            if not row:
+                raise MarketplaceError("Listing not found")
+            return dict(row)
+
+    def delete_listing(self, listing_id: int, user_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "DELETE FROM marketplace_listings WHERE id = ? AND seller_id = ? AND status = 'active'",
+                (listing_id, user_id),
+            )
+            if cur.rowcount == 0:
+                raise MarketplaceError("Listing not found or cannot be deleted")
+            conn.commit()
+
+    # --------------------------- bidding ---------------------------
+    def place_bid(self, listing_id: int, bidder_id: int, amount_cents: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            listing = self._get_listing(cur, listing_id)
+            if listing["status"] != "active":
+                raise MarketplaceError("Listing not active")
+            if amount_cents <= listing["current_price_cents"]:
+                raise MarketplaceError("Bid must be higher than current price")
+            cur.execute(
+                "INSERT INTO marketplace_bids (listing_id, bidder_id, amount_cents) VALUES (?, ?, ?)",
+                (listing_id, bidder_id, amount_cents),
+            )
+            cur.execute(
+                "UPDATE marketplace_listings SET current_price_cents = ?, highest_bidder_id = ? WHERE id = ?",
+                (amount_cents, bidder_id, listing_id),
+            )
+            conn.commit()
+
+    # --------------------------- purchasing ---------------------------
+    def purchase(self, listing_id: int, buyer_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            listing = self._get_listing(cur, listing_id)
+            if listing["status"] != "active":
+                raise MarketplaceError("Listing not active")
+            if listing.get("highest_bidder_id") != buyer_id:
+                raise MarketplaceError("Only highest bidder can purchase")
+            try:
+                self.economy.transfer(buyer_id, listing["seller_id"], listing["current_price_cents"])
+            except EconomyError as exc:
+                raise MarketplaceError(str(exc))
+            cur.execute("UPDATE marketplace_listings SET status = 'sold' WHERE id = ?", (listing_id,))
+            conn.commit()

--- a/frontend/src/marketplace/ListingList.tsx
+++ b/frontend/src/marketplace/ListingList.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+
+interface Listing {
+  id: number;
+  title: string;
+  description: string;
+  current_price_cents: number;
+}
+
+interface Props {
+  reloadKey: number;
+}
+
+const ListingList: React.FC<Props> = ({ reloadKey }) => {
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [bids, setBids] = useState<Record<number, number>>({});
+
+  const load = () => {
+    fetch('/marketplace/listings')
+      .then((res) => res.json())
+      .then(setListings);
+  };
+
+  useEffect(() => {
+    load();
+  }, [reloadKey]);
+
+  const placeBid = async (id: number) => {
+    const amount = bids[id];
+    if (!amount) return;
+    await fetch(`/marketplace/listings/${id}/bid`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amount_cents: amount }),
+    });
+    setBids((prev) => ({ ...prev, [id]: 0 }));
+    load();
+  };
+
+  const purchase = async (id: number) => {
+    await fetch(`/marketplace/listings/${id}/purchase`, { method: 'POST' });
+    load();
+  };
+
+  return (
+    <div>
+      <h3 className="font-semibold">Listings</h3>
+      <ul className="space-y-2">
+        {listings.map((l) => (
+          <li key={l.id} className="border p-2">
+            <div className="font-bold">{l.title}</div>
+            <div className="text-sm">{l.description}</div>
+            <div>Current: {l.current_price_cents}¢</div>
+            <div className="flex space-x-2 mt-1">
+              <input
+                type="number"
+                className="border px-1 w-24"
+                value={bids[l.id] || ''}
+                onChange={(e) =>
+                  setBids({ ...bids, [l.id]: Number(e.target.value) })
+                }
+                placeholder="Bid (¢)"
+              />
+              <button
+                className="text-blue-500"
+                onClick={() => placeBid(l.id)}
+              >
+                Bid
+              </button>
+              <button
+                className="text-green-600"
+                onClick={() => purchase(l.id)}
+              >
+                Buy
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ListingList;

--- a/frontend/src/marketplace/Marketplace.tsx
+++ b/frontend/src/marketplace/Marketplace.tsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import ListingList from './ListingList';
+import NewListingForm from './NewListingForm';
+
+const Marketplace: React.FC = () => {
+  const [reloadKey, setReloadKey] = useState(0);
+  const reload = () => setReloadKey((k) => k + 1);
+  return (
+    <div className="p-4 space-y-4">
+      <NewListingForm onCreated={reload} />
+      <ListingList reloadKey={reloadKey} />
+    </div>
+  );
+};
+
+export default Marketplace;

--- a/frontend/src/marketplace/NewListingForm.tsx
+++ b/frontend/src/marketplace/NewListingForm.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onCreated: () => void;
+}
+
+const NewListingForm: React.FC<Props> = ({ onCreated }) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [price, setPrice] = useState<number>(0);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/marketplace/listings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title,
+        description,
+        starting_price_cents: price,
+      }),
+    });
+    setTitle('');
+    setDescription('');
+    setPrice(0);
+    onCreated();
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-2">
+      <input
+        className="border px-1 w-full"
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <textarea
+        className="border px-1 w-full"
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <input
+        className="border px-1 w-full"
+        type="number"
+        placeholder="Starting price (¢)"
+        value={price}
+        onChange={(e) => setPrice(Number(e.target.value))}
+      />
+      <button type="submit" className="text-blue-500">
+        List Item
+      </button>
+    </form>
+  );
+};
+
+export default NewListingForm;

--- a/frontend/src/marketplace/index.tsx
+++ b/frontend/src/marketplace/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Marketplace from './Marketplace';
+import '../index.css';
+
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<Marketplace />);
+}


### PR DESCRIPTION
## Summary
- implement marketplace service with listing, bidding and purchases via EconomyService
- expose FastAPI marketplace routes for CRUD, bidding and purchasing
- add React components for listing, browsing and bidding on items

## Testing
- `pytest` *(fails: sqlite3.OperationalError: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68b99db1ca7c8325be3f56100c034452