### PR TITLE
Add shop NPC dialogue and daily special endpoints

### DIFF
--- a/backend/routes/shop_routes.py
+++ b/backend/routes/shop_routes.py
@@ -2,11 +2,12 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from backend.auth.dependencies import get_current_user_id, require_role
-from backend.services.economy_service import EconomyService, EconomyError
-from backend.services.item_service import item_service
 from backend.services.books_service import books_service
-from backend.services.loyalty_service import loyalty_service
 from backend.services.city_shop_service import city_shop_service
+from backend.services.economy_service import EconomyError, EconomyService
+from backend.services.item_service import item_service
+from backend.services.loyalty_service import loyalty_service
+from backend.services.shop_npc_service import shop_npc_service
 
 router = APIRouter(prefix="/shop", tags=["Shop"])
 
@@ -101,3 +102,21 @@ def sell_book(shop_id: int, book_id: int, payload: SellIn, user_id: int = Depend
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     return {"status": "ok", "payout_cents": payout}
+
+
+@router.get("/npc/dialogue")
+def get_shop_dialogue(choices: str = ""):
+    """Return dialogue lines and possible responses for the shop NPC."""
+
+    try:
+        parsed = [int(c) for c in choices.split(",") if c]
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid choices")
+    return shop_npc_service.get_dialogue(parsed)
+
+
+@router.get("/daily-special")
+def get_daily_special():
+    """Return today's rotating promotion."""
+
+    return shop_npc_service.get_daily_special()

--- a/backend/services/shop_npc_service.py
+++ b/backend/services/shop_npc_service.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, List, Optional
+
+from backend.models.npc_dialogue import DialogueNode, DialogueResponse, DialogueTree
+from backend.services.npc_service import NPCService
+
+
+class ShopNPCService:
+    """Simple helper around :class:`NPCService` for shop interactions.
+
+    It provides dialogue traversal for a pre-created shop keeper NPC and a
+    daily rotating promotion that acts as the shop's "daily special".
+    The goal is not to be production ready but to supply enough behaviour for
+    tests and the demo front end.
+    """
+
+    def __init__(self, npc_service: Optional[NPCService] = None):
+        self._npc_service = npc_service or NPCService()
+        # create a default shop NPC with a tiny dialogue tree
+        dialogue = self._default_dialogue().dict()
+        npc = self._npc_service.create_npc("Shopkeeper", "merchant", dialogue_hooks=dialogue)
+        self._npc_id = npc["id"]
+        # rotating promotions
+        self._promotions: List[Dict[str, str]] = [
+            {"item": "Guitar Strings", "description": "10% off all strings today!"},
+            {"item": "Vinyl Cleaner", "description": "Buy one get one free."},
+            {"item": "Tour Poster", "description": "Limited edition poster available."},
+        ]
+
+    # ------------------------------------------------------------------
+    def _default_dialogue(self) -> DialogueTree:
+        """Return a tiny dialogue tree used for the shop keeper."""
+
+        return DialogueTree(
+            root="start",
+            nodes={
+                "start": DialogueNode(
+                    id="start",
+                    text="Welcome to the shop!",
+                    responses=[
+                        DialogueResponse(text="What's today's special?", next_id="special"),
+                        DialogueResponse(text="Just browsing.", next_id="end"),
+                    ],
+                ),
+                "special": DialogueNode(
+                    id="special",
+                    text="Check out our daily deal!",
+                    responses=[DialogueResponse(text="Thanks!", next_id="end")],
+                ),
+                "end": DialogueNode(id="end", text="Come back soon!"),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    def get_dialogue(self, choices: Optional[List[int]] = None) -> Dict[str, List[str]]:
+        """Return dialogue lines and response options following ``choices``.
+
+        Args:
+            choices: optional sequence of response indices indicating the path
+                taken through the dialogue tree.
+
+        Returns:
+            Dict containing ``lines`` encountered so far and the available
+            ``options`` for the next step. If the dialogue has ended the
+            options list will be empty.
+        """
+
+        choices = choices or []
+        npc = self._npc_service.db.get(self._npc_id)
+        if not npc or not npc.dialogue_hooks:
+            return {"lines": [], "options": []}
+        tree = DialogueTree(**npc.dialogue_hooks)
+        lines = tree.traverse(choices)
+
+        # determine current node after choices to expose available responses
+        current = tree.nodes.get(tree.root)
+        for idx in choices:
+            if not current or idx < 0 or idx >= len(current.responses):
+                current = None
+                break
+            resp = current.responses[idx]
+            if not resp.next_id:
+                current = None
+                break
+            current = tree.nodes.get(resp.next_id)
+
+        options: List[str] = []
+        if current:
+            options = [resp.text for resp in current.responses]
+        return {"lines": lines, "options": options}
+
+    # ------------------------------------------------------------------
+    def get_daily_special(self) -> Dict[str, str]:
+        """Return the promotion for the current day.
+
+        The promotion rotates based on the current day so that tests can
+        rely on deterministic results without needing persistent storage.
+        """
+
+        idx = date.today().toordinal() % len(self._promotions)
+        return self._promotions[idx]
+
+
+# default singleton used by routes
+shop_npc_service = ShopNPCService()
+
+__all__ = ["shop_npc_service", "ShopNPCService"]

--- a/frontend/src/shop/DailySpecial.tsx
+++ b/frontend/src/shop/DailySpecial.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+
+interface Special {
+  item: string;
+  description: string;
+}
+
+const DailySpecial: React.FC = () => {
+  const [special, setSpecial] = useState<Special | null>(null);
+
+  useEffect(() => {
+    fetch('/shop/daily-special')
+      .then((r) => r.json())
+      .then((data) => setSpecial(data));
+  }, []);
+
+  if (!special) return null;
+
+  return (
+    <div className="p-2 bg-yellow-100">
+      <strong>{special.item}: </strong>
+      <span>{special.description}</span>
+    </div>
+  );
+};
+
+export default DailySpecial;

--- a/frontend/src/shop/ShopDialogue.tsx
+++ b/frontend/src/shop/ShopDialogue.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+
+interface DialogueResponse {
+  lines: string[];
+  options: string[];
+}
+
+const ShopDialogue: React.FC = () => {
+  const [choices, setChoices] = useState<number[]>([]);
+  const [dialogue, setDialogue] = useState<DialogueResponse>({ lines: [], options: [] });
+
+  useEffect(() => {
+    const query = choices.join(',');
+    fetch(`/shop/npc/dialogue?choices=${query}`)
+      .then((r) => r.json())
+      .then((data) => setDialogue(data));
+  }, [choices]);
+
+  return (
+    <div className="space-y-2">
+      {dialogue.lines.map((l, i) => (
+        <p key={i}>{l}</p>
+      ))}
+      <div className="space-x-2">
+        {dialogue.options.map((opt, idx) => (
+          <button
+            key={idx}
+            className="px-2 py-1 bg-blue-200"
+            onClick={() => setChoices([...choices, idx])}
+          >
+            {opt}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ShopDialogue;

--- a/frontend/src/shop/index.tsx
+++ b/frontend/src/shop/index.tsx
@@ -1,2 +1,4 @@
 export { default as SellButton } from './SellButton';
 export { default as ShopItem } from './ShopItem';
+export { default as ShopDialogue } from './ShopDialogue';
+export { default as DailySpecial } from './DailySpecial';


### PR DESCRIPTION
## Summary
- add ShopNPCService for dialogue traversal and rotating promotions
- expose shop NPC dialogue and daily special via API routes
- display dialogue and daily special in frontend shop views

## Testing
- `ruff check backend/services/shop_npc_service.py backend/routes/shop_routes.py`
- `pytest -q` *(fails: sqlite3.OperationalError unable to open database file; missing dependencies email-validator, boto3)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ed328380832592a131d7066be82f