### PR TITLE
feat: add shop haggling

### DIFF
--- a/frontend/src/shop/HaggleDialog.tsx
+++ b/frontend/src/shop/HaggleDialog.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+
+interface Props {
+  itemId: number;
+  basePrice: number;
+}
+
+interface HaggleResult {
+  counteroffer_cents?: number;
+  accepted?: boolean;
+  lines?: string[];
+}
+
+const HaggleDialog: React.FC<Props> = ({ itemId, basePrice }) => {
+  const [offer, setOffer] = useState<number>(basePrice);
+  const [skill, setSkill] = useState<number>(0);
+  const [reputation, setReputation] = useState<number>(0);
+  const [result, setResult] = useState<HaggleResult>({});
+
+  const submit = () => {
+    fetch(`/shop/items/${itemId}/haggle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ offer_cents: offer, skill, reputation }),
+    })
+      .then((r) => r.json())
+      .then((data) => setResult(data));
+  };
+
+  return (
+    <div className="space-y-2 border p-2 mt-2">
+      <div>
+        <label>
+          Offer (¢):
+          <input
+            type="number"
+            value={offer}
+            onChange={(e) => setOffer(parseInt(e.target.value, 10))}
+            className="ml-1 w-16 border"
+          />
+        </label>
+      </div>
+      <div className="space-x-2">
+        <label>
+          Skill:
+          <input
+            type="number"
+            value={skill}
+            onChange={(e) => setSkill(parseInt(e.target.value, 10))}
+            className="ml-1 w-12 border"
+          />
+        </label>
+        <label>
+          Reputation:
+          <input
+            type="number"
+            value={reputation}
+            onChange={(e) => setReputation(parseInt(e.target.value, 10))}
+            className="ml-1 w-12 border"
+          />
+        </label>
+      </div>
+      <button className="px-2 py-1 bg-green-200" onClick={submit}>
+        Haggle
+      </button>
+      {result.counteroffer_cents !== undefined && (
+        <p>
+          Counteroffer: {result.counteroffer_cents}¢{' '}
+          {result.accepted ? '- Deal!' : ''}
+        </p>
+      )}
+      {result.lines && result.lines.map((l, i) => <p key={i}>{l}</p>)}
+    </div>
+  );
+};
+
+export default HaggleDialog;

--- a/frontend/src/shop/ShopItem.tsx
+++ b/frontend/src/shop/ShopItem.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import SellButton from './SellButton';
+import HaggleDialog from './HaggleDialog';
 
 interface Props {
   id: number;
@@ -11,13 +12,28 @@ interface Props {
 
 const symbolMap = { up: '▲', down: '▼', stable: '→' };
 
-const ShopItem: React.FC<Props> = ({ id, name, price_cents, trend, onSell }) => (
-  <div className="flex justify-between items-center border-b py-1">
-    <span>
-      {name} - {price_cents}¢ <span>{symbolMap[trend]}</span>
-    </span>
-    <SellButton onConfirm={() => onSell(id)} />
-  </div>
-);
+const ShopItem: React.FC<Props> = ({ id, name, price_cents, trend, onSell }) => {
+  const [showHaggle, setShowHaggle] = useState(false);
+
+  return (
+    <div className="flex flex-col border-b py-1">
+      <div className="flex justify-between items-center">
+        <span>
+          {name} - {price_cents}¢ <span>{symbolMap[trend]}</span>
+        </span>
+        <div className="space-x-2">
+          <button
+            className="px-2 py-1 bg-yellow-200"
+            onClick={() => setShowHaggle((s) => !s)}
+          >
+            Haggle
+          </button>
+          <SellButton onConfirm={() => onSell(id)} />
+        </div>
+      </div>
+      {showHaggle && <HaggleDialog itemId={id} basePrice={price_cents} />}
+    </div>
+  );
+};
 
 export default ShopItem;

--- a/frontend/src/shop/index.tsx
+++ b/frontend/src/shop/index.tsx
@@ -3,3 +3,4 @@ export { default as ShopItem } from './ShopItem';
 export { default as ShopDialogue } from './ShopDialogue';
 export { default as DailySpecial } from './DailySpecial';
 export { default as Membership } from './Membership';
+export { default as HaggleDialog } from './HaggleDialog';


### PR DESCRIPTION
## Summary
- add haggle endpoints to compute counteroffers using player skill and reputation
- extend shop NPC dialogue tree with negotiation branches
- present interactive haggling UI in shop views

## Testing
- `ruff check backend/routes/shop_routes.py backend/services/shop_npc_service.py`
- `pytest` *(fails: sqlite3.OperationalError: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f86aa87c83258f6f4e59355ca7b0