### PR TITLE
Add skill specialization and synergy support

### DIFF
--- a/backend/models/skill.py
+++ b/backend/models/skill.py
@@ -1,5 +1,14 @@
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+
+@dataclass
+class SkillSpecialization:
+    """Metadata describing a specialization for a skill."""
+
+    name: str
+    related_skills: Dict[int, int]
+    bonus: float = 0.1
 
 
 @dataclass
@@ -13,6 +22,8 @@ class Skill:
     xp: int = 0
     level: int = 1
     modifier: float = 1.0
+    specializations: Dict[str, SkillSpecialization] = field(default_factory=dict)
+    specialization: Optional[str] = None
 
 
-__all__ = ["Skill"]
+__all__ = ["Skill", "SkillSpecialization"]

--- a/backend/routes/learning_routes.py
+++ b/backend/routes/learning_routes.py
@@ -20,6 +20,14 @@ class SessionRequest(BaseModel):
     duration: int
 
 
+class SpecializationRequest(BaseModel):
+    user_id: int
+    skill_id: int
+    skill_name: str
+    skill_category: str
+    specialization: str
+
+
 @router.post("/sessions")
 def enqueue_session(payload: SessionRequest):
     """Enqueue a learning session (stub)."""
@@ -35,6 +43,18 @@ def enqueue_session(payload: SessionRequest):
 def cancel_session(session_id: int):
     """Cancel a queued session (stub)."""
     return {"status": "cancelled", "session_id": session_id}
+
+
+@router.post("/specializations")
+def choose_specialization(payload: SpecializationRequest):
+    """Select a specialization for a skill."""
+    skill = Skill(
+        id=payload.skill_id,
+        name=payload.skill_name,
+        category=payload.skill_category,
+    )
+    svc.select_specialization(payload.user_id, skill, payload.specialization)
+    return {"status": "selected", "specialization": payload.specialization}
 
 
 __all__ = ["router"]

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -5,7 +5,7 @@ import pytest
 
 from backend.models.item import Item
 from backend.models.learning_method import LearningMethod
-from backend.models.skill import Skill
+from backend.models.skill import Skill, SkillSpecialization
 from backend.models.xp_config import XPConfig, get_config, set_config
 from backend.services.item_service import item_service
 from backend.services.skill_service import SkillService
@@ -185,4 +185,15 @@ def test_method_burnout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     svc.train_with_method(1, skill, LearningMethod.PRACTICE, 1)
     updated = svc.train_with_method(1, skill, LearningMethod.PRACTICE, 1)
     assert updated.xp == 27
+
+
+def test_synergy_bonus_applied() -> None:
+    svc = SkillService()
+    spec = SkillSpecialization(name="lead", related_skills={31: 2}, bonus=0.5)
+    guitar = Skill(id=30, name="guitar", category="instrument", specializations={"lead": spec})
+    theory = Skill(id=31, name="music theory", category="knowledge")
+    svc.select_specialization(1, guitar, "lead")
+    svc.train(1, theory, 200)
+    updated = svc.train(1, guitar, 100)
+    assert updated.xp == 150
 


### PR DESCRIPTION
## Summary
- expand Skill model with specialization metadata
- add synergy bonuses and specialization selection in SkillService
- expose specialization selection endpoint in learning routes
- cover synergy bonus with new test

## Testing
- `PYTHONPATH=. pytest tests/test_skill_service.py::test_synergy_bonus_applied -q`
- `PYTHONPATH=. pytest -q` *(fails: sqlite3.OperationalError: unable to open database file; ImportError: email-validator not installed; ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68baaf642ba883258377aecfbab97983