### PR TITLE
Use SQLite-backed KarmaDB for karma tracking

### DIFF
--- a/backend/routes/karma_routes.py
+++ b/backend/routes/karma_routes.py
@@ -1,10 +1,11 @@
 from auth.dependencies import get_current_user_id, require_role
 
 from flask import Blueprint, request, jsonify
+from services.karma_db import KarmaDB
 from services.karma_service import KarmaService
 
 karma_routes = Blueprint('karma_routes', __name__)
-karma_service = KarmaService(db=None)
+karma_service = KarmaService(KarmaDB())
 
 @karma_routes.route('/karma/<int:user_id>', methods=['GET'])
 def get_karma(user_id):

--- a/backend/routes/legal_routes.py
+++ b/backend/routes/legal_routes.py
@@ -5,27 +5,13 @@ from pydantic import BaseModel
 
 from services.economy_service import EconomyService
 from services.legal_service import LegalService
+from services.karma_db import KarmaDB
 from services.karma_service import KarmaService
-
-
-class _KarmaDB:
-    def __init__(self):
-        self.totals = {}
-        self.events = []
-
-    def insert_karma_event(self, event):
-        self.events.append(event)
-
-    def update_user_karma(self, user_id, amount):
-        self.totals[user_id] = self.totals.get(user_id, 0) + amount
-
-    def get_user_karma_total(self, user_id):
-        return self.totals.get(user_id, 0)
 
 
 _economy = EconomyService()
 _economy.ensure_schema()
-_karma = KarmaService(_KarmaDB())
+_karma = KarmaService(KarmaDB())
 svc = LegalService(_economy, _karma)
 
 router = APIRouter(prefix="/legal", tags=["Legal"])

--- a/backend/services/karma_service.py
+++ b/backend/services/karma_service.py
@@ -2,12 +2,21 @@
 from datetime import datetime
 
 from models.karma_event import KarmaEvent
+from services.karma_db import KarmaDB
 from services.xp_reward_service import xp_reward_service
 
 
 class KarmaService:
-    def __init__(self, db):
-        self.db = db
+    def __init__(self, db=None):
+        """Service for adjusting and retrieving karma information.
+
+        Parameters
+        ----------
+        db: Optional object implementing the KarmaDB interface.
+            If not provided, a :class:`KarmaDB` instance is created which
+            persists data to the shared SQLite database.
+        """
+        self.db = db or KarmaDB()
 
     def adjust_karma(self, user_id, amount, reason, source, grant_xp: bool = False):
         event = KarmaEvent(


### PR DESCRIPTION
## Summary
- provide KarmaService with SQLite-backed KarmaDB persistence
- use KarmaDB in legal and karma routes instead of in-memory placeholder

## Testing
- `pytest backend/tests/legal/test_legal_service.py backend/tests/legal/test_legal_routes.py`
- `pytest` *(fails: sqlite3.OperationalError: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68ba09ba13a483259dd4d54eb9fb41ea