### PR TITLE
Add sales and support-related API routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -26,19 +26,22 @@ from routes import (
     music_metrics_routes,
     onboarding_routes,
     playlist_routes,
+    sales,
     schedule_routes,
     setlist_routes,
     shipping_routes,
-    world_pulse_routes,
     social_routes,
     song_forecast_routes,
     sponsorship,
+    support_slot_routes,
     tour_collab_routes,
     tour_planner_routes,
     trade_routes,
     university_routes,
     user_settings_routes,
+    venue_sponsorships_routes,
     video_routes,
+    world_pulse_routes,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -97,6 +100,9 @@ app.include_router(apprenticeship_routes.router, prefix="/api", tags=["Apprentic
 
 # Additional routers
 app.include_router(sponsorship.router, prefix="/api/sponsorships", tags=["Sponsorships"])
+app.include_router(venue_sponsorships_routes.router, prefix="/api", tags=["Venue Sponsorships"])
+app.include_router(support_slot_routes.router, prefix="/api", tags=["Support Slots"])
+app.include_router(sales.router, prefix="/api", tags=["Sales"])
 app.include_router(social_routes.router, prefix="/api/social", tags=["Social"])
 app.include_router(video_routes.router, tags=["Videos"])
 app.include_router(legacy_routes.router, prefix="/api", tags=["Legacy"])

--- a/backend/routes/sales.py
+++ b/backend/routes/sales.py
@@ -1,93 +1,123 @@
-from auth.dependencies import get_current_user_id, require_role
-# File: backend/routes/sales.py
-from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel
-from typing import List
-from services.sales_service import SalesService, SalesError
+from __future__ import annotations
 
-# Adjust to your project's auth dep path
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
 try:
     from auth.dependencies import require_role
-except Exception:
-    def require_role(roles):
-        async def _noop():
-            return True
+except Exception:  # pragma: no cover
+    def require_role(_: List[str]):
+        async def _noop() -> None:  # type: ignore[return-value]
+            return None
+
         return _noop
+
+from services.sales_service import SalesError, SalesService
 
 router = APIRouter(prefix="/sales", tags=["Sales"])
 
 svc = SalesService()
 svc.ensure_schema()
 
-# -------- Digital --------
+
 class DigitalSaleIn(BaseModel):
-    
-buyer_user_id: int
+    buyer_user_id: int
     work_type: str  # 'song' | 'album'
     work_id: int
     price_cents: int
     currency: str = "USD"
     source: str | None = "store"
 
-@router.post("/digital", dependencies=[Depends(require_role(["band_member","admin","moderator"]))])
-def record_digital(payload: DigitalSaleIn):
+
+@router.post(
+    "/digital",
+    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+)
+async def record_digital(payload: DigitalSaleIn) -> dict[str, int]:
+    """Record a digital song or album sale."""
+
     try:
         sid = svc.record_digital_sale(**payload.model_dump())
-        return {"sale_id": sid}
-    except SalesError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    except SalesError as exc:  # pragma: no cover
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"sale_id": sid}
 
-@router.get("/digital/{work_type}/{work_id}", dependencies=[Depends(require_role(["admin","moderator"]))])
-def list_digital_sales(work_type: str, work_id: int):
+
+@router.get(
+    "/digital/{work_type}/{work_id}",
+    dependencies=[Depends(require_role(["admin", "moderator"]))],
+)
+async def list_digital_sales(work_type: str, work_id: int):
+    """List digital sales for a work."""
+
     return svc.list_digital_sales_for_work(work_type, work_id)
 
-# -------- Vinyl --------
+
 class VinylSkuIn(BaseModel):
-    
-album_id: int
+    album_id: int
     variant: str
     price_cents: int
     stock_qty: int
     currency: str = "USD"
 
+
 class VinylItemIn(BaseModel):
-    
-sku_id: int
+    sku_id: int
     qty: int
 
+
 class VinylPurchaseIn(BaseModel):
-    
-buyer_user_id: int
+    buyer_user_id: int
     items: List[VinylItemIn]
     shipping_address: str | None = None
 
-@router.post("/vinyl/sku", dependencies=[Depends(require_role(["admin","moderator"]))])
-def create_vinyl_sku(payload: VinylSkuIn):
+
+@router.post(
+    "/vinyl/sku",
+    dependencies=[Depends(require_role(["admin", "moderator"]))],
+)
+async def create_vinyl_sku(payload: VinylSkuIn) -> dict[str, int]:
     try:
         sku_id = svc.create_vinyl_sku(**payload.model_dump())
-        return {"sku_id": sku_id}
-    except SalesError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    except SalesError as exc:  # pragma: no cover
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"sku_id": sku_id}
 
-@router.get("/vinyl/sku/{album_id}", dependencies=[Depends(require_role(["band_member","admin","moderator"]))])
-def list_vinyl_skus(album_id: int):
+
+@router.get(
+    "/vinyl/sku/{album_id}",
+    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+)
+async def list_vinyl_skus(album_id: int):
     return svc.list_vinyl_skus(album_id)
 
-@router.post("/vinyl/purchase", dependencies=[Depends(require_role(["band_member","admin","moderator"]))])
-def purchase_vinyl(payload: VinylPurchaseIn):
+
+@router.post(
+    "/vinyl/purchase",
+    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+)
+async def purchase_vinyl(payload: VinylPurchaseIn) -> dict[str, int]:
     try:
         order_id = svc.purchase_vinyl(
             buyer_user_id=payload.buyer_user_id,
             items=[i.model_dump() for i in payload.items],
             shipping_address=payload.shipping_address,
         )
-        return {"order_id": order_id}
-    except SalesError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    except SalesError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"order_id": order_id}
 
