### PR TITLE
Enable selling items and books to city shops

### DIFF
--- a/backend/routes/shop_routes.py
+++ b/backend/routes/shop_routes.py
@@ -6,6 +6,7 @@ from backend.services.economy_service import EconomyService, EconomyError
 from backend.services.item_service import item_service
 from backend.services.books_service import books_service
 from backend.services.loyalty_service import loyalty_service
+from backend.services.city_shop_service import city_shop_service
 
 router = APIRouter(prefix="/shop", tags=["Shop"])
 
@@ -20,6 +21,10 @@ async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
 
 class PurchaseIn(BaseModel):
     owner_user_id: int
+    quantity: int = 1
+
+
+class SellIn(BaseModel):
     quantity: int = 1
 
 
@@ -51,6 +56,15 @@ def purchase_item(item_id: int, payload: PurchaseIn, user_id: int = Depends(_cur
     }
 
 
+@router.post("/city/{shop_id}/items/{item_id}/sell")
+def sell_item(shop_id: int, item_id: int, payload: SellIn, user_id: int = Depends(_current_user)):
+    try:
+        payout = city_shop_service.sell_item(shop_id, user_id, item_id, payload.quantity)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok", "payout_cents": payout}
+
+
 @router.post("/books/{book_id}/purchase")
 def purchase_book(book_id: int, payload: PurchaseIn, user_id: int = Depends(_current_user)):
     try:
@@ -78,3 +92,12 @@ def purchase_book(book_id: int, payload: PurchaseIn, user_id: int = Depends(_cur
         "discount_cents": discount_cents,
         "earned_points": earned,
     }
+
+
+@router.post("/city/{shop_id}/books/{book_id}/sell")
+def sell_book(shop_id: int, book_id: int, payload: SellIn, user_id: int = Depends(_current_user)):
+    try:
+        payout = city_shop_service.sell_book(shop_id, user_id, book_id, payload.quantity)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok", "payout_cents": payout}

--- a/frontend/src/shop/SellButton.tsx
+++ b/frontend/src/shop/SellButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface Props {
+  onConfirm: () => void;
+  label?: string;
+}
+
+const SellButton: React.FC<Props> = ({ onConfirm, label = 'Sell' }) => {
+  const handleClick = () => {
+    if (window.confirm('Are you sure you want to sell this item?')) {
+      onConfirm();
+    }
+  };
+
+  return (
+    <button className="text-red-600" onClick={handleClick}>
+      {label}
+    </button>
+  );
+};
+
+export default SellButton;

--- a/frontend/src/shop/ShopItem.tsx
+++ b/frontend/src/shop/ShopItem.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import SellButton from './SellButton';
+
+interface Props {
+  id: number;
+  name: string;
+  onSell: (id: number) => void;
+}
+
+const ShopItem: React.FC<Props> = ({ id, name, onSell }) => (
+  <div className="flex justify-between items-center border-b py-1">
+    <span>{name}</span>
+    <SellButton onConfirm={() => onSell(id)} />
+  </div>
+);
+
+export default ShopItem;

--- a/frontend/src/shop/index.tsx
+++ b/frontend/src/shop/index.tsx
@@ -1,0 +1,2 @@
+export { default as SellButton } from './SellButton';
+export { default as ShopItem } from './ShopItem';


### PR DESCRIPTION
## Summary
- allow city shops to buy items and books from players and deposit earnings
- expose sell endpoints for items and books
- add basic shop UI components with sell buttons and confirmation dialogs

## Testing
- `pytest` *(fails: NoReferencedTableError)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e6974e0c8325b95a7b41eb24fcfc