### PR TITLE
Add trade route service and frontend visualization

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ from routes import (
     apprenticeship_routes,
     avatar,
     chemistry_routes,
+    crafting_routes,
     daily_loop_routes,
     event_routes,
     legacy_routes,
@@ -22,18 +23,18 @@ from routes import (
     music_metrics_routes,
     onboarding_routes,
     playlist_routes,
-    crafting_routes,
     schedule_routes,
     setlist_routes,
+    shipping_routes,
     social_routes,
     song_forecast_routes,
     sponsorship,
     tour_collab_routes,
     tour_planner_routes,
+    trade_routes,
     university_routes,
     user_settings_routes,
     video_routes,
-    shipping_routes,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -108,6 +109,7 @@ app.include_router(playlist_routes.router, prefix="/api", tags=["Playlists"])
 app.include_router(chemistry_routes.router)
 app.include_router(crafting_routes.router, prefix="/api", tags=["Crafting"])
 app.include_router(shipping_routes.router, prefix="/api", tags=["Shipping"])
+app.include_router(trade_routes.router, prefix="/api", tags=["Trade"])
 
 
 

--- a/backend/routes/trade_routes.py
+++ b/backend/routes/trade_routes.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_role
+from backend.services.trade_route_service import TradeRouteService
+
+router = APIRouter(prefix="/trade", tags=["Trade"])
+
+trade_service = TradeRouteService()
+
+
+async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
+    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    return user_id
+
+
+class TradeIn(BaseModel):
+    source_city: str
+    dest_city: str
+    goods: str
+    quantity: int = 1
+    value_cents: int
+
+
+@router.post("/routes")
+def create_route(payload: TradeIn, user_id: int = Depends(_current_user)):
+    return trade_service.schedule_trade(
+        payload.source_city,
+        payload.dest_city,
+        payload.goods,
+        payload.quantity,
+        payload.value_cents,
+    )
+
+
+@router.get("/routes/{route_id}")
+def route_detail(route_id: int, user_id: int = Depends(_current_user)):
+    route = trade_service.get_route(route_id)
+    if not route:
+        raise HTTPException(status_code=404, detail="Route not found")
+    return route
+
+
+@router.get("/routes")
+def route_list(user_id: int = Depends(_current_user)):
+    return trade_service.list_routes()

--- a/backend/services/trade_route_service.py
+++ b/backend/services/trade_route_service.py
@@ -1,0 +1,109 @@
+"""Service to schedule trade shipments applying taxes or tariffs."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class TradeRouteService:
+    """Manage city-to-city trade routes with fees and transit times."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        """Ensure the trade routes table exists."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS trade_routes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_city TEXT NOT NULL,
+                    dest_city TEXT NOT NULL,
+                    goods TEXT NOT NULL,
+                    quantity INTEGER NOT NULL,
+                    value_cents INTEGER NOT NULL,
+                    tax_cents INTEGER NOT NULL,
+                    total_cents INTEGER NOT NULL,
+                    transit_hours INTEGER NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'in_transit',
+                    created_at TEXT DEFAULT (datetime('now')),
+                    arrival_time TEXT NOT NULL
+                )
+                """,
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _calculate_transit(self, src: str, dest: str) -> int:
+        return 24 if src == dest else 72
+
+    def _calculate_tax(self, value: int, src: str, dest: str) -> int:
+        rate = 0.0 if src == dest else 0.1
+        return int(value * rate)
+
+    def _refresh_status(self, conn: sqlite3.Connection) -> None:
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE trade_routes SET status='delivered' WHERE status='in_transit' AND arrival_time <= datetime('now')"
+        )
+        conn.commit()
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+    def schedule_trade(
+        self, source_city: str, dest_city: str, goods: str, quantity: int, value_cents: int
+    ) -> Dict[str, Any]:
+        transit_hours = self._calculate_transit(source_city, dest_city)
+        tax = self._calculate_tax(value_cents, source_city, dest_city)
+        total = value_cents + tax
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO trade_routes (
+                    source_city, dest_city, goods, quantity,
+                    value_cents, tax_cents, total_cents,
+                    transit_hours, arrival_time
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now', ?))
+                """,
+                (
+                    source_city,
+                    dest_city,
+                    goods,
+                    quantity,
+                    value_cents,
+                    tax,
+                    total,
+                    transit_hours,
+                    f"+{transit_hours} hours",
+                ),
+            )
+            rid = int(cur.lastrowid or 0)
+            conn.commit()
+        return self.get_route(rid) or {}
+
+    def get_route(self, route_id: int) -> Optional[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            self._refresh_status(conn)
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("SELECT * FROM trade_routes WHERE id = ?", (route_id,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def list_routes(self) -> List[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            self._refresh_status(conn)
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("SELECT * FROM trade_routes ORDER BY created_at DESC")
+            return [dict(r) for r in cur.fetchall()]

--- a/frontend/src/trade/TradeRoutes.tsx
+++ b/frontend/src/trade/TradeRoutes.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+interface TradeRoute {
+  id: number;
+  source_city: string;
+  dest_city: string;
+  goods: string;
+  quantity: number;
+  tax_cents: number;
+  total_cents: number;
+  status: string;
+}
+
+const TradeRoutes: React.FC = () => {
+  const [routes, setRoutes] = useState<TradeRoute[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch('/trade/routes');
+      if (res.ok) {
+        const data = await res.json();
+        setRoutes(data);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div>
+      <h3 className="font-bold">Active Trade Routes</h3>
+      <ul>
+        {routes.map((r) => (
+          <li key={r.id} className="border-b py-1">
+            {r.goods} x{r.quantity} from {r.source_city} to {r.dest_city} - fee {r.tax_cents}¢ (total {r.total_cents}¢) [{r.status}]
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TradeRoutes;


### PR DESCRIPTION
## Summary
- implement TradeRouteService with tax and transit calculations
- expose city trade APIs and include router
- add React component to display active trade routes

## Testing
- `ruff check backend/main.py backend/services/trade_route_service.py backend/routes/trade_routes.py`
- `pytest` *(fails: unable to open database)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f4c026848325b29ee9e47266b8a5