### PR TITLE
Add region-aware charts and fan playlist endpoints

### DIFF
--- a/backend/migrations/sql/105_chart_regions.sql
+++ b/backend/migrations/sql/105_chart_regions.sql
@@ -1,0 +1,3 @@
+-- Add region column to chart_snapshots to support regional charts
+ALTER TABLE chart_snapshots ADD COLUMN region TEXT DEFAULT 'global';
+CREATE INDEX IF NOT EXISTS ix_charts_region ON chart_snapshots(region);

--- a/backend/migrations/versions/0023_105_chart_regions.py
+++ b/backend/migrations/versions/0023_105_chart_regions.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from alembic import op
+
+revision = '0023'
+down_revision = '0022'
+branch_labels = None
+depends_on = None
+
+SQL_FILE = Path(__file__).resolve().parent.parent / 'sql' / '105_chart_regions.sql'
+
+def upgrade() -> None:
+    op.execute(SQL_FILE.read_text())
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_charts_region;")
+    # SQLite does not support dropping columns easily; omit column removal

--- a/backend/models/chart_entry.py
+++ b/backend/models/chart_entry.py
@@ -1,14 +1,16 @@
 
 from datetime import datetime
 
+
 class ChartEntry:
-    def __init__(self, id, song_id, band_id, chart_type, position, week_start):
+    def __init__(self, id, song_id, band_id, chart_type, position, week_start, region="global"):
         self.id = id
         self.song_id = song_id
         self.band_id = band_id
         self.chart_type = chart_type  # e.g., Global Top 100, Digital Sales, Vinyl, Streaming
         self.position = position
         self.week_start = week_start or datetime.utcnow().date().isoformat()
+        self.region = region
 
     def to_dict(self):
         return self.__dict__

--- a/backend/routes/chart_routes.py
+++ b/backend/routes/chart_routes.py
@@ -1,23 +1,26 @@
-from backend.auth.dependencies import get_current_user_id
-from backend.services.chart_service import ChartService
 from fastapi import APIRouter, Depends, HTTPException, Request
 
+from backend.auth.dependencies import get_current_user_id
+from backend.services.chart_service import calculate_weekly_chart, get_chart
+
 router = APIRouter(prefix="/charts", tags=["Charts"])
-chart_service = ChartService(db=None)
 
 
-@router.get("/global/{week_start}")
+@router.get("/{region}/{week_start}")
 def get_global_chart(
-    week_start: str, _req: Request, user_id: int = Depends(get_current_user_id)
+    region: str,
+    week_start: str,
+    _req: Request,
+    user_id: int = Depends(get_current_user_id),
 ):
-    return chart_service.get_chart("Global Top 100", week_start)
+    return get_chart("Global Top 100", region, week_start)
 
 
-@router.post("/recalculate", status_code=204)
+@router.post("/{region}/recalculate", status_code=204)
 def recalculate_charts(
-    _req: Request, user_id: int = Depends(get_current_user_id)
+    region: str, _req: Request, user_id: int = Depends(get_current_user_id)
 ):
     try:
-        chart_service.calculate_weekly_charts()
+        calculate_weekly_chart(region=region)
     except Exception as e:  # pragma: no cover - example stub
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/routes/playlist_routes.py
+++ b/backend/routes/playlist_routes.py
@@ -100,3 +100,16 @@ def get_public_playlist(playlist_id: int) -> PlaylistOut:
     if not pl or not pl.is_public:
         raise HTTPException(status_code=404, detail="Playlist not found")
     return PlaylistOut(**pl.to_dict())
+
+
+# Fan-facing endpoints exposing public playlists
+@router.get("/playlists/fans", response_model=List[PlaylistOut])
+def list_fan_playlists() -> List[PlaylistOut]:
+    """List all playlists created by fans that are marked public."""
+    return list_public_playlists()
+
+
+@router.get("/playlists/fans/{playlist_id}", response_model=PlaylistOut)
+def get_fan_playlist(playlist_id: int) -> PlaylistOut:
+    """Retrieve a specific fan-created public playlist."""
+    return get_public_playlist(playlist_id)

