### PR TITLE
Add lyric generation API and temporary skill buffs

### DIFF
--- a/backend/services/songwriting_service.py
+++ b/backend/services/songwriting_service.py
@@ -71,6 +71,36 @@ class SongwritingService:
         self._versions: Dict[int, List[SongDraftVersion]] = {}
         self._counter = 1
 
+    def generate_lyrics(self, themes: List[str], *, lines: int = 4) -> str:
+        """Generate simple placeholder lyrics referencing the provided themes.
+
+        This utility does not rely on an LLM which keeps it deterministic for
+        tests and offline usage.  It returns a newline separated string and
+        guarantees each theme appears at least once in the lyrics.  Exactly
+        three themes must be provided.
+        """
+
+        if len(themes) != 3:
+            raise ValueError("exactly_three_themes_required")
+        if any(t not in THEMES for t in themes):
+            raise ValueError("unknown_theme")
+
+        base_lines = [
+            f"{themes[0]} and {themes[1]} we wander through the day",
+            f"Dreams of {themes[2]} guide us on our way",
+            f"{themes[0]} echoes softly in the night",
+            f"{themes[2]} keeps our hearts alight",
+        ]
+
+        if lines <= 4:
+            return "\n".join(base_lines[:lines])
+
+        extra = [
+            f"{themes[i % 3]} and {themes[(i + 1) % 3]} help us stay"
+            for i in range(lines - 4)
+        ]
+        return "\n".join(base_lines + extra)
+
     async def generate_draft(
         self,
         creator_id: int,


### PR DESCRIPTION
## Summary
- add deterministic lyric generator utility
- expose lyric generation endpoint for collaboration
- support temporary XP buffs for successful sessions

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: unable to open database file)*
- `pytest backend/tests/songwriting/test_songwriting_service.py backend/tests/routes/test_songwriting_routes.py backend/tests/test_songwriting_ws.py -q`
- `ruff check backend/routes/songwriting_routes.py backend/services/songwriting_service.py backend/services/skill_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68baaaecf23c832584f2823d05acc6fa