-@router.post("/vinyl/refund/{order_id}", dependencies=[Depends(require_role(["admin","moderator"]))])
-def refund_vinyl(order_id: int, reason: str = ""):
+
+@router.post(
+    "/vinyl/refund/{order_id}",
+    dependencies=[Depends(require_role(["admin", "moderator"]))],
+)
+async def refund_vinyl(order_id: int, reason: str = "") -> dict[str, bool]:
     try:
-        return svc.refund_vinyl_order(order_id, reason)
-    except SalesError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        svc.refund_vinyl_order(order_id, reason)
+    except SalesError as exc:  # pragma: no cover
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"ok": True}
+

--- a/backend/routes/support_slot_routes.py
+++ b/backend/routes/support_slot_routes.py
@@ -1,2 +1,92 @@
-from auth.dependencies import get_current_user_id, require_role
-<FULL support_slot_routes.py CODE FROM ABOVE>
+from __future__ import annotations
+
+from itertools import count
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+try:  # Authentication dependencies may not be available during tests
+    from auth.dependencies import get_current_user_id, require_role
+except Exception:  # pragma: no cover - fallback for docs builds
+    def require_role(_: List[str]):
+        async def _noop() -> None:  # type: ignore[return-value]
+            return None
+
+        return _noop
+
+    async def get_current_user_id() -> int:  # type: ignore[misc]
+        return 0
+
+router = APIRouter(prefix="/support/slots", tags=["Support Slots"])
+
+# simple in-memory storage for demonstration and testing purposes
+_slots: dict[int, dict[str, object]] = {}
+_id_seq = count(1)
+
+
+class SupportSlotIn(BaseModel):
+    """Payload for creating or updating a support slot."""
+
+    title: str
+    description: Optional[str] = None
+
+
+class SupportSlotOut(SupportSlotIn):
+    id: int
+    owner_id: int
+
+
+@router.post(
+    "",
+    response_model=SupportSlotOut,
+    dependencies=[Depends(require_role(["admin", "moderator"]))],
+)
+async def create_slot(
+    payload: SupportSlotIn, user_id: int = Depends(get_current_user_id)
+) -> SupportSlotOut:
+    """Create a new support slot for the current user."""
+
+    slot_id = next(_id_seq)
+    slot = {"id": slot_id, "owner_id": user_id, **payload.model_dump()}
+    _slots[slot_id] = slot
+    return SupportSlotOut(**slot)
+
+
+@router.get(
+    "",
+    response_model=List[SupportSlotOut],
+    dependencies=[Depends(require_role(["admin", "moderator"]))],
+)
+async def list_slots() -> List[SupportSlotOut]:
+    """Return all defined support slots."""
+
+    return [SupportSlotOut(**slot) for slot in _slots.values()]
+
+
+@router.get(
+    "/{slot_id}",
+    response_model=SupportSlotOut,
+    dependencies=[Depends(require_role(["admin", "moderator"]))],
+)
+async def get_slot(slot_id: int) -> SupportSlotOut:
+    """Retrieve a single support slot by identifier."""
+
+    slot = _slots.get(slot_id)
+    if not slot:
+        raise HTTPException(status_code=404, detail="Slot not found")
+    return SupportSlotOut(**slot)
+
+
+@router.delete(
+    "/{slot_id}",
+    dependencies=[Depends(require_role(["admin", "moderator"]))],
+)
+async def delete_slot(slot_id: int) -> dict[str, bool]:
+    """Delete a support slot."""
+
+    if slot_id not in _slots:
+        raise HTTPException(status_code=404, detail="Slot not found")
+    del _slots[slot_id]
+    return {"ok": True}
+