--- a/backend/services/chart_service.py
+++ b/backend/services/chart_service.py
@@ -1,15 +1,19 @@
 import sqlite3
 from datetime import datetime, timedelta
-from backend.database import DB_PATH
+
 from services.achievement_service import AchievementService
 from services.legacy_service import LegacyService
+
+from backend.database import DB_PATH
 
 achievement_service = AchievementService(DB_PATH)
 legacy_service = LegacyService(DB_PATH)
 legacy_service.ensure_schema()
 
 
-def calculate_weekly_chart(chart_type: str = 'Global Top 100', start_date: str = None) -> dict:
+def calculate_weekly_chart(
+    chart_type: str = "Global Top 100", region: str = "global", start_date: str = None
+) -> dict:
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
 
@@ -19,21 +23,33 @@ def calculate_weekly_chart(chart_type: str = 'Global Top 100', start_date: str =
         start_date = (today - timedelta(days=today.weekday())).isoformat()
 
     # Retrieve stream counts and revenues per song in date range
-    cur.execute("""
+    cur.execute(
+        """
         SELECT s.id, s.title, b.id, b.name,
-               SUM(CASE WHEN str.timestamp BETWEEN ? AND ? 
+               SUM(CASE WHEN str.timestamp BETWEEN ? AND ?
+                        AND (str.region = ? OR str.region IS NULL)
                    THEN 1 ELSE 0 END) AS streams,
-               SUM(CASE WHEN e.source_type = 'stream' AND e.source_id = s.id 
+               SUM(CASE WHEN e.source_type = 'stream' AND e.source_id = s.id
                    THEN e.amount ELSE 0 END) AS revenue
-        FROM songs s 
+        FROM songs s
         JOIN bands b ON s.band_id = b.id
         LEFT JOIN streams str ON str.song_id = s.id
         LEFT JOIN earnings e ON e.source_type = 'stream' AND e.source_id = s.id
-        WHERE str.timestamp BETWEEN ? AND ? OR e.timestamp BETWEEN ? AND ?
+        WHERE (str.timestamp BETWEEN ? AND ? AND (str.region = ? OR str.region IS NULL))
+              OR e.timestamp BETWEEN ? AND ?
         GROUP BY s.id
-    """, (start_date, datetime.utcnow().isoformat(),
-           start_date, datetime.utcnow().isoformat(),
-           start_date, datetime.utcnow().isoformat()))
+        """,
+        (
+            start_date,
+            datetime.utcnow().isoformat(),
+            region,
+            start_date,
+            datetime.utcnow().isoformat(),
+            region,
+            start_date,
+            datetime.utcnow().isoformat(),
+        ),
+    )
 
     rows = cur.fetchall()
     scoring = []
@@ -50,10 +66,19 @@ def calculate_weekly_chart(chart_type: str = 'Global Top 100', start_date: str =
         cur.execute(
             """
             INSERT INTO chart_entries
-            (chart_type, week_start, position, song_id, band_name, score, generated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            (chart_type, region, week_start, position, song_id, band_name, score, generated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (chart_type, start_date, position, song_id, band_name, score, datetime.utcnow().isoformat()),
+            (
+                chart_type,
+                region,
+                start_date,
+                position,
+                song_id,
+                band_name,
+                score,
+                datetime.utcnow().isoformat(),
+            ),
         )
 
     conn.commit()
@@ -76,42 +101,53 @@ def calculate_weekly_chart(chart_type: str = 'Global Top 100', start_date: str =
                 pass
 
     top_entries = [(s, t, b_name, sc) for (s, t, _, b_name, sc) in top]
-    return {'chart_type': chart_type, 'week_start': start_date, 'entries': top_entries}
+    return {
+        "chart_type": chart_type,
+        "region": region,
+        "week_start": start_date,
+        "entries": top_entries,
+    }
 
 
-def get_chart(chart_type: str, week_start: str) -> list:
+def get_chart(chart_type: str, region: str, week_start: str) -> list:
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
 
-    cur.execute("""
+    cur.execute(
+        """
         SELECT position, song_id, band_name, score
         FROM chart_entries
-        WHERE chart_type = ? AND week_start = ?
+        WHERE chart_type = ? AND region = ? AND week_start = ?
         ORDER BY position ASC
-    """, (chart_type, week_start))
+        """,
+        (chart_type, region, week_start),
+    )
     rows = cur.fetchall()
     conn.close()
 
-    return [dict(zip(['position', 'song_id', 'band_name', 'score'], row)) for row in rows]
+    return [dict(zip(["position", "song_id", "band_name", "score"], row)) for row in rows]
 
 
-def get_historical_charts(chart_type: str, weeks: int = 4) -> dict:
+def get_historical_charts(chart_type: str, region: str, weeks: int = 4) -> dict:
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
 
     # Get distinct week_starts for the chart type
-    cur.execute("""
+    cur.execute(
+        """
         SELECT DISTINCT week_start
         FROM chart_entries
-        WHERE chart_type = ?
+        WHERE chart_type = ? AND region = ?
         ORDER BY week_start DESC
         LIMIT ?
-    """, (chart_type, weeks))
+        """,
+        (chart_type, region, weeks),
+    )
     dates = [row[0] for row in cur.fetchall()]
 
     history = {}
     for wk in dates:
-        history[wk] = get_chart(chart_type, wk)
+        history[wk] = get_chart(chart_type, region, wk)
 
     conn.close()
     return history

--- a/backend/tests/achievements/test_achievements.py
+++ b/backend/tests/achievements/test_achievements.py
@@ -1,22 +1,20 @@
 import sqlite3
 import sys
+import types
 from pathlib import Path
-
-import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.services.achievement_service import AchievementService
-from backend.services.property_service import PropertyService
-from backend.services.economy_service import EconomyService
 import pydantic
+
+from backend.services.achievement_service import AchievementService
+from backend.services.economy_service import EconomyService
+from backend.services.property_service import PropertyService
 
 if not hasattr(pydantic, "Field"):
     def Field(default=None, **kwargs):
         return default
     pydantic.Field = Field
-
-import types
 
 core_errors = types.ModuleType("core.errors")
 
@@ -34,9 +32,9 @@ core_errors.VenueConflictError = VenueConflictError
 core_errors.TourMinStopsError = TourMinStopsError
 sys.modules["core.errors"] = core_errors
 
-from backend.services.tour_service import TourService
-from backend.services.chart_service import calculate_weekly_chart
-from backend.routes import achievement_routes
+from backend.routes import achievement_routes  # noqa: E402
+from backend.services.chart_service import calculate_weekly_chart  # noqa: E402
+from backend.services.tour_service import TourService  # noqa: E402
 
 
 def setup_db(tmp_path):
@@ -86,7 +84,7 @@ def test_chart_topper_unlock(tmp_path):
             CREATE TABLE songs (id INTEGER PRIMARY KEY, title TEXT, band_id INTEGER);
             CREATE TABLE streams (id INTEGER PRIMARY KEY AUTOINCREMENT, song_id INTEGER, timestamp TEXT);
             CREATE TABLE earnings (id INTEGER PRIMARY KEY AUTOINCREMENT, source_type TEXT, source_id INTEGER, amount REAL, timestamp TEXT);
-            CREATE TABLE chart_entries (id INTEGER PRIMARY KEY AUTOINCREMENT, chart_type TEXT, week_start TEXT, position INTEGER, song_id INTEGER, band_name TEXT, score REAL, generated_at TEXT);
+            CREATE TABLE chart_entries (id INTEGER PRIMARY KEY AUTOINCREMENT, chart_type TEXT, region TEXT, week_start TEXT, position INTEGER, song_id INTEGER, band_name TEXT, score REAL, generated_at TEXT);
             """
         )
         cur.execute("INSERT INTO bands (id, name) VALUES (1, 'Band A')")


### PR DESCRIPTION
## Summary
- track chart regions via new `region` field and migration
- support region-filtered chart aggregation and lookup
- expose fan-created playlists through public endpoints

## Testing
- `ruff check backend/models/chart_entry.py backend/services/chart_service.py backend/routes/chart_routes.py backend/routes/playlist_routes.py backend/tests/achievements/test_achievements.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install fastapi pydantic sqlalchemy` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68baaccdbd688325a0d27d8bd0f3c581