### PR TITLE
Include admin analytics routes in main app

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from middleware.locale import LocaleMiddleware
 from middleware.observability import ObservabilityMiddleware
 from middleware.rate_limit import RateLimitMiddleware
 from routes import (
+    admin_analytics_routes,
     admin_routes,
     apprenticeship_routes,
     avatar,
@@ -23,8 +24,8 @@ from routes import (
     legacy_routes,
     lifestyle_routes,
     locale_routes,
-    membership_routes,
     mail_routes,
+    membership_routes,
     music_metrics_routes,
     onboarding_routes,
     playlist_routes,
@@ -97,6 +98,9 @@ def startup() -> None:
 app.include_router(event_routes.router, prefix="/api/events", tags=["Events"])
 app.include_router(lifestyle_routes.router, prefix="/api", tags=["Lifestyle"])
 app.include_router(admin_routes.router, prefix="/admin", tags=["Admin"])
+app.include_router(
+    admin_analytics_routes.router, prefix="/api", tags=["Admin Analytics"]
+)
 app.include_router(admin_mfa_router)
 app.include_router(apprenticeship_routes.router, prefix="/api", tags=["Apprenticeships"])
 


### PR DESCRIPTION
## Summary
- import and register `admin_analytics_routes` with the main FastAPI application

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'email_validator')*
- `pytest backend/tests/test_storage_s3_mock.py -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68ba183d671883258ab66f7ff11eb8f3