### PR TITLE
Add support slot scheduling routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -101,7 +101,11 @@ app.include_router(apprenticeship_routes.router, prefix="/api", tags=["Apprentic
 # Additional routers
 app.include_router(sponsorship.router, prefix="/api/sponsorships", tags=["Sponsorships"])
 app.include_router(venue_sponsorships_routes.router, prefix="/api", tags=["Venue Sponsorships"])
-app.include_router(support_slot_routes.router, prefix="/api", tags=["Support Slots"])
+app.include_router(
+    support_slot_routes.router,
+    prefix="/api/support-slots",
+    tags=["Support Slots"],
+)
 app.include_router(sales.router, prefix="/api", tags=["Sales"])
 app.include_router(social_routes.router, prefix="/api/social", tags=["Social"])
 app.include_router(video_routes.router, tags=["Videos"])


### PR DESCRIPTION
## Summary
- add CRUD endpoints for support slot scheduling with access control
- expose support slot router at `/api/support-slots`

## Testing
- `ruff check backend/routes/support_slot_routes.py backend/main.py`
- `pytest backend/tests/test_support_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba14723f04832596b94628a48d4c09