### PR TITLE
Add festival proposal voting support

### DIFF
--- a/backend/models/festival.py
+++ b/backend/models/festival.py
@@ -1,6 +1,8 @@
-from pydantic import BaseModel
-from typing import List, Optional
 from datetime import date
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
 
 class Festival(BaseModel):
     id: int
@@ -22,3 +24,20 @@ class Festival(BaseModel):
     revenue: float
     genre_id: Optional[int]
     success_score: Optional[float]
+
+
+class FestivalProposal(BaseModel):
+    """Represents a player submitted festival idea awaiting votes."""
+
+    id: int
+    proposer_id: int
+    name: str
+    description: Optional[str] = None
+    votes: List[int] = Field(default_factory=list)
+
+
+class ProposalVote(BaseModel):
+    """Record of a player's vote on a proposal."""
+
+    proposal_id: int
+    voter_id: int

--- a/backend/routes/election_routes.py
+++ b/backend/routes/election_routes.py
@@ -1,10 +1,10 @@
-from auth.dependencies import get_current_user_id, require_role
-
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, jsonify, request
 from services.election_service import ElectionService
+from services.festival_builder_service import FestivalBuilderService
 
 election_routes = Blueprint('election_routes', __name__)
 election_service = ElectionService(db=None)
+festival_builder_service = FestivalBuilderService()
 
 @election_routes.route('/elections/create', methods=['POST'])
 def create_election():
@@ -37,3 +37,36 @@ def close_election(election_id):
         return jsonify(result), 200
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
+
+@election_routes.route('/festival/proposals', methods=['POST'])
+def create_festival_proposal():
+    data = request.json
+    try:
+        proposal_id = festival_builder_service.propose_festival(
+            proposer_id=data['proposer_id'],
+            name=data['name'],
+            description=data.get('description'),
+        )
+        return jsonify({'proposal_id': proposal_id}), 201
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
+
+
+@election_routes.route('/festival/proposals', methods=['GET'])
+def list_festival_proposals():
+    proposals = festival_builder_service.list_proposals()
+    return jsonify([p.dict() for p in proposals]), 200
+
+
+@election_routes.route('/festival/proposals/<int:proposal_id>/vote', methods=['POST'])
+def vote_on_festival_proposal(proposal_id):
+    data = request.json
+    try:
+        votes = festival_builder_service.vote_on_proposal(
+            proposal_id=proposal_id,
+            voter_id=data['voter_id'],
+        )
+        return jsonify({'votes': votes}), 200
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400

--- a/backend/tests/festival_builder/test_service.py
+++ b/backend/tests/festival_builder/test_service.py
@@ -10,6 +10,7 @@ sys.path.append(str(Path(__file__).resolve().parents[3]))
 from backend.services.festival_builder_service import (
     BookingConflictError,
     FestivalBuilderService,
+    FestivalError,
 )
 
 
@@ -63,3 +64,15 @@ def test_financial_reconciliation():
     assert finances["payouts"] == 500
     assert svc.economy.get_balance(1) == 3000
     assert svc.economy.get_balance(2) == 500
+
+
+def test_proposals_and_voting():
+    svc = setup_service()
+    pid = svc.propose_festival(proposer_id=1, name="IdeaFest")
+    assert pid == 1
+    proposals = svc.list_proposals()
+    assert proposals[0].name == "IdeaFest"
+    votes = svc.vote_on_proposal(pid, voter_id=2)
+    assert votes == 1
+    with pytest.raises(FestivalError):
+        svc.vote_on_proposal(pid, voter_id=2)


### PR DESCRIPTION
## Summary
- add festival proposal and vote models
- allow festival builder service to handle proposals and votes
- expose REST endpoints for proposing festivals and voting

## Testing
- `ruff check backend/models/festival.py backend/services/festival_builder_service.py backend/routes/election_routes.py backend/tests/festival_builder/test_service.py`
- `pytest backend/tests/festival_builder/test_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68bab702edb08325a69049c94c812f02