### PR TITLE
Document frontend setup and serve static pages

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,12 @@
 import os
+from pathlib import Path
 
 from auth.routes import admin_mfa_router
 from core.config import settings
 from database import init_db
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from middleware.admin_mfa import AdminMFAMiddleware
 from middleware.locale import LocaleMiddleware
 from middleware.observability import ObservabilityMiddleware
@@ -58,6 +60,13 @@ app.add_middleware(ObservabilityMiddleware)
 app.add_middleware(RateLimitMiddleware)
 app.add_middleware(LocaleMiddleware)
 app.add_middleware(AdminMFAMiddleware)
+
+# Serve the frontend HTML pages from ``frontend/pages`` for local development.
+frontend_pages = (
+    Path(__file__).resolve().parent.parent / "frontend" / "pages"
+)
+if frontend_pages.exists():
+    app.mount("/frontend", StaticFiles(directory=str(frontend_pages), html=True), name="frontend")
 
 
 @app.on_event("startup")

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,31 @@
+# RockMundo Frontend
+
+## Setup
+
+Install dependencies with [npm](https://www.npmjs.com/):
+
+```bash
+npm install
+```
+
+## Development
+
+Start a development server that proxies API requests to the FastAPI backend:
+
+```bash
+npm run start
+```
+
+This launches the app at <http://localhost:3000/>.
+
+## Static HTML Pages
+
+Prebuilt pages live in the `pages/` directory. You can serve them with any static file server, for example:
+
+```bash
+npx serve pages
+# or
+python -m http.server --directory pages
+```
+
+When the backend is running, these files are also served under the `/frontend` path.


### PR DESCRIPTION
## Summary
- Add README for the frontend with setup and static-serving instructions
- Expose `frontend/pages` through FastAPI so HTML assets can be served during development

## Testing
- `ruff check backend/main.py`
- `pytest -q` *(fails: email-validator, boto3, database errors)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba05d626b88325ad4e1b6e68790f13