### PR TITLE
feat: add contextual random events

### DIFF
--- a/backend/routes/random_event_routes.py
+++ b/backend/routes/random_event_routes.py
@@ -1,15 +1,30 @@
-from auth.dependencies import get_current_user_id, require_role
-
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, jsonify, request
 from services.random_event_service import RandomEventService
 
-event_routes = Blueprint('random_event_routes', __name__)
+event_routes = Blueprint("random_event_routes", __name__)
 event_service = RandomEventService(db=None)
 
-@event_routes.route('/events/trigger/<int:band_id>', methods=['POST'])
+
+@event_routes.route("/events/trigger/<int:band_id>", methods=["POST"])
 def trigger_event(band_id):
+    """Trigger a context-aware event for a band.
+
+    The request body can include optional ``location`` and ``mood`` fields to
+    influence the selected event.  Possible event types include:
+
+    * ``delay`` – Vehicle breakdown caused a delay.
+    * ``press`` – Local press covered the band’s arrival.
+    * ``fan_interaction`` – Fans welcomed the band at the venue.
+    * ``local_cuisine`` – Sampled local cuisine, lifting spirits.
+    """
+
+    payload = request.get_json(silent=True) or {}
+    location = payload.get("location")
+    mood = payload.get("mood")
     try:
-        result = event_service.trigger_event_for_band(band_id)
+        result = event_service.trigger_event_for_band(
+            band_id, location=location, mood=mood
+        )
         return jsonify(result), 200
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception as e:  # pragma: no cover - simple error pass-through
+        return jsonify({"error": str(e)}), 500

--- a/backend/services/random_event_service.py
+++ b/backend/services/random_event_service.py
@@ -18,51 +18,112 @@ class RandomEventService:
     # ------------------------------------------------------------------
     # Trigger helpers
     # ------------------------------------------------------------------
-    def trigger_event_for_band(self, band_id: int, user_id: int | None = None):
-        options = [
-            (
-                "delay",
-                "Vehicle breakdown caused a delay.",
-                {"skill": ("stamina", -5)},
-            ),
-            (
-                "press",
-                "Local press covered the band’s arrival.",
-                {"fame": 10},
-            ),
-            (
-                "fan_interaction",
-                "Fans welcomed the band at the venue.",
-                {"funds": 50},
-            ),
-        ]
-        return self._trigger(band_id=band_id, avatar_id=None, user_id=user_id, options=options)
+    def trigger_event_for_band(
+        self,
+        band_id: int,
+        user_id: int | None = None,
+        *,
+        location: str | None = None,
+        mood: int | None = None,
+    ):
+        """Trigger a contextual event for a band."""
 
-    def trigger_event_for_avatar(self, avatar_id: int, user_id: int | None = None):
         options = [
-            (
-                "street_performance",
-                "You impressed passersby with a street solo.",
-                {"fame": 5, "funds": 20},
-            ),
-            (
-                "practice",
-                "Extra practice boosted your skills.",
-                {"skill": ("guitar", 2)},
-            ),
+            {
+                "type": "delay",
+                "description": "Vehicle breakdown caused a delay.",
+                "impact": {"skill": ("stamina", -5)},
+            },
+            {
+                "type": "press",
+                "description": "Local press covered the band’s arrival.",
+                "impact": {"fame": 10},
+                "location": ["city", "venue"],
+            },
+            {
+                "type": "fan_interaction",
+                "description": "Fans welcomed the band at the venue.",
+                "impact": {"funds": 50},
+                "mood_range": (60, 100),
+            },
+            {
+                "type": "local_cuisine",
+                "description": "Sampled local cuisine, lifting spirits.",
+                "impact": {"fame": 3},
+                "location": ["city"],
+                "mood_range": (0, 55),
+            },
         ]
-        return self._trigger(band_id=None, avatar_id=avatar_id, user_id=user_id, options=options)
+        return self._trigger(
+            band_id=band_id,
+            avatar_id=None,
+            user_id=user_id,
+            options=options,
+            location=location,
+            mood=mood,
+        )
 
-    def _trigger(self, band_id, avatar_id, user_id, options):
-        selected = random.choice(options)
-        impact = selected[2]
+    def trigger_event_for_avatar(
+        self,
+        avatar_id: int,
+        user_id: int | None = None,
+        *,
+        location: str | None = None,
+        mood: int | None = None,
+    ):
+        options = [
+            {
+                "type": "street_performance",
+                "description": "You impressed passersby with a street solo.",
+                "impact": {"fame": 5, "funds": 20},
+                "location": ["street"],
+            },
+            {
+                "type": "practice",
+                "description": "Extra practice boosted your skills.",
+                "impact": {"skill": ("guitar", 2)},
+                "mood_range": (50, 100),
+            },
+            {
+                "type": "rainy_day_jam",
+                "description": "A rainy day inspired a reflective jam session.",
+                "impact": {"skill": ("songwriting", 1), "fame": 2},
+                "location": ["indoors"],
+                "mood_range": (20, 80),
+            },
+        ]
+        return self._trigger(
+            band_id=None,
+            avatar_id=avatar_id,
+            user_id=user_id,
+            options=options,
+            location=location,
+            mood=mood,
+        )
+
+    def _trigger(self, band_id, avatar_id, user_id, options, *, location=None, mood=None):
+        candidates = []
+        for opt in options:
+            locs = opt.get("location")
+            mood_range = opt.get("mood_range")
+            if locs and location not in locs:
+                continue
+            if mood_range and mood is not None:
+                low, high = mood_range
+                if not (low <= mood <= high):
+                    continue
+            candidates.append(opt)
+        if not candidates:
+            candidates = options
+        selected = random.choice(candidates)
+        impact = selected.get("impact", {})
         skill_name, skill_delta = impact.get("skill", (None, 0))
         event = RandomEvent(
             id=None,
             band_id=band_id,
             avatar_id=avatar_id,
-            type=selected[0],
-            description=selected[1],
+            type=selected["type"],
+            description=selected["description"],
             fame=impact.get("fame", 0),
             funds=impact.get("funds", 0),
             skill=skill_name,


### PR DESCRIPTION
## Summary
- add location and mood aware random event definitions for bands and avatars
- filter event selection by supplied location and mood
- document available contextual events in the random event trigger route

## Testing
- `ruff check backend/services/random_event_service.py backend/routes/random_event_routes.py backend/tests/services/test_random_event_service.py`
- `pytest backend/tests/services/test_random_event_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bab3575af083258f54e2d411309d16