### PR TITLE
Add character CRUD API and service

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from routes import (
     admin_routes,
     apprenticeship_routes,
     avatar,
+    character,
     chemistry_routes,
     crafting_routes,
     daily_loop_routes,
@@ -123,6 +124,7 @@ app.include_router(university_routes.router, prefix="/api", tags=["University"])
 app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])
 app.include_router(user_settings_routes.router, prefix="/api", tags=["UserSettings"])
 app.include_router(avatar.router, prefix="/api", tags=["Avatars"])
+app.include_router(character.router, prefix="/api", tags=["Characters"])
 app.include_router(playlist_routes.router, prefix="/api", tags=["Playlists"])
 app.include_router(chemistry_routes.router)
 app.include_router(crafting_routes.router, prefix="/api", tags=["Crafting"])

--- a/backend/routes/character.py
+++ b/backend/routes/character.py
@@ -1,1 +1,78 @@
+"""Character API routes."""
+
 from auth.dependencies import get_current_user_id, require_role
+from fastapi import APIRouter, Depends, HTTPException
+from schemas.character import CharacterCreate, CharacterResponse
+from services.character_service import character_service
+from utils.i18n import _
+
+router = APIRouter(prefix="/characters", tags=["Characters"])
+
+
+@router.post(
+    "/",
+    response_model=CharacterResponse,
+    dependencies=[Depends(require_role(["admin", "player"]))],
+)
+def create_character(
+    character: CharacterCreate, user_id: int = Depends(get_current_user_id)
+):
+    """Create a new character."""
+    return character_service.create_character(character)
+
+
+@router.get(
+    "/{character_id}",
+    response_model=CharacterResponse,
+    dependencies=[Depends(require_role(["admin", "player"]))],
+)
+def read_character(
+    character_id: int, user_id: int = Depends(get_current_user_id)
+):
+    """Retrieve a single character by ID."""
+    char = character_service.get_character(character_id)
+    if not char:
+        raise HTTPException(status_code=404, detail=_("Character not found"))
+    return char
+
+
+@router.get(
+    "/",
+    response_model=list[CharacterResponse],
+    dependencies=[Depends(require_role(["admin", "player"]))],
+)
+def list_characters(user_id: int = Depends(get_current_user_id)):
+    """List all characters."""
+    return character_service.list_characters()
+
+
+@router.put(
+    "/{character_id}",
+    response_model=CharacterResponse,
+    dependencies=[Depends(require_role(["admin", "player"]))],
+)
+def update_character(
+    character_id: int,
+    character: CharacterCreate,
+    user_id: int = Depends(get_current_user_id),
+):
+    """Update character information."""
+    updated = character_service.update_character(character_id, character)
+    if not updated:
+        raise HTTPException(status_code=404, detail=_("Character not found"))
+    return updated
+
+
+@router.delete(
+    "/{character_id}",
+    dependencies=[Depends(require_role(["admin", "player"]))],
+)
+def delete_character(
+    character_id: int, user_id: int = Depends(get_current_user_id)
+):
+    """Delete a character."""
+    deleted = character_service.delete_character(character_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=_("Character not found"))
+    return {"ok": True}
+

--- a/backend/services/character_service.py
+++ b/backend/services/character_service.py
@@ -1,0 +1,93 @@
+"""Service layer for character CRUD operations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from schemas.character import CharacterCreate
+from utils.db import get_conn
+
+
+class CharacterService:
+    """Simple CRUD operations for characters backed by SQLite."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        self.db_path = db_path
+        self._ensure_table()
+
+    # ------------------------------------------------------------------
+    def _ensure_table(self) -> None:
+        """Ensure the ``characters`` table exists."""
+        with get_conn(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS characters (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    genre TEXT NOT NULL,
+                    trait TEXT NOT NULL,
+                    birthplace TEXT NOT NULL,
+                    created_at TEXT DEFAULT (datetime('now'))
+                )
+                """
+            )
+
+    # ------------------------------------------------------------------
+    def list_characters(self) -> List[Dict[str, Any]]:
+        with get_conn(self.db_path) as conn:
+            rows = conn.execute(
+                "SELECT id, name, genre, trait, birthplace, created_at FROM characters"
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def get_character(self, character_id: int) -> Optional[Dict[str, Any]]:
+        with get_conn(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT id, name, genre, trait, birthplace, created_at FROM characters WHERE id=?",
+                (character_id,),
+            ).fetchone()
+            return dict(row) if row else None
+
+    def create_character(self, character: CharacterCreate) -> Dict[str, Any]:
+        with get_conn(self.db_path) as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO characters (name, genre, trait, birthplace)
+                VALUES (?, ?, ?, ?)
+                """,
+                (character.name, character.genre, character.trait, character.birthplace),
+            )
+            char_id = int(cur.lastrowid)
+            row = conn.execute(
+                "SELECT id, name, genre, trait, birthplace, created_at FROM characters WHERE id=?",
+                (char_id,),
+            ).fetchone()
+            return dict(row)
+
+    def update_character(self, character_id: int, character: CharacterCreate) -> Optional[Dict[str, Any]]:
+        with get_conn(self.db_path) as conn:
+            cur = conn.execute(
+                """
+                UPDATE characters
+                SET name=?, genre=?, trait=?, birthplace=?
+                WHERE id=?
+                """,
+                (character.name, character.genre, character.trait, character.birthplace, character_id),
+            )
+            if cur.rowcount == 0:
+                return None
+            row = conn.execute(
+                "SELECT id, name, genre, trait, birthplace, created_at FROM characters WHERE id=?",
+                (character_id,),
+            ).fetchone()
+            return dict(row)
+
+    def delete_character(self, character_id: int) -> bool:
+        with get_conn(self.db_path) as conn:
+            cur = conn.execute("DELETE FROM characters WHERE id=?", (character_id,))
+            return cur.rowcount > 0
+
+
+character_service = CharacterService()
+
+__all__ = ["CharacterService", "character_service"]


### PR DESCRIPTION
## Summary
- add CRUD API for characters with role-based access
- implement SQLite-backed character service
- register character endpoints in main application

## Testing
- `ruff check backend/routes/character.py backend/services/character_service.py backend/main.py`
- `pytest -q` *(fails: No module named 'email_validator'; No module named 'boto3')*


------
https://chatgpt.com/codex/tasks/task_e_68ba132f0b7883259435d41f2dbf2a05