### PR TITLE
Add durability tracking and repair endpoints

### DIFF
--- a/frontend/src/items/ItemDetail.tsx
+++ b/frontend/src/items/ItemDetail.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+interface Props {
+  id: number;
+  name: string;
+  durability: number;
+  ownerId: number;
+}
+
+const ItemDetail: React.FC<Props> = ({ id, name, durability, ownerId }) => {
+  const [dur, setDur] = useState(durability);
+
+  const handleRepair = async () => {
+    const res = await fetch(`/shop/items/${id}/repair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ owner_user_id: ownerId }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setDur(data.new_durability ?? 100);
+    }
+  };
+
+  return (
+    <div className="p-2 border rounded">
+      <h3 className="font-bold">{name}</h3>
+      <div className="h-2 bg-gray-200 mt-2">
+        <div
+          role="progressbar"
+          className="h-2 bg-green-500"
+          style={{ width: `${dur}%` }}
+        />
+      </div>
+      <button
+        className="mt-2 bg-blue-500 text-white px-2 py-1 rounded"
+        onClick={handleRepair}
+      >
+        Repair
+      </button>
+    </div>
+  );
+};
+
+export default ItemDetail;

--- a/frontend/src/items/index.tsx
+++ b/frontend/src/items/index.tsx
@@ -1,0 +1,1 @@
+export { default as ItemDetail } from './ItemDetail';

--- a/frontend/tests/ItemDetail.test.tsx
+++ b/frontend/tests/ItemDetail.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import ItemDetail from '../src/items/ItemDetail';
+
+test('renders durability bar and triggers repair', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ new_durability: 100 }),
+  });
+  const originalFetch = global.fetch;
+  vi.stubGlobal('fetch', fetchMock);
+
+  render(<ItemDetail id={1} name="Sword" durability={50} ownerId={2} />);
+  const bar = screen.getByRole('progressbar');
+  expect(bar).toHaveStyle('width: 50%');
+  const btn = screen.getByText(/repair/i);
+  btn.click();
+  expect(fetchMock).toHaveBeenCalledWith(
+    '/shop/items/1/repair',
+    expect.objectContaining({ method: 'POST' })
+  );
+  (global as any).fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- store item durability per user inventory and support repairs
- add shop repair endpoint charging maintenance fees
- display durability bar with repair control in item detail UI

## Testing
- `pytest` *(fails: unable to open database file)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f043ef448325822fd1d63e825b55