### PR TITLE
Add bank service and banking UI

### DIFF
--- a/backend/services/bank_service.py
+++ b/backend/services/bank_service.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import sqlite3
+
+from backend.models.banking import InterestAccount, Loan
+from backend.utils.logging import get_logger
+from .economy_service import EconomyService, EconomyError
+
+logger = get_logger(__name__)
+
+
+class BankService:
+    """Service providing simple banking operations."""
+
+    def __init__(self, economy: EconomyService):
+        self.economy = economy
+
+    # internal --------------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection:
+        """Return a connection to the shared economy database."""
+        return sqlite3.connect(self.economy.db_path)
+
+    # savings accounts ------------------------------------------------------
+    def create_savings_account(
+        self, user_id: int, interest_rate: float = 0.01, currency: str = "USD"
+    ) -> InterestAccount:
+        """Create or fetch a savings account for the user."""
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, user_id, balance_cents, interest_rate, currency, created_at "
+                "FROM interest_accounts WHERE user_id = ?",
+                (user_id,),
+            )
+            row = cur.fetchone()
+            if row:
+                return InterestAccount(*row)
+            cur.execute(
+                "INSERT INTO interest_accounts (user_id, balance_cents, interest_rate, currency) "
+                "VALUES (?, 0, ?, ?)",
+                (user_id, interest_rate, currency),
+            )
+            acct_id = cur.lastrowid
+            conn.commit()
+            cur.execute(
+                "SELECT id, user_id, balance_cents, interest_rate, currency, created_at "
+                "FROM interest_accounts WHERE id = ?",
+                (acct_id,),
+            )
+            row = cur.fetchone()
+        return InterestAccount(*row)
+
+    def deposit_to_savings(self, user_id: int, amount_cents: int) -> int:
+        """Move funds from the user's main account into their savings account."""
+        # Withdraw from main account first to ensure sufficient funds
+        self.economy.withdraw(user_id, amount_cents)
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "UPDATE interest_accounts SET balance_cents = balance_cents + ? "
+                "WHERE user_id = ?",
+                (amount_cents, user_id),
+            )
+            if cur.rowcount == 0:
+                raise EconomyError("Savings account not found")
+            cur.execute(
+                "SELECT balance_cents FROM interest_accounts WHERE user_id = ?",
+                (user_id,),
+            )
+            balance = cur.fetchone()[0]
+            conn.commit()
+        return balance
+
+    def withdraw_from_savings(self, user_id: int, amount_cents: int) -> int:
+        """Move funds from savings back to the user's main account."""
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT balance_cents FROM interest_accounts WHERE user_id = ?",
+                (user_id,),
+            )
+            row = cur.fetchone()
+            if not row or row[0] < amount_cents:
+                raise EconomyError("Insufficient savings balance")
+            cur.execute(
+                "UPDATE interest_accounts SET balance_cents = balance_cents - ? "
+                "WHERE user_id = ?",
+                (amount_cents, user_id),
+            )
+            balance = row[0] - amount_cents
+            conn.commit()
+        # Deposit back into main account
+        self.economy.deposit(user_id, amount_cents)
+        return balance
+
+    def accrue_interest(self) -> None:
+        """Apply interest to all savings accounts."""
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, balance_cents, interest_rate FROM interest_accounts"
+            )
+            accounts = cur.fetchall()
+            for acct_id, balance, rate in accounts:
+                interest = int(balance * rate)
+                if interest > 0:
+                    cur.execute(
+                        "UPDATE interest_accounts SET balance_cents = balance_cents + ? "
+                        "WHERE id = ?",
+                        (interest, acct_id),
+                    )
+            conn.commit()
+
+    # loans -----------------------------------------------------------------
+    def issue_loan(
+        self, user_id: int, principal_cents: int, interest_rate: float, term_days: int
+    ) -> Loan:
+        """Issue a loan and deposit the funds into the user's account."""
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO loans (user_id, principal_cents, balance_cents, interest_rate, term_days) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (user_id, principal_cents, principal_cents, interest_rate, term_days),
+            )
+            loan_id = cur.lastrowid
+            conn.commit()
+            cur.execute(
+                "SELECT id, user_id, principal_cents, balance_cents, interest_rate, term_days, created_at "
+                "FROM loans WHERE id = ?",
+                (loan_id,),
+            )
+            row = cur.fetchone()
+        # Deposit the principal into the user's main account
+        self.economy.deposit(user_id, principal_cents)
+        return Loan(*row)
+
+    def repay_loan(self, loan_id: int, user_id: int, amount_cents: int) -> int:
+        """Repay part of a loan by withdrawing from the user's account."""
+        # Withdraw funds from the user's main account
+        self.economy.withdraw(user_id, amount_cents)
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT balance_cents FROM loans WHERE id = ? AND user_id = ?",
+                (loan_id, user_id),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise EconomyError("Loan not found")
+            new_balance = max(0, row[0] - amount_cents)
+            cur.execute(
+                "UPDATE loans SET balance_cents = ? WHERE id = ?",
+                (new_balance, loan_id),
+            )
+            conn.commit()
+        return new_balance

