### PR TITLE
Add venue sponsorship negotiation workflow

### DIFF
--- a/backend/models/venue_sponsorship.py
+++ b/backend/models/venue_sponsorship.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict
+
+
+class NegotiationStage(str, Enum):
+    """Possible states of a sponsorship negotiation."""
+
+    OFFER = "offer"
+    COUNTER = "counter"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+@dataclass
+class SponsorshipNegotiation:
+    """In-memory representation of a sponsorship negotiation."""
+
+    id: int
+    venue_id: int
+    sponsor_name: str
+    terms: Dict[str, Any]
+    stage: NegotiationStage = NegotiationStage.OFFER


### PR DESCRIPTION
## Summary
- introduce negotiation models for venue sponsorships
- implement negotiation creation, counter offers, and acceptance logic
- expose sponsorship negotiation endpoints

## Testing
- `ruff check backend/models/venue_sponsorship.py backend/services/venue_sponsorships_service.py backend/routes/venue_sponsorships_routes.py`
- `pytest` *(fails: sqlite3.OperationalError unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68bab80b0d8883259a49705ed8f2ef26