--- a/backend/routes/venue_sponsorships_routes.py
+++ b/backend/routes/venue_sponsorships_routes.py
@@ -1,86 +1,131 @@
-from auth.dependencies import get_current_user_id, require_role
-# File: backend/routes/venue_sponsorships_routes.py
-from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel, HttpUrl
-from typing import Optional, List, Dict, Any
-from services.venue_sponsorships_service import VenueSponsorshipsService, VenueSponsorshipError, SponsorshipIn
-from utils.i18n import _
+from __future__ import annotations
 
-# Auth dependency
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, HttpUrl
+
 try:
-    from auth.dependencies import require_role
-except Exception:
-    def require_role(roles):
-        async def _noop():
-            return True
+    from auth.dependencies import get_current_user_id, require_role
+except Exception:  # pragma: no cover
+    def require_role(_: List[str]):
+        async def _noop() -> None:  # type: ignore[return-value]
+            return None
+
         return _noop
+
+    async def get_current_user_id() -> int:  # type: ignore[misc]
+        return 0
+
+from services.venue_sponsorships_service import (
+    SponsorshipIn,
+    VenueSponsorshipError,
+    VenueSponsorshipsService,
+)
 
 router = APIRouter(prefix="/venues/sponsorships", tags=["Venue Sponsorships"])
 svc = VenueSponsorshipsService()
 svc.ensure_schema()
 
+
 class SponsorshipInModel(BaseModel):
-    
-venue_id: int
+    venue_id: int
     sponsor_name: str
-    sponsor_website: Optional[str] = None
-    sponsor_logo_url: Optional[str] = None
-    naming_pattern: Optional[str] = "{sponsor} {venue}"
-    start_date: Optional[str] = None    # YYYY-MM-DD
-    end_date: Optional[str] = None      # YYYY-MM-DD
+    sponsor_website: Optional[HttpUrl] = None
+    sponsor_logo_url: Optional[HttpUrl] = None
+    naming_pattern: str = "{sponsor} {venue}"
+    start_date: Optional[str] = None  # YYYY-MM-DD
+    end_date: Optional[str] = None  # YYYY-MM-DD
     is_active: bool = True
 
+
 @router.post("", dependencies=[Depends(require_role(["admin", "moderator"]))])
-def upsert_sponsorship(payload: SponsorshipInModel):
+async def upsert_sponsorship(payload: SponsorshipInModel) -> Dict[str, int]:
+    """Create or update a sponsorship for a venue."""
+
     try:
         sid = svc.upsert_sponsorship(SponsorshipIn(**payload.model_dump()))
