### PR TITLE
Add seasonal logic and NPC scheduling

### DIFF
--- a/backend/models/world_pulse.py
+++ b/backend/models/world_pulse.py
@@ -1,14 +1,25 @@
 
 from datetime import datetime
 
+
 class WorldPulse:
-    def __init__(self, id, trending_genres, karma_level, active_events, top_players, updated_at=None):
+    def __init__(
+        self,
+        id,
+        trending_genres,
+        karma_level,
+        active_events,
+        top_players,
+        season,
+        updated_at=None,
+    ):
         self.id = id
         # list of dicts: {"genre_id": int, "subgenre_id": Optional[int], "count": int}
         self.trending_genres = trending_genres
         self.karma_level = karma_level  # e.g., 'Peaceful', 'Chaotic'
         self.active_events = active_events  # list of event titles
         self.top_players = top_players  # list of usernames or ids
+        self.season = season
         self.updated_at = updated_at or datetime.utcnow().isoformat()
 
     def to_dict(self):

--- a/backend/routes/world_pulse_routes.py
+++ b/backend/routes/world_pulse_routes.py
@@ -13,8 +13,10 @@ from fastapi import APIRouter, HTTPException, Query
 # The service lives under ``services`` when the package root is ``backend``.
 try:  # pragma: no cover - import shim for tests vs runtime
     from services.jobs_world_pulse import WorldPulseService
+    from services.world_pulse_service import get_current_season
 except Exception:  # pragma: no cover
     from backend.services.jobs_world_pulse import WorldPulseService
+    from backend.services.world_pulse_service import get_current_season
 
 
 router = APIRouter(prefix="/world-pulse", tags=["World Pulse"])
@@ -42,6 +44,13 @@ def ranked_list(
         )
     except Exception as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/season")
+def current_season() -> dict:
+    """Expose the game's current season."""
+
+    return {"season": get_current_season()}
 
 
 @router.get("/trending")

--- a/backend/services/npc_band_service.py
+++ b/backend/services/npc_band_service.py
@@ -3,6 +3,11 @@ from models.npc_band import NPCBand
 from datetime import datetime, timedelta
 import random
 
+try:  # pragma: no cover - import path shim
+    from services.world_pulse_service import get_current_season
+except Exception:  # pragma: no cover
+    from backend.services.world_pulse_service import get_current_season
+
 class NPCBandService:
     def __init__(self, db):
         self.db = db
@@ -24,4 +29,31 @@ class NPCBandService:
             band_id = band["id"]
             fame_gain = random.randint(0, band["activity_level"])
             self.db.increase_npc_fame(band_id, fame_gain)
-            self.db.record_npc_event(band_id, f"Gained {fame_gain} fame from a simulated event")
+            self.db.record_npc_event(
+                band_id, f"Gained {fame_gain} fame from a simulated event"
+            )
+
+            # Occasionally schedule a seasonal gig or release
+            if random.random() < 0.3:
+                self.schedule_seasonal_activity(band_id)
+
+    def schedule_seasonal_activity(self, band_id: int) -> dict:
+        """Plan a seasonal gig or release for an NPC band.
+
+        The activity type is chosen at random and scheduled within the next
+        ninety days. A corresponding event is persisted via ``record_npc_event``.
+        """
+
+        season = get_current_season()
+        activity = random.choice(["gig", "release"])
+        date = datetime.utcnow() + timedelta(days=random.randint(1, 90))
+        description = (
+            f"Scheduled {activity} for the {season} season on {date.date().isoformat()}"
+        )
+        self.db.record_npc_event(band_id, description)
+        return {
+            "band_id": band_id,
+            "activity": activity,
+            "season": season,
+            "date": date.date().isoformat(),
+        }

--- a/backend/services/world_pulse_service.py
+++ b/backend/services/world_pulse_service.py
@@ -2,6 +2,26 @@
 from models.world_pulse import WorldPulse
 from datetime import datetime
 
+
+def get_current_season(now: datetime | None = None) -> str:
+    """Return the meteorological season for ``now``.
+
+    The helper defaults to :func:`datetime.utcnow` when ``now`` is ``None`` and
+    maps the month to one of ``Spring``, ``Summer``, ``Autumn`` or ``Winter``.
+    This logic is shared by multiple services that need to reason about the
+    current season.
+    """
+
+    now = now or datetime.utcnow()
+    month = now.month
+    if month in (12, 1, 2):
+        return "Winter"
+    if month in (3, 4, 5):
+        return "Spring"
+    if month in (6, 7, 8):
+        return "Summer"
+    return "Autumn"
+
 class WorldPulseService:
     def __init__(self, db):
         self.db = db
@@ -17,7 +37,8 @@ class WorldPulseService:
             trending_genres=genres,
             karma_level=self._calculate_karma_level(karma),
             active_events=[e["title"] for e in events],
-            top_players=top_players
+            top_players=top_players,
+            season=get_current_season(),
         )
 
         self.db.insert_world_pulse(pulse)


### PR DESCRIPTION
## Summary
- compute current season in world pulse service and include in pulse output
- schedule seasonal gigs or releases for NPC bands
- expose current season via world pulse API

## Testing
- `pytest` *(fails: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68bab4756f708325918e6b925a86759c