### PR TITLE
Add media moderation service and enforce checks during video uploads

### DIFF
--- a/backend/services/media_moderation_service.py
+++ b/backend/services/media_moderation_service.py
@@ -1,1 +1,99 @@
-# Full code for service was provided in chat - media_moderation_service.py
+"""Utilities for scanning uploaded media for disallowed content."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from backend.services.moderation_service import (
+    BANNED_WORDS as TEXT_BANNED_WORDS,
+    moderate_content,
+)
+
+
+@dataclass
+class ModerationResult:
+    """Structured result from a moderation scan."""
+
+    allowed: bool
+    reasons: List[str]
+
+
+class MediaModerationService:
+    """Scan media payloads for banned terms.
+
+    The implementation is intentionally lightweight – it simply looks for the
+    same banned words used by the text moderation utilities. This is sufficient
+    for the unit tests and mirrors how a real system might delegate to an
+    external moderation provider.
+    """
+
+    def __init__(self, banned_words: Iterable[str] | None = None) -> None:
+        self.banned_words = [w.lower() for w in (banned_words or TEXT_BANNED_WORDS)]
+
+    # ------------------------------------------------------------------
+    # Scanning helpers
+    def scan_bytes(self, data: bytes) -> ModerationResult:
+        """Check raw bytes for banned words."""
+
+        lowered = data.lower()
+        reasons = [word for word in self.banned_words if word.encode() in lowered]
+        return ModerationResult(allowed=not reasons, reasons=reasons)
+
+    def scan_text(self, text: str) -> ModerationResult:
+        """Check a text string for banned words."""
+
+        lowered = text.lower()
+        reasons = [word for word in self.banned_words if word in lowered]
+        return ModerationResult(allowed=not reasons, reasons=reasons)
+
+    # ------------------------------------------------------------------
+    def filter_text(self, text: str) -> str:
+        """Apply text filtering using the existing moderation utilities."""
+
+        return moderate_content(text)
+
+    def check(
+        self,
+        *,
+        data: bytes | None = None,
+        text: str | None = None,
+        filename: str | None = None,
+    ) -> ModerationResult:
+        """Run moderation checks on any provided fields."""
+
+        reasons: List[str] = []
+
+        if data is not None:
+            res = self.scan_bytes(data)
+            reasons.extend(res.reasons)
+
+        for field in (text, filename):
+            if field:
+                res = self.scan_text(field)
+                reasons.extend(res.reasons)
+
+        # Deduplicate reasons while preserving order
+        deduped = list(dict.fromkeys(reasons))
+        return ModerationResult(allowed=not deduped, reasons=deduped)
+
+    def ensure_clean(
+        self,
+        *,
+        data: bytes | None = None,
+        text: str | None = None,
+        filename: str | None = None,
+    ) -> ModerationResult:
+        """Raise ``ValueError`` if disallowed content is detected."""
+
+        result = self.check(data=data, text=text, filename=filename)
+        if not result.allowed:
+            raise ValueError(
+                "Disallowed content: " + ", ".join(result.reasons)
+            )
+        return result
+
+
+# Shared instance used by other services
+media_moderation_service = MediaModerationService()
+

--- a/backend/services/video_service.py
+++ b/backend/services/video_service.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 
 from backend.models.video import Video
 from backend.services.economy_service import EconomyService
+from backend.services.media_moderation_service import media_moderation_service
 from backend.utils.metrics import _REGISTRY, Histogram
 
 if "service_latency_ms" in _REGISTRY:
@@ -30,6 +31,9 @@ class VideoService:
 
     # -------------------- CRUD --------------------
     def upload_video(self, owner_id: int, title: str, filename: str) -> Video:
+        # Ensure the title/filename do not contain disallowed terms
+        media_moderation_service.ensure_clean(text=title, filename=filename)
+
         video = Video(
             id=self._next_id,
             owner_id=owner_id,

--- a/backend/tests/services/test_media_moderation_service.py
+++ b/backend/tests/services/test_media_moderation_service.py
@@ -1,0 +1,28 @@
+import tempfile
+
+import pytest
+
+from services.economy_service import EconomyService
+from services.media_moderation_service import media_moderation_service
+from services.video_service import VideoService
+
+
+def _setup_video_service():
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    economy = EconomyService(db_path=tmp.name)
+    economy.ensure_schema()
+    return VideoService(economy)
+
+
+def test_scan_bytes_detects_banned_word():
+    res = media_moderation_service.scan_bytes(b"scene of murder")
+    assert not res.allowed
+    assert "murder" in res.reasons
+
+
+def test_upload_video_rejects_inappropriate_title():
+    svc = _setup_video_service()
+    with pytest.raises(ValueError):
+        svc.upload_video(owner_id=1, title="Murder Scene", filename="clip.mp4")
+


### PR DESCRIPTION
## Summary
- implement `MediaModerationService` to scan media data, filenames, or text for banned terms
- use media moderation during `VideoService.upload_video` to reject disallowed content
- add tests covering media scan results and upload rejection

## Testing
- `pytest backend/tests/services/test_media_moderation_service.py backend/tests/video/test_video_service.py backend/tests/video/test_video_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba0e29be908325a5d25d7df60edd64