### PR TITLE
Expand lifestyle model with nutrition and fitness XP modifiers

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -57,6 +57,8 @@ def init_db():
             stress REAL DEFAULT 0.0,
             training_discipline REAL DEFAULT 50.0,
             mental_health REAL DEFAULT 100.0,
+            nutrition REAL DEFAULT 70.0,
+            fitness REAL DEFAULT 70.0,
             last_updated TEXT,
             FOREIGN KEY(user_id) REFERENCES users(id)
         )

--- a/backend/models/lifestyle.py
+++ b/backend/models/lifestyle.py
@@ -10,4 +10,6 @@ class Lifestyle(BaseModel):
     stress: float = 0.0
     training_discipline: float = 50.0
     mental_health: float = 100.0
+    nutrition: float = 70.0
+    fitness: float = 70.0
     lifestyle_score: Optional[float] = None

--- a/backend/routes/avatar.py
+++ b/backend/routes/avatar.py
@@ -25,6 +25,8 @@ class LifestylePayload(BaseModel):
     training_discipline: int
     mental_health: int
     drinking: str = "none"
+    nutrition: int = 70
+    fitness: int = 70
 
 @router.post("/", response_model=AvatarResponse, dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
 def create_avatar(payload: AvatarCreate):

--- a/backend/routes/lifestyle_routes.py
+++ b/backend/routes/lifestyle_routes.py
@@ -12,7 +12,9 @@ fake_lifestyle_data = {
     "drinking": "heavy",
     "stress": 90,
     "training_discipline": 60,
-    "mental_health": 80
+    "mental_health": 80,
+    "nutrition": 30,
+    "fitness": 40,
 }
 
 @router.get("/lifestyle/me")

--- a/backend/services/lifestyle_scheduler.py
+++ b/backend/services/lifestyle_scheduler.py
@@ -16,7 +16,7 @@ DECAY = {
 }
 
 # XP modifier ranges
-def lifestyle_xp_modifier(sleep, stress, discipline, mental):
+def lifestyle_xp_modifier(sleep, stress, discipline, mental, nutrition, fitness):
     modifier = 1.0
 
     if sleep < 5:
@@ -27,6 +27,10 @@ def lifestyle_xp_modifier(sleep, stress, discipline, mental):
         modifier *= 0.85
     if mental < 60:
         modifier *= 0.8
+    if nutrition < 40:
+        modifier *= 0.9
+    if fitness < 30:
+        modifier *= 0.9
 
     return round(modifier, 2)
 
@@ -115,7 +119,9 @@ def apply_lifestyle_decay_and_xp_effects():
                 (new_energy, user_id),
             )
 
-            modifier = lifestyle_xp_modifier(sleep, stress, discipline, mental)
+            nutrition = row[7]
+            fitness = row[8]
+            modifier = lifestyle_xp_modifier(sleep, stress, discipline, mental, nutrition, fitness)
             modifier *= event_svc.get_active_multiplier()
 
             cur.execute("""

--- a/backend/services/lifestyle_service.py
+++ b/backend/services/lifestyle_service.py
@@ -7,9 +7,11 @@ def calculate_lifestyle_score(data):
     # Composite score from normalized attributes
     score = (
         (min(data["sleep_hours"], 8) / 8.0) * 20 +
-        (100 - data["stress"]) * 0.2 +
-        data["training_discipline"] * 0.2 +
-        data["mental_health"] * 0.4
+        (100 - data["stress"]) * 0.15 +
+        data["training_discipline"] * 0.15 +
+        data["mental_health"] * 0.3 +
+        data["nutrition"] * 0.1 +
+        data["fitness"] * 0.1
     )
     return round(score, 2)
 
@@ -21,4 +23,8 @@ def evaluate_lifestyle_risks(data):
         events.append("illness")
     if data["sleep_hours"] < 6 and random.random() < 0.2:
         events.append("mental fatigue")
+    if data["nutrition"] < 40 and random.random() < 0.1:
+        events.append("nutrition deficiency")
+    if data["fitness"] < 30 and random.random() < 0.1:
+        events.append("injury")
     return events

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -61,7 +61,7 @@ class SkillService:
                 cur = conn.cursor()
                 # Lifestyle metrics
                 cur.execute(
-                    "SELECT sleep_hours, stress, training_discipline, mental_health FROM lifestyle WHERE user_id = ?",
+                    "SELECT sleep_hours, stress, training_discipline, mental_health, nutrition, fitness FROM lifestyle WHERE user_id = ?",
                     (user_id,),
                 )
                 row = cur.fetchone()

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -22,7 +22,7 @@ class DummyXPEvents:
 def _setup_db(
     tmp_path: Path,
     xp_modifier: float = 1.0,
-    lifestyle: tuple[float, float, float, float] = (7, 0, 50, 100),
+    lifestyle: tuple[float, float, float, float, float, float] = (7, 0, 50, 100, 70, 70),
     learning_style: str = "balanced",
 ) -> Path:
     db = tmp_path / "db.sqlite"
@@ -36,10 +36,10 @@ def _setup_db(
         (xp_modifier,),
     )
     cur.execute(
-        "CREATE TABLE lifestyle (user_id INTEGER, sleep_hours REAL, stress REAL, training_discipline REAL, mental_health REAL)"
+        "CREATE TABLE lifestyle (user_id INTEGER, sleep_hours REAL, stress REAL, training_discipline REAL, mental_health REAL, nutrition REAL, fitness REAL)"
     )
     cur.execute(
-        "INSERT INTO lifestyle (user_id, sleep_hours, stress, training_discipline, mental_health) VALUES (1, ?, ?, ?, ?)",
+        "INSERT INTO lifestyle (user_id, sleep_hours, stress, training_discipline, mental_health, nutrition, fitness) VALUES (1, ?, ?, ?, ?, ?, ?)",
         lifestyle,
     )
     cur.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, learning_style TEXT)")
@@ -167,7 +167,7 @@ def test_environment_quality(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_lifestyle_modifier(tmp_path: Path) -> None:
-    db = _setup_db(tmp_path, lifestyle=(4, 90, 50, 100))
+    db = _setup_db(tmp_path, lifestyle=(4, 90, 50, 100, 100, 100))
     svc = SkillService(db_path=db, xp_events=DummyXPEvents(1.0))
     skill = Skill(id=22, name="bass", category="instrument")
     updated = svc.train(1, skill, 10)


### PR DESCRIPTION
## Summary
- Add nutrition and fitness fields to lifestyle data model
- Factor nutrition and fitness into lifestyle scoring, risk events, and XP modifiers
- Update skill service and tests to consume expanded lifestyle metrics

## Testing
- `PYTHONPATH=. pytest`
- `PYTHONPATH=. pytest tests/test_skill_service.py::test_lifestyle_modifier -q`
- `PYTHONPATH=. pytest tests/test_skill_service.py::test_skill_gain_with_modifiers -q`


------
https://chatgpt.com/codex/tasks/task_e_68bab01c22d4832585336ae75730311d