-        return {"sponsorship_id": sid}
-    except VenueSponsorshipError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    except VenueSponsorshipError as exc:  # pragma: no cover - thin wrapper
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"sponsorship_id": sid}
 
-@router.get("/{venue_id}", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
-def get_sponsorship(venue_id: int):
-    s = svc.get_sponsorship(venue_id)
-    if not s:
-        raise HTTPException(status_code=404, detail=_("No sponsorship set for this venue"))
-    return s
 
-@router.post("/{venue_id}/deactivate", dependencies=[Depends(require_role(["admin", "moderator"]))])
-def deactivate(venue_id: int):
+@router.get(
+    "/{venue_id}",
+    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+)
+async def get_sponsorship(venue_id: int) -> Dict[str, Any]:
+    """Retrieve sponsorship details for a venue."""
+
+    sponsorship = svc.get_sponsorship(venue_id)
+    if not sponsorship:
+        raise HTTPException(status_code=404, detail="No sponsorship set for this venue")
+    return sponsorship
+
+
+@router.post(
+    "/{venue_id}/deactivate",
+    dependencies=[Depends(require_role(["admin", "moderator"]))],
+)
+async def deactivate_sponsorship(venue_id: int) -> Dict[str, bool]:
+    """Deactivate a sponsorship for a venue."""
+
     try:
         svc.deactivate(venue_id)
-        return {"ok": True}
-    except VenueSponsorshipError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    except VenueSponsorshipError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"ok": True}
+
 
 class BrandingQuery(BaseModel):
-    
-venue_name: str
+    venue_name: str
     on_date: Optional[str] = None
 
-@router.post("/{venue_id}/branding", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
-def effective_branding(venue_id: int, query: BrandingQuery):
+
+@router.post(
+    "/{venue_id}/branding",
+    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+)
+async def effective_branding(venue_id: int, query: BrandingQuery) -> Dict[str, Any]:
+    """Return the effective branding for a venue."""
+
     return svc.effective_branding(venue_id, query.venue_name, query.on_date)
 
-# ---- Ad Impressions ----
+
 class ImpressionIn(BaseModel):
-    
-sponsorship_id: int
+    sponsorship_id: int
     placement: Optional[str] = None
     event_id: Optional[int] = None
     meta: Optional[Dict[str, Any]] = None
 
-@router.post("/impressions", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
-def record_impression(payload: ImpressionIn):
+
+@router.post(
+    "/impressions",
+    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+)
+async def record_impression(
+    payload: ImpressionIn, user_id: int = Depends(get_current_user_id)
+) -> Dict[str, int]:
+    """Record an ad impression for a sponsorship."""
+
     iid = svc.record_impression(
         sponsorship_id=payload.sponsorship_id,
         placement=payload.placement,
-        user_id=payload.user_id,
+        user_id=user_id,
         event_id=payload.event_id,
         meta=payload.meta,
     )
     return {"impression_id": iid}
 
-@router.get("/impressions/{sponsorship_id}", dependencies=[Depends(require_role(["admin", "moderator"]))])
-def list_impressions(sponsorship_id: int, limit: int = 100):
+
+@router.get(
+    "/impressions/{sponsorship_id}",
+    dependencies=[Depends(require_role(["admin", "moderator"]))],
+)
+async def list_impressions(
+    sponsorship_id: int, limit: int = 100
+) -> List[Dict[str, Any]]:
+    """List ad impressions for a sponsorship."""
+
     return svc.list_impressions(sponsorship_id, limit)
+


### PR DESCRIPTION
## Summary
- add in-memory support slot endpoints with role-based protection
- add venue sponsorship routes for CRUD and tracking ad impressions
- expose sales API for digital and vinyl transactions
- wire new routers into main application

## Testing
- `ruff check backend/routes/support_slot_routes.py backend/routes/venue_sponsorships_routes.py backend/routes/sales.py backend/main.py`
- `pytest -q` *(fails: NoReferencedTableError, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ba10cd367c832592e83352ca6702a7