### PR TITLE
feat: add daily challenge tokens and tiers

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -371,6 +371,8 @@ def init_db():
             current_challenge TEXT,
             challenge_progress INTEGER DEFAULT 0,
             reward_claimed INTEGER DEFAULT 0,
+            catch_up_tokens INTEGER DEFAULT 0,
+            challenge_tier INTEGER DEFAULT 1,
             FOREIGN KEY(user_id) REFERENCES users(id)
         )
         """)

--- a/backend/routes/daily_loop_routes.py
+++ b/backend/routes/daily_loop_routes.py
@@ -18,3 +18,19 @@ class ClaimRequest(BaseModel):
 @router.post("/claim")
 def claim_reward(req: ClaimRequest):
     return daily_loop.claim_reward(req.user_id)
+
+
+class TokenGrantRequest(BaseModel):
+    user_id: int
+    amount: int = 1
+
+
+@router.post("/grant-token")
+def grant_token(req: TokenGrantRequest):
+    return daily_loop.grant_catch_up_tokens(req.user_id, req.amount)
+
+
+@router.post("/rotate")
+def rotate_challenge():
+    daily_loop.rotate_daily_challenge()
+    return {"status": "ok"}

--- a/backend/services/xp_reward_service.py
+++ b/backend/services/xp_reward_service.py
@@ -117,6 +117,15 @@ class XPRewardService:
             conn.commit()
             return True
 
+    # ------------------------------------------------------------------
+    def grant_daily_reward(self, user_id: int, tier: int) -> bool:
+        """Award XP for completing the daily challenge.
+
+        The amount scales with the provided ``tier``.
+        """
+        amount = 10 * max(1, int(tier))
+        return self.grant_hidden_xp(user_id, f"daily_tier_{tier}", amount)
+
 
 xp_reward_service = XPRewardService()
 

--- a/backend/tests/schedule/test_default_plan.py
+++ b/backend/tests/schedule/test_default_plan.py
@@ -64,7 +64,7 @@ def test_scheduler_populates_daily_schedule(tmp_path):
     # User has no login for today
     with sqlite3.connect(database.DB_PATH) as conn:
         conn.execute(
-            "INSERT INTO daily_loop (user_id, login_streak, last_login, current_challenge, challenge_progress, reward_claimed) VALUES (1,0,'2024-01-01','',0,0)"
+            "INSERT INTO daily_loop (user_id, login_streak, last_login, current_challenge, challenge_progress, reward_claimed, catch_up_tokens, challenge_tier) VALUES (1,0,'2024-01-01','',0,0,0,1)"
         )
         conn.commit()
 

--- a/backend/tests/schedule/test_recurring_templates.py
+++ b/backend/tests/schedule/test_recurring_templates.py
@@ -47,7 +47,7 @@ def test_recurring_template_populates_daily_schedule(tmp_path):
     # Ensure user exists in daily_loop with old login date
     with sqlite3.connect(database.DB_PATH) as conn:
         conn.execute(
-            "INSERT INTO daily_loop (user_id, login_streak, last_login, current_challenge, challenge_progress, reward_claimed) VALUES (1,0,'2024-01-01','',0,0)"
+            "INSERT INTO daily_loop (user_id, login_streak, last_login, current_challenge, challenge_progress, reward_claimed, catch_up_tokens, challenge_tier) VALUES (1,0,'2024-01-01','',0,0,0,1)"
         )
         conn.commit()
 
@@ -72,7 +72,7 @@ def test_inactive_template_not_applied(tmp_path):
 
     with sqlite3.connect(database.DB_PATH) as conn:
         conn.execute(
-            "INSERT INTO daily_loop (user_id, login_streak, last_login, current_challenge, challenge_progress, reward_claimed) VALUES (1,0,'2024-01-01','',0,0)"
+            "INSERT INTO daily_loop (user_id, login_streak, last_login, current_challenge, challenge_progress, reward_claimed, catch_up_tokens, challenge_tier) VALUES (1,0,'2024-01-01','',0,0,0,1)"
         )
         conn.commit()
 


### PR DESCRIPTION
## Summary
- extend daily loop model with catch-up tokens and challenge tiers
- expose routes to grant tokens and rotate challenges
- distribute daily rewards through XP reward service

## Testing
- `pytest backend/tests/schedule/test_recurring_templates.py backend/tests/schedule/test_default_plan.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68baba4ee414832588dee4fb8dcd39a0