### PR TITLE
Add media upload, listing and moderation routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from routes import (
     legacy_routes,
     lifestyle_routes,
     locale_routes,
+    media_routes,
     membership_routes,
     music_metrics_routes,
     onboarding_routes,
@@ -109,6 +110,7 @@ app.include_router(
 )
 app.include_router(sales.router, prefix="/api", tags=["Sales"])
 app.include_router(social_routes.router, prefix="/api/social", tags=["Social"])
+app.include_router(media_routes.router, prefix="/api", tags=["Media & Publicity"])
 app.include_router(video_routes.router, tags=["Videos"])
 app.include_router(legacy_routes.router, prefix="/api", tags=["Legacy"])
 app.include_router(locale_routes.router, prefix="/api", tags=["Locale"])

--- a/backend/routes/media_routes.py
+++ b/backend/routes/media_routes.py
@@ -1,3 +1,80 @@
+from __future__ import annotations
+
+from typing import List, Optional
+import uuid
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+
 from auth.dependencies import get_current_user_id, require_role
-# File: backend/routes/media_routes.py
-# Full code provided in assistant response above
+from services.media_event_service import media_event_service
+from services.media_moderation_service import media_moderation_service
+from services.storage_service import get_storage_backend
+
+router = APIRouter(prefix="/media")
+
+# Simple in-memory store of uploaded media metadata.
+_media_store: List[dict] = []
+
+
+async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
+    """Ensure the caller is an authenticated user."""
+
+    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    return user_id
+
+
+@router.post("/upload")
+async def upload_media(
+    file: UploadFile = File(...),
+    song_id: Optional[int] = None,
+    user_id: int = Depends(_current_user),
+):
+    """Upload a media file after moderation and store it via the storage backend.
+
+    If ``song_id`` is provided, a publicity event is registered using the
+    ``media_event_service`` to simulate the media helping the song trend.
+    """
+
+    data = await file.read()
+    try:
+        media_moderation_service.ensure_clean(data=data, filename=file.filename)
+    except ValueError as exc:  # pragma: no cover - simple validation
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    storage = get_storage_backend()
+    key = f"media/{uuid.uuid4()}-{file.filename}"
+    obj = storage.upload_bytes(data, key, content_type=file.content_type)
+
+    if song_id is not None:
+        media_event_service.tiktok_trend(song_id)
+
+    item = {
+        "id": len(_media_store) + 1,
+        "owner_id": user_id,
+        "filename": file.filename,
+        "url": obj.url,
+        "size": obj.size,
+    }
+    _media_store.append(item)
+    return item
+
+
+@router.get("/")
+async def list_media() -> List[dict]:
+    """List uploaded media items."""
+
+    return _media_store
+
+
+@router.post("/moderate")
+async def moderate_media(
+    file: UploadFile | None = File(default=None),
+    text: Optional[str] = None,
+):
+    """Run moderation checks on the provided media or text."""
+
+    data = await file.read() if file else None
+    result = media_moderation_service.check(
+        data=data, text=text, filename=file.filename if file else None
+    )
+    return {"allowed": result.allowed, "reasons": result.reasons}


### PR DESCRIPTION
## Summary
- add FastAPI router for media upload, listing, and moderation with storage, moderation scan, and publicity event hook
- wire media router into main application

## Testing
- `pytest` *(fails: sqlite3 OperationalError unable to open database file)*
- `ruff check backend/routes/media_routes.py backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba1736c72c8325a3d39bd6858d6adb