### PR TITLE
feat: add mood tracking for avatars

### DIFF
--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from pydantic import BaseModel
 from typing import Optional
+
+from pydantic import BaseModel
 
 
 class AvatarBase(BaseModel):
@@ -23,6 +24,7 @@ class AvatarBase(BaseModel):
     level: int = 1
     experience: int = 0
     health: int = 100
+    mood: int = 50
 
 
 class AvatarCreate(AvatarBase):
@@ -47,6 +49,7 @@ class AvatarUpdate(BaseModel):
     level: Optional[int] = None
     experience: Optional[int] = None
     health: Optional[int] = None
+    mood: Optional[int] = None
 
 
 class AvatarResponse(AvatarBase):

--- a/backend/tests/avatars/test_avatar_service.py
+++ b/backend/tests/avatars/test_avatar_service.py
@@ -1,3 +1,4 @@
+# ruff: noqa: I001
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -40,6 +41,8 @@ def test_crud_lifecycle():
         )
     )
     assert avatar.id is not None
+    # Default mood should be neutral (50)
+    assert avatar.mood == 50
 
     fetched = svc.get_avatar(avatar.id)
     assert fetched and fetched.nickname == "Hero"
@@ -47,6 +50,12 @@ def test_crud_lifecycle():
     svc.update_avatar(avatar.id, AvatarUpdate(nickname="Legend"))
     updated = svc.get_avatar(avatar.id)
     assert updated and updated.nickname == "Legend"
+
+    # Adjust mood based on lifestyle and events
+    updated = svc.adjust_mood(avatar.id, lifestyle_score=80, events=["burnout"])
+    assert updated and updated.mood == 55
+    # get_mood should reflect persisted value
+    assert svc.get_mood(avatar.id) == 55
 
     assert svc.delete_avatar(avatar.id)
     assert svc.get_avatar(avatar.id) is None


### PR DESCRIPTION
## Summary
- add mood column and persistence to avatar model
- adjust avatar mood based on lifestyle score and events
- expose mood via new avatar endpoints

## Testing
- `ruff check backend/models/avatar.py backend/services/avatar_service.py backend/routes/avatar.py backend/schemas/avatar.py backend/tests/avatars/test_avatar_service.py`
- `pytest backend/tests/avatars/test_avatar_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baa7f9398c8325b3fbab8be0171e8a