### PR TITLE
Add World Pulse API routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -29,6 +29,7 @@ from routes import (
     schedule_routes,
     setlist_routes,
     shipping_routes,
+    world_pulse_routes,
     social_routes,
     song_forecast_routes,
     sponsorship,
@@ -107,6 +108,7 @@ app.include_router(
 )
 app.include_router(setlist_routes.router, prefix="/api", tags=["Setlists"])
 app.include_router(music_metrics_routes.router)
+app.include_router(world_pulse_routes.router, prefix="/api", tags=["World Pulse"])
 app.include_router(schedule_routes.router, prefix="/api", tags=["Schedule"])
 app.include_router(song_forecast_routes.router)
 app.include_router(tour_collab_routes.router, prefix="/api", tags=["TourCollab"])

--- a/backend/routes/world_pulse_routes.py
+++ b/backend/routes/world_pulse_routes.py
@@ -1,1 +1,90 @@
-<content from world_pulse_routes.py above>
+"""API routes for World Pulse metrics.
+
+These endpoints expose ranked lists of genres, trending movers and
+sparkline series.  They are thin wrappers around
+``WorldPulseService`` which handles all of the data gathering and
+aggregation from the database.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+# The service lives under ``services`` when the package root is ``backend``.
+try:  # pragma: no cover - import shim for tests vs runtime
+    from services.jobs_world_pulse import WorldPulseService
+except Exception:  # pragma: no cover
+    from backend.services.jobs_world_pulse import WorldPulseService
+
+
+router = APIRouter(prefix="/world-pulse", tags=["World Pulse"])
+
+# Instantiate the service once; it manages its own SQLite connections.
+svc = WorldPulseService()
+
+
+@router.get("/ranked")
+def ranked_list(
+    date: str = Query(..., description="YYYY-MM-DD of the snapshot"),
+    region: str = Query("Global"),
+    limit: int = Query(20, ge=1, le=100),
+    period: str = Query("daily"),
+    lookback: Optional[int] = Query(None, ge=1),
+):
+    """Return ranked list of genres for a given date/region."""
+    try:
+        return svc.ui_ranked_list(
+            date=date,
+            region=region,
+            limit=limit,
+            period=period,
+            lookback=lookback,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/trending")
+def trending_genres(
+    date: str = Query(..., description="YYYY-MM-DD of the snapshot"),
+    region: str = Query("Global"),
+    limit: int = Query(10, ge=1, le=100),
+    period: str = Query("daily"),
+    lookback: Optional[int] = Query(None, ge=1),
+):
+    """Return genres with biggest gains and losses."""
+    try:
+        return svc.ui_trending_movers(
+            date=date,
+            region=region,
+            limit=limit,
+            period=period,
+            lookback=lookback,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/sparkline")
+def sparkline(
+    date: str = Query(..., description="YYYY-MM-DD of the snapshot"),
+    region: str = Query("Global"),
+    period: str = Query("daily"),
+    top_n: int = Query(5, ge=1, le=50),
+    points: int = Query(14, ge=1, le=365),
+):
+    """Return sparkline time-series data for top genres."""
+    try:
+        return svc.sparkline_series(
+            date=date,
+            region=region,
+            period=period,
+            top_n=top_n,
+            points=points,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+__all__ = ["router"]
+


### PR DESCRIPTION
## Summary
- add World Pulse router with endpoints for ranked lists, trending movers, and sparkline series
- wire World Pulse router into FastAPI main app

## Testing
- `pytest backend/tests/test_world_pulse_jobs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba0d5bbb788325840dfba2f3b1ac62