### PR TITLE
Integrate gifting API routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -21,12 +21,12 @@ from routes import (
     crafting_routes,
     daily_loop_routes,
     event_routes,
+    gifting_routes,
     legacy_routes,
     lifestyle_routes,
     locale_routes,
-    media_routes,
-    membership_routes,
     mail_routes,
+    media_routes,
     membership_routes,
     music_metrics_routes,
     onboarding_routes,
@@ -140,6 +140,7 @@ app.include_router(character.router, prefix="/api", tags=["Characters"])
 app.include_router(playlist_routes.router, prefix="/api", tags=["Playlists"])
 app.include_router(chemistry_routes.router)
 app.include_router(crafting_routes.router, prefix="/api", tags=["Crafting"])
+app.include_router(gifting_routes.router, prefix="/api", tags=["Gifting"])
 app.include_router(shipping_routes.router, prefix="/api", tags=["Shipping"])
 app.include_router(trade_routes.router, prefix="/api", tags=["Trade"])
 app.include_router(membership_routes.router, prefix="/api", tags=["Membership"])


### PR DESCRIPTION
## Summary
- import gifting routes into FastAPI main module
- mount gifting endpoints at `/api/gifts` tagged `Gifting`

## Testing
- `ruff check backend/main.py`
- `pytest backend/tests/test_health.py -q` *(fails: ModuleNotFoundError: No module named 'email_validator')*
- `pip install email-validator` *(failed: Could not find a version that satisfies the requirement email-validator)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1b12a79c8325b9d713c8706d4dd1