### PR TITLE
feat: add player shop ownership and admin tools

### DIFF
--- a/backend/routes/admin_city_shop_routes.py
+++ b/backend/routes/admin_city_shop_routes.py
@@ -21,7 +21,8 @@ async def create_shop(payload: dict, req: Request):
     await _ensure_admin(req)
     city = payload.get("city", "")
     name = payload.get("name", "")
-    return svc.create_shop(city=city, name=name)
+    owner = payload.get("owner_user_id")
+    return svc.create_shop(city=city, name=name, owner_user_id=owner)
 
 
 @router.get("/")

--- a/backend/routes/admin_player_shop_routes.py
+++ b/backend/routes/admin_player_shop_routes.py
@@ -1,0 +1,89 @@
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services.admin_audit_service import audit_dependency
+from backend.services.city_shop_service import CityShopService
+
+router = APIRouter(
+    prefix="/economy/player-shops",
+    tags=["AdminPlayerShops"],
+    dependencies=[Depends(audit_dependency)],
+)
+svc = CityShopService()
+
+
+async def _current_user(req: Request) -> int:
+    uid = await get_current_user_id(req)
+    await require_role(["user", "band_member", "moderator", "admin"], uid)
+    return uid
+
+
+async def _ensure_owner(shop_id: int, req: Request) -> int:
+    uid = await _current_user(req)
+    shop = svc.get_shop(shop_id)
+    if not shop or shop.get("owner_user_id") != uid:
+        raise HTTPException(status_code=403, detail="Not shop owner")
+    return uid
+
+
+async def _ensure_admin(req: Request) -> None:
+    uid = await get_current_user_id(req)
+    await require_role(["admin"], uid)
+
+
+@router.get("/")
+async def list_owned_shops(req: Request):
+    uid = await _current_user(req)
+    return svc.list_shops(owner_user_id=uid)
+
+
+@router.get("/{shop_id}/items")
+async def list_items(shop_id: int, req: Request):
+    await _ensure_owner(shop_id, req)
+    return svc.list_items(shop_id)
+
+
+@router.get("/{shop_id}/books")
+async def list_books(shop_id: int, req: Request):
+    await _ensure_owner(shop_id, req)
+    return svc.list_books(shop_id)
+
+
+@router.put("/{shop_id}/items/{item_id}")
+async def update_item(shop_id: int, item_id: int, payload: dict, req: Request):
+    await _ensure_owner(shop_id, req)
+    qty = payload.get("quantity")
+    price = payload.get("price_cents")
+    try:
+        svc.update_item(shop_id, item_id, quantity=qty, price_cents=price)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok"}
+
+
+@router.put("/{shop_id}/books/{book_id}")
+async def update_book(shop_id: int, book_id: int, payload: dict, req: Request):
+    await _ensure_owner(shop_id, req)
+    qty = payload.get("quantity")
+    price = payload.get("price_cents")
+    try:
+        svc.update_book(shop_id, book_id, quantity=qty, price_cents=price)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok"}
+
+
+@router.get("/{shop_id}/revenue")
+async def revenue(shop_id: int, req: Request):
+    await _ensure_owner(shop_id, req)
+    return {"revenue_cents": svc.get_revenue(shop_id)}
+
+
+@router.post("/{shop_id}/transfer")
+async def transfer(shop_id: int, payload: dict, req: Request):
+    await _ensure_admin(req)
+    new_owner = payload.get("owner_user_id")
+    shop = svc.transfer_ownership(shop_id, new_owner)
+    if not shop:
+        raise HTTPException(status_code=404, detail="Shop not found")
+    return shop

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -13,6 +13,7 @@ from .admin_book_routes import router as book_router
 from .admin_business_routes import router as business_router
 from .admin_course_routes import router as course_router
 from .admin_city_shop_routes import router as city_shop_router
+from .admin_player_shop_routes import router as player_shop_router
 from .admin_loyalty_routes import router as loyalty_router
 from .admin_workshop_routes import router as workshop_router
 from .admin_economy_routes import router as economy_router
@@ -55,6 +56,7 @@ router.include_router(analytics_router)
 router.include_router(audit_router)
 router.include_router(business_router)
 router.include_router(city_shop_router)
+router.include_router(player_shop_router)
 router.include_router(loyalty_router)
 router.include_router(economy_router)
 router.include_router(xp_router)

--- a/frontend/src/admin/App.tsx
+++ b/frontend/src/admin/App.tsx
@@ -15,6 +15,7 @@ import TutorsAdmin from './learning/TutorsAdmin';
 import MentorsAdmin from './learning/MentorsAdmin';
 import CityShopsAdmin from './economy/CityShopsAdmin';
 import ShopAnalytics from './economy/ShopAnalytics';