--- a/frontend/src/bank/AccountView.tsx
+++ b/frontend/src/bank/AccountView.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+
+interface Props {
+  reloadKey: number;
+}
+
+interface AccountInfo {
+  balance_cents: number;
+  savings_cents: number;
+}
+
+const AccountView: React.FC<Props> = ({ reloadKey }) => {
+  const [info, setInfo] = useState<AccountInfo>({ balance_cents: 0, savings_cents: 0 });
+  const [depositAmt, setDepositAmt] = useState(0);
+  const [withdrawAmt, setWithdrawAmt] = useState(0);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/bank/account');
+        if (res.ok) {
+          const data = await res.json();
+          setInfo(data);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [reloadKey]);
+
+  const deposit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/bank/deposit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amount_cents: depositAmt }),
+    });
+    setDepositAmt(0);
+  };
+
+  const withdraw = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/bank/withdraw', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amount_cents: withdrawAmt }),
+    });
+    setWithdrawAmt(0);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div>Balance: {info.balance_cents}¢</div>
+      <div>Savings: {info.savings_cents}¢</div>
+      <form onSubmit={deposit} className="space-x-2">
+        <input
+          type="number"
+          value={depositAmt}
+          onChange={(e) => setDepositAmt(Number(e.target.value))}
+          className="border px-1"
+        />
+        <button type="submit" className="text-blue-500">
+          Deposit
+        </button>
+      </form>
+      <form onSubmit={withdraw} className="space-x-2">
+        <input
+          type="number"
+          value={withdrawAmt}
+          onChange={(e) => setWithdrawAmt(Number(e.target.value))}
+          className="border px-1"
+        />
+        <button type="submit" className="text-blue-500">
+          Withdraw
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default AccountView;

--- a/frontend/src/bank/Banking.tsx
+++ b/frontend/src/bank/Banking.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+import AccountView from './AccountView';
+import LoanApplicationForm from './LoanApplicationForm';
+
+const Banking: React.FC = () => {
+  const [reloadKey, setReloadKey] = useState(0);
+  const reload = () => setReloadKey((k) => k + 1);
+
+  return (
+    <div className="p-4 space-y-4">
+      <AccountView reloadKey={reloadKey} />
+      <LoanApplicationForm onSubmitted={reload} />
+    </div>
+  );
+};
+
+export default Banking;

--- a/frontend/src/bank/LoanApplicationForm.tsx
+++ b/frontend/src/bank/LoanApplicationForm.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onSubmitted: () => void;
+}
+
+const LoanApplicationForm: React.FC<Props> = ({ onSubmitted }) => {
+  const [amount, setAmount] = useState(0);
+  const [rate, setRate] = useState(0.05);
+  const [term, setTerm] = useState(30);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/bank/loan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        principal_cents: amount,
+        interest_rate: rate,
+        term_days: term,
+      }),
+    });
+    setAmount(0);
+    onSubmitted();
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-2">
+      <input
+        type="number"
+        className="border px-1 w-full"
+        placeholder="Loan amount (¢)"
+        value={amount}
+        onChange={(e) => setAmount(Number(e.target.value))}
+      />
+      <input
+        type="number"
+        className="border px-1 w-full"
+        step="0.01"
+        placeholder="Interest rate"
+        value={rate}
+        onChange={(e) => setRate(Number(e.target.value))}
+      />
+      <input
+        type="number"
+        className="border px-1 w-full"
+        placeholder="Term (days)"
+        value={term}
+        onChange={(e) => setTerm(Number(e.target.value))}
+      />
+      <button type="submit" className="text-blue-500">
+        Apply for Loan
+      </button>
+    </form>
+  );
+};
+
+export default LoanApplicationForm;

--- a/frontend/src/bank/index.tsx
+++ b/frontend/src/bank/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Banking from './Banking';
+import '../index.css';
+
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<Banking />);
+}


### PR DESCRIPTION
## Summary
- Implement `BankService` with savings accounts, interest accrual, and loan issuance/repayment linked to `EconomyService`
- Provide banking UI with account view, deposit/withdrawal actions, and loan application form

## Testing
- `pytest` *(fails: OperationalError unable to open database file; ImportError email-validator, boto3)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fcc3b2188325b4c093694997c59e