### PR TITLE
Integrate travel risk checks and disruptions

### DIFF
--- a/backend/services/random_event_service.py
+++ b/backend/services/random_event_service.py
@@ -35,6 +35,21 @@ class RandomEventService:
                 "impact": {"skill": ("stamina", -5)},
             },
             {
+                "type": "traffic_jam",
+                "description": "Heavy traffic slowed the band's travel.",
+                "impact": {"skill": ("stamina", -2)},
+            },
+            {
+                "type": "weather_delay",
+                "description": "Severe weather forced a detour.",
+                "impact": {"funds": -20},
+            },
+            {
+                "type": "mechanical_issue",
+                "description": "A mechanical issue required roadside repairs.",
+                "impact": {"skill": ("stamina", -3)},
+            },
+            {
                 "type": "press",
                 "description": "Local press covered the band’s arrival.",
                 "impact": {"fame": 10},

--- a/backend/services/tour_logistics_service.py
+++ b/backend/services/tour_logistics_service.py
@@ -4,9 +4,12 @@ from models.tour_route import TourRoute
 from datetime import datetime, timedelta
 import random
 
+from services.transport_service import TransportService
+
 class TourLogisticsService:
-    def __init__(self, db):
+    def __init__(self, db, transport: TransportService | None = None):
         self.db = db
+        self.transport = transport or TransportService(db)
 
     def register_vehicle(self, band_id, type, capacity, perks):
         vehicle = TourVehicle(id=None, band_id=band_id, type=type, capacity=capacity, perks=perks)
@@ -31,10 +34,31 @@ class TourLogisticsService:
         self.db.deduct_band_funds(band_id, cost)
         self.db.increase_band_fatigue(band_id, fatigue)
         self.db.add_mileage(vehicle_id, hours * 50)
-        return route.to_dict()
+
+        vehicle_type = "van"
+        try:
+            vehicle = self.db.get_vehicle(vehicle_id)
+            vehicle_type = getattr(vehicle, "type", vehicle_type)
+        except Exception:
+            pass
+        disruption_info = self.check_disruptions(vehicle_type, origin, destination)
+        data = route.to_dict()
+        data.update(disruption_info)
+        return data
 
     def get_band_routes(self, band_id):
         return self.db.get_routes_by_band(band_id)
 
     def get_band_vehicles(self, band_id):
         return self.db.get_vehicles_by_band(band_id)
+
+    def check_disruptions(self, vehicle_type, origin, destination, weather="clear"):
+        risks = self.transport.evaluate_risks(vehicle_type, weather)
+        options = []
+        if "mechanical_issue" in risks:
+            options.extend(["repair_vehicle", "hire_replacement"])
+        if "traffic_jam" in risks:
+            options.extend(["wait_it_out", "take_detour"])
+        if "weather_delay" in risks:
+            options.extend(["delay_departure", "change_route"])
+        return {"disruptions": risks, "options": options}

--- a/backend/services/transport_service.py
+++ b/backend/services/transport_service.py
@@ -1,6 +1,7 @@
 
 from models.transport import Transport
 from datetime import datetime
+import random
 
 DEFAULT_VEHICLE_STATS = {
     "van": {"speed": 80, "fatigue_rate": 1.2, "capacity": 4, "perks": []},
@@ -33,3 +34,19 @@ class TransportService:
 
     def update_maintenance(self, vehicle_id):
         self.db.update_transport_maintenance(vehicle_id, datetime.utcnow().isoformat())
+
+    def evaluate_risks(self, vehicle_type, weather="clear"):
+        """Simple travel risk assessment.
+
+        Returns a list of potential disruptions based on vehicle type and
+        ambient weather. Probabilities are intentionally light-weight for
+        demonstration and tests.
+        """
+        risks = []
+        if random.random() < 0.1:
+            risks.append("traffic_jam")
+        if vehicle_type in ("van", "bus", "truck") and random.random() < 0.05:
+            risks.append("mechanical_issue")
+        if weather in ("storm", "snow") and random.random() < 0.3:
+            risks.append("weather_delay")
+        return risks


### PR DESCRIPTION
## Summary
- add simple travel risk assessment to transport and tour logistics services
- introduce traffic, weather, and mechanical disruption event types
- expose travel disruption options via new tour route endpoint

## Testing
- `pytest` *(fails: sqlite operational errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bab8d69ec083258462c0f3f63bb33d