+import PlayerShopAdmin from './economy/PlayerShopAdmin';
 
 const App: React.FC = () => {
   const path = window.location.pathname;
@@ -41,6 +42,8 @@ const App: React.FC = () => {
     content = <PluginManager />;
   } else if (path.includes('/admin/economy/analytics')) {
     content = <ShopAnalytics />;
+  } else if (path.includes('/admin/economy/player-shops')) {
+    content = <PlayerShopAdmin />;
   } else if (path.includes('/admin/economy/city-shops')) {
     content = <CityShopsAdmin />;
   } else if (path.includes('/admin/events')) {

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -12,6 +12,7 @@ const navItems: NavItem[] = [
   { label: 'Quests', href: '/admin/quests' },
   { label: 'Economy', href: '/admin/economy' },
   { label: 'City Shops', href: '/admin/economy/city-shops' },
+  { label: 'Player Shops', href: '/admin/economy/player-shops' },
   { label: 'Shop Analytics', href: '/admin/economy/analytics' },
   { label: 'XP', href: '/admin/xp' },
   { label: 'XP Events', href: '/admin/xp-events' },

--- a/frontend/src/admin/economy/PlayerShopAdmin.tsx
+++ b/frontend/src/admin/economy/PlayerShopAdmin.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useState } from 'react';
+
+interface Shop {
+  id: number;
+  city: string;
+  name: string;
+}
+
+interface Item {
+  item_id: number;
+  quantity: number;
+  price_cents: number;
+}
+
+interface Book {
+  book_id: number;
+  quantity: number;
+  price_cents: number;
+}
+
+const PlayerShopAdmin: React.FC = () => {
+  const [shops, setShops] = useState<Shop[]>([]);
+  const [items, setItems] = useState<Record<number, Item[]>>({});
+  const [books, setBooks] = useState<Record<number, Book[]>>({});
+  const [revenue, setRevenue] = useState<Record<number, number>>({});
+
+  const loadInventory = (shopId: number) => {
+    Promise.all([
+      fetch(`/admin/economy/player-shops/${shopId}/items`).then((r) => r.json()),
+      fetch(`/admin/economy/player-shops/${shopId}/books`).then((r) => r.json()),
+      fetch(`/admin/economy/player-shops/${shopId}/revenue`).then((r) => r.json()),
+    ]).then(([itemData, bookData, revData]) => {
+      setItems((prev) => ({ ...prev, [shopId]: itemData }));
+      setBooks((prev) => ({ ...prev, [shopId]: bookData }));
+      setRevenue((prev) => ({ ...prev, [shopId]: revData.revenue_cents }));
+    });
+  };
+
+  const loadShops = () => {
+    fetch('/admin/economy/player-shops')
+      .then((res) => res.json())
+      .then((data) => {
+        setShops(data);
+        data.forEach((s: Shop) => loadInventory(s.id));
+      });
+  };
+
+  useEffect(() => {
+    loadShops();
+  }, []);
+
+  const handleUpdateItem = async (
+    shopId: number,
+    itemId: number,
+    e: React.FormEvent<HTMLFormElement>,
+  ) => {
+    e.preventDefault();
+    const form = e.target as HTMLFormElement;
+    const price = Number(
+      (form.elements.namedItem('priceCents') as HTMLInputElement).value,
+    );
+    await fetch(`/admin/economy/player-shops/${shopId}/items/${itemId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ price_cents: price }),
+    });
+    loadInventory(shopId);
+  };
+
+  const handleUpdateBook = async (
+    shopId: number,
+    bookId: number,
+    e: React.FormEvent<HTMLFormElement>,
+  ) => {
+    e.preventDefault();
+    const form = e.target as HTMLFormElement;
+    const price = Number(
+      (form.elements.namedItem('priceCents') as HTMLInputElement).value,
+    );
+    await fetch(`/admin/economy/player-shops/${shopId}/books/${bookId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ price_cents: price }),
+    });
+    loadInventory(shopId);
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">My Shops</h2>
+      {shops.map((shop) => (
+        <div key={shop.id} className="border p-4 mb-4">
+          <h3 className="font-semibold">
+            {shop.name} ({shop.city})
+          </h3>
+          <div className="mb-2">
+            Revenue: ${(revenue[shop.id] || 0) / 100}
+          </div>
+          <div className="mb-4">
+            <h4 className="font-medium">Items</h4>
+            {items[shop.id]?.map((item) => (
+              <form
+                key={item.item_id}
+                onSubmit={(e) => handleUpdateItem(shop.id, item.item_id, e)}
+                className="mb-2 flex gap-2"
+              >
+                <span>
+                  Item {item.item_id} qty {item.quantity}
+                </span>
+                <input
+                  name="priceCents"
+                  defaultValue={item.price_cents}
+                  className="border px-1 w-24"
+                />
+                <button type="submit" className="bg-blue-500 text-white px-2">
+                  Save
+                </button>
+              </form>
+            ))}
+          </div>
+          <div>
+            <h4 className="font-medium">Books</h4>
+            {books[shop.id]?.map((book) => (
+              <form
+                key={book.book_id}
+                onSubmit={(e) => handleUpdateBook(shop.id, book.book_id, e)}
+                className="mb-2 flex gap-2"
+              >
+                <span>
+                  Book {book.book_id} qty {book.quantity}
+                </span>
+                <input
+                  name="priceCents"
+                  defaultValue={book.price_cents}
+                  className="border px-1 w-24"
+                />
+                <button type="submit" className="bg-blue-500 text-white px-2">
+                  Save
+                </button>
+              </form>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PlayerShopAdmin;


### PR DESCRIPTION
## Summary
- add owner and revenue tracking fields to city shop tables
- introduce player shop admin routes for managing inventory and revenue
- provide dashboard for players to adjust prices and view revenue

## Testing
- `pytest` *(fails: unable to open database file)*


------
https://chatgpt.com/codex/tasks/task_e_68b9f36e1ab883258cbee02ff143ffcf