### PR TITLE
Add shipping service with API endpoints and UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -32,6 +32,7 @@ from routes import (
     university_routes,
     user_settings_routes,
     video_routes,
+    shipping_routes,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -104,6 +105,7 @@ app.include_router(user_settings_routes.router, prefix="/api", tags=["UserSettin
 app.include_router(avatar.router, prefix="/api", tags=["Avatars"])
 app.include_router(playlist_routes.router, prefix="/api", tags=["Playlists"])
 app.include_router(chemistry_routes.router)
+app.include_router(shipping_routes.router, prefix="/api", tags=["Shipping"])
 
 
 @app.get("/metrics")

--- a/backend/routes/shipping_routes.py
+++ b/backend/routes/shipping_routes.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services.shipping_service import ShippingService
+
+router = APIRouter(prefix="/shipping", tags=["Shipping"])
+
+shipping_service = ShippingService()
+
+
+async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
+    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    return user_id
+
+
+class TransferIn(BaseModel):
+    source_shop_id: int
+    dest_shop_id: int
+    item_id: int
+    quantity: int = 1
+
+
+@router.post("/transfer")
+def transfer(payload: TransferIn, user_id: int = Depends(_current_user)):
+    try:
+        return shipping_service.create_shipment(
+            payload.source_shop_id,
+            payload.dest_shop_id,
+            payload.item_id,
+            payload.quantity,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.get("/shipments/{shipment_id}")
+def shipment_detail(shipment_id: int, user_id: int = Depends(_current_user)):
+    shipment = shipping_service.get_shipment(shipment_id)
+    if not shipment:
+        raise HTTPException(status_code=404, detail="Shipment not found")
+    return shipment
+
+
+@router.get("/shipments")
+def shipment_list(shop_id: int | None = None, user_id: int = Depends(_current_user)):
+    return shipping_service.list_shipments(shop_id)

--- a/backend/services/shipping_service.py
+++ b/backend/services/shipping_service.py
@@ -1,0 +1,124 @@
+"""Service for handling item shipments between city shops."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class ShippingService:
+    """Manage inter-city transfers of shop items with fees and transit times."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        """Ensure the shipments table exists."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS shipments (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_shop_id INTEGER NOT NULL,
+                    dest_shop_id INTEGER NOT NULL,
+                    item_id INTEGER NOT NULL,
+                    quantity INTEGER NOT NULL,
+                    fee_cents INTEGER NOT NULL,
+                    transit_hours INTEGER NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'in_transit',
+                    created_at TEXT DEFAULT (datetime('now')),
+                    arrival_time TEXT NOT NULL,
+                    FOREIGN KEY(source_shop_id) REFERENCES city_shops(id),
+                    FOREIGN KEY(dest_shop_id) REFERENCES city_shops(id)
+                )
+                """,
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _shop_city(self, shop_id: int) -> Optional[str]:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT city FROM city_shops WHERE id = ?", (shop_id,))
+            row = cur.fetchone()
+            return row[0] if row else None
+
+    def _calculate_transit(self, src_city: str, dest_city: str) -> int:
+        return 24 if src_city == dest_city else 72
+
+    def _calculate_fee(self, quantity: int, src_city: str, dest_city: str) -> int:
+        fee = quantity * 100
+        if src_city != dest_city:
+            fee += 500
+        return fee
+
+    def _refresh_status(self, conn: sqlite3.Connection) -> None:
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE shipments SET status='delivered' WHERE status='in_transit' AND arrival_time <= datetime('now')"
+        )
+        conn.commit()
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+    def create_shipment(
+        self, source_shop_id: int, dest_shop_id: int, item_id: int, quantity: int
+    ) -> Dict[str, Any]:
+        src_city = self._shop_city(source_shop_id)
+        dest_city = self._shop_city(dest_shop_id)
+        if not src_city or not dest_city:
+            raise ValueError("Invalid shop id")
+        transit_hours = self._calculate_transit(src_city, dest_city)
+        fee = self._calculate_fee(quantity, src_city, dest_city)
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO shipments (
+                    source_shop_id, dest_shop_id, item_id, quantity,
+                    fee_cents, transit_hours, arrival_time
+                ) VALUES (?, ?, ?, ?, ?, ?, datetime('now', ?))
+                """,
+                (
+                    source_shop_id,
+                    dest_shop_id,
+                    item_id,
+                    quantity,
+                    fee,
+                    transit_hours,
+                    f"+{transit_hours} hours",
+                ),
+            )
+            sid = int(cur.lastrowid or 0)
+            conn.commit()
+        return self.get_shipment(sid) or {}
+
+    def get_shipment(self, shipment_id: int) -> Optional[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            self._refresh_status(conn)
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("SELECT * FROM shipments WHERE id = ?", (shipment_id,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def list_shipments(self, shop_id: int | None = None) -> List[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            self._refresh_status(conn)
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            query = "SELECT * FROM shipments"
+            params: List[Any] = []
+            if shop_id is not None:
+                query += " WHERE source_shop_id = ? OR dest_shop_id = ?"
+                params = [shop_id, shop_id]
+            query += " ORDER BY created_at DESC"
+            cur.execute(query, params)
+            return [dict(r) for r in cur.fetchall()]

--- a/frontend/src/shipping/ShipmentList.tsx
+++ b/frontend/src/shipping/ShipmentList.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+
+interface Shipment {
+  id: number;
+  source_shop_id: number;
+  dest_shop_id: number;
+  item_id: number;
+  quantity: number;
+  fee_cents: number;
+  status: string;
+  arrival_time: string;
+}
+
+interface Props {
+  refresh: number;
+}
+
+const ShipmentList: React.FC<Props> = ({ refresh }) => {
+  const [shipments, setShipments] = useState<Shipment[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch('/shipping/shipments');
+      const data = await res.json();
+      setShipments(data);
+    };
+    load();
+  }, [refresh]);
+
+  return (
+    <div>
+      <h3 className="font-bold">Shipments</h3>
+      <ul>
+        {shipments.map((s) => (
+          <li key={s.id} className="border-b py-1">
+            #{s.id} item {s.item_id} x{s.quantity} from {s.source_shop_id} to {s.dest_shop_id} - {s.status} (fee {s.fee_cents}¢)
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ShipmentList;

--- a/frontend/src/shipping/ShippingPanel.tsx
+++ b/frontend/src/shipping/ShippingPanel.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import ShipmentList from './ShipmentList';
+
+const ShippingPanel: React.FC = () => {
+  const [source, setSource] = useState<number>(0);
+  const [dest, setDest] = useState<number>(0);
+  const [item, setItem] = useState<number>(0);
+  const [qty, setQty] = useState<number>(1);
+  const [refresh, setRefresh] = useState(0);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/shipping/transfer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source_shop_id: source,
+        dest_shop_id: dest,
+        item_id: item,
+        quantity: qty,
+      }),
+    });
+    setSource(0);
+    setDest(0);
+    setItem(0);
+    setQty(1);
+    setRefresh((r) => r + 1);
+  };
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={submit} className="space-y-2">
+        <input
+          type="number"
+          className="border px-1 w-full"
+          placeholder="Source shop ID"
+          value={source}
+          onChange={(e) => setSource(Number(e.target.value))}
+        />
+        <input
+          type="number"
+          className="border px-1 w-full"
+          placeholder="Destination shop ID"
+          value={dest}
+          onChange={(e) => setDest(Number(e.target.value))}
+        />
+        <input
+          type="number"
+          className="border px-1 w-full"
+          placeholder="Item ID"
+          value={item}
+          onChange={(e) => setItem(Number(e.target.value))}
+        />
+        <input
+          type="number"
+          className="border px-1 w-full"
+          placeholder="Quantity"
+          value={qty}
+          onChange={(e) => setQty(Number(e.target.value))}
+        />
+        <button type="submit" className="text-blue-500">
+          Ship Item
+        </button>
+      </form>
+      <ShipmentList refresh={refresh} />
+    </div>
+  );
+};
+
+export default ShippingPanel;

--- a/frontend/src/shipping/index.tsx
+++ b/frontend/src/shipping/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import ShippingPanel from './ShippingPanel';
+import '../index.css';
+
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<ShippingPanel />);
+}


### PR DESCRIPTION
## Summary
- add ShippingService managing inter-city item transfers with fees and transit times
- expose /shipping API endpoints for creating and tracking shipments
- build simple frontend shipping panel for initiating and listing shipments

## Testing
- `pytest` (fails: sqlite3.OperationalError unable to open database file)
- `npm test` (fails: Could not read package.json)
- `ruff check backend/services/shipping_service.py backend/routes/shipping_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9e81f5aa48325a7b66e7a69e990c7