### PR TITLE
Add basic mail API routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from routes import (
     lifestyle_routes,
     locale_routes,
     membership_routes,
+    mail_routes,
     music_metrics_routes,
     onboarding_routes,
     playlist_routes,
@@ -135,6 +136,7 @@ app.include_router(crafting_routes.router, prefix="/api", tags=["Crafting"])
 app.include_router(shipping_routes.router, prefix="/api", tags=["Shipping"])
 app.include_router(trade_routes.router, prefix="/api", tags=["Trade"])
 app.include_router(membership_routes.router, prefix="/api", tags=["Membership"])
+app.include_router(mail_routes.router, prefix="/api", tags=["Mail"])
 
 
 

--- a/backend/routes/mail_routes.py
+++ b/backend/routes/mail_routes.py
@@ -1,3 +1,43 @@
-from fastapi import Depends
-from auth.dependencies import get_current_user_id, require_role
-# mail_routes.py content here
+"""Mail API routes.
+
+Endpoints for sending, listing, and deleting mail messages.
+"""
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from auth.dependencies import get_current_user_id
+from services.mailbox_service import delete_message, get_inbox, send_message
+
+
+router = APIRouter(prefix="/mail", tags=["Mail"])
+
+
+class MailSendIn(BaseModel):
+    """Payload for sending a new mail message."""
+
+    recipient_id: int
+    subject: str
+    body: str
+
+
+@router.post("/")
+async def send_mail(payload: MailSendIn, user_id: int = Depends(get_current_user_id)):
+    """Send a mail message from the authenticated user."""
+
+    return send_message(user_id, payload.recipient_id, payload.subject, payload.body)
+
+
+@router.get("/")
+async def list_mail(user_id: int = Depends(get_current_user_id)):
+    """Return the inbox for the authenticated user."""
+
+    return get_inbox(user_id)
+
+
+@router.delete("/{message_id}")
+async def delete_mail(message_id: int, user_id: int = Depends(get_current_user_id)):
+    """Delete a mail message owned by the authenticated user."""
+
+    return delete_message(message_id, user_id)
+


### PR DESCRIPTION
## Summary
- add `/mail` routes for sending, listing, and deleting messages
- wire mail router into main app under the `/api` prefix

## Testing
- `pytest backend/tests/test_mail_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba157ca58c8325908bd3bc84a88493