### PR TITLE
Add recovery actions reducing burnout

### DIFF
--- a/backend/routes/lifestyle_routes.py
+++ b/backend/routes/lifestyle_routes.py
@@ -1,8 +1,11 @@
-from auth.dependencies import get_current_user_id, require_role
-# routes/lifestyle_routes.py
+"""Lifestyle routes exposing wellness mechanics."""
 
-from fastapi import APIRouter, Depends
-from services.lifestyle_service import calculate_lifestyle_score, evaluate_lifestyle_risks
+from fastapi import APIRouter
+from services.lifestyle_service import (
+    calculate_lifestyle_score,
+    evaluate_lifestyle_risks,
+    apply_recovery_action,
+)
 
 router = APIRouter()
 
@@ -26,3 +29,12 @@ def get_lifestyle():
         "lifestyle": fake_lifestyle_data,
         "risk_events": events
     }
+
+
+@router.post("/lifestyle/recover/{action}")
+def recover(action: str):
+    apply_recovery_action(fake_lifestyle_data["user_id"], fake_lifestyle_data, action)
+    score = calculate_lifestyle_score(fake_lifestyle_data)
+    events = evaluate_lifestyle_risks(fake_lifestyle_data)
+    fake_lifestyle_data["lifestyle_score"] = score
+    return {"lifestyle": fake_lifestyle_data, "risk_events": events}

--- a/backend/services/lifestyle_service.py
+++ b/backend/services/lifestyle_service.py
@@ -3,6 +3,8 @@
 from datetime import datetime
 import random
 
+from .skill_service import skill_service
+
 def calculate_lifestyle_score(data):
     # Composite score from normalized attributes
     score = (
@@ -28,3 +30,61 @@ def evaluate_lifestyle_risks(data):
     if data["fitness"] < 30 and random.random() < 0.1:
         events.append("injury")
     return events
+
+
+# ---------------------------------------------------------------------------
+# Recovery helpers
+
+_RECOVERY_ACTIONS = {
+    "rest": {
+        "sleep_hours": 2,  # hours of extra rest
+        "stress": -20,
+        "burnout": 2,
+    },
+    "meditate": {
+        "stress": -15,
+        "mental_health": 5,
+        "burnout": 1,
+    },
+}
+
+
+def apply_recovery_action(user_id: int, data: dict, action: str) -> dict:
+    """Apply a recovery action to lifestyle data and reduce burnout.
+
+    Parameters
+    ----------
+    user_id: int
+        The id of the user taking the action.
+    data: dict
+        The lifestyle data to mutate.
+    action: str
+        Name of the recovery action (e.g. ``"rest"`` or ``"meditate"``).
+    """
+
+    effects = _RECOVERY_ACTIONS.get(action)
+    if not effects:
+        return data
+
+    burnout_reduction = effects.get("burnout", 1)
+
+    # Mutate lifestyle attributes within reasonable bounds
+    for key, delta in effects.items():
+        if key == "burnout":
+            continue
+        if key == "sleep_hours":
+            data[key] = min(12, data.get(key, 0) + delta)
+        else:
+            data[key] = max(0, min(100, data.get(key, 0) + delta))
+
+    # Recovery actions help relieve burnout from repetitive training
+    skill_service.reduce_burnout(user_id, amount=burnout_reduction)
+
+    return data
+
+
+__all__ = [
+    "calculate_lifestyle_score",
+    "evaluate_lifestyle_risks",
+    "apply_recovery_action",
+]

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -254,6 +254,31 @@ class SkillService:
 
         return self.train(user_id, skill, int(base_xp))
 
+    def reduce_burnout(self, user_id: int, amount: int = 1) -> None:
+        """Reduce the stored burnout streak for a user.
+
+        A streak of repetitive learning methods causes diminishing returns.
+        Recovery actions can call this to lower the streak and ease the XP
+        penalty.
+
+        Parameters
+        ----------
+        user_id: int
+            The user whose streak should be reduced.
+        amount: int
+            How much to reduce the streak by. If the streak drops to zero the
+            history entry is cleared.
+        """
+
+        last, streak = self._method_history.get(user_id, (None, 0))
+        if streak <= 0:
+            return
+        streak = max(0, streak - amount)
+        if streak == 0:
+            self._method_history.pop(user_id, None)
+        else:
+            self._method_history[user_id] = (last, streak)
+
     def apply_decay(self, user_id: int, skill_id: int, amount: int) -> Skill | None:
         """Reduce XP for a skill and update its level."""
 

--- a/docs/learning_methods.md
+++ b/docs/learning_methods.md
@@ -39,3 +39,18 @@ Practice Time -> Fatigue -> Burnout -> XP Penalty
 ```
 
 This pipeline illustrates how extended practice sessions can lead to fatigue and eventual burnout, reducing XP gains until the avatar recovers.
+
+## Recovery Actions
+
+Taking breaks restores more than just mood. Certain lifestyle actions now
+directly chip away at the burnout streak that builds up from repeating the
+same learning method. Examples include:
+
+- **Rest** – adds extra sleep, lowers stress and removes two steps from the
+  burnout counter.
+- **Meditation** – improves mental health, eases stress and reduces the
+  counter by one.
+
+Triggering a recovery action refreshes the XP modifier applied in the next
+training session, allowing avatars to rebound to full learning efficiency
+instead of being stuck with diminished gains.

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -187,6 +187,20 @@ def test_method_burnout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     assert updated.xp == 27
 
 
+def test_burnout_recovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _setup_db(tmp_path)
+    svc = SkillService(db_path=db)
+    skill = Skill(id=24, name="piano", category="instrument")
+    monkeypatch.setattr(
+        "backend.services.skill_service.random.random", lambda: 0.99
+    )
+    svc.train_with_method(1, skill, LearningMethod.PRACTICE, 1)
+    svc.train_with_method(1, skill, LearningMethod.PRACTICE, 1)
+    svc.reduce_burnout(1, amount=2)
+    updated = svc.train_with_method(1, skill, LearningMethod.PRACTICE, 1)
+    assert updated.xp == 29
+
+
 def test_synergy_bonus_applied() -> None:
     svc = SkillService()
     spec = SkillSpecialization(name="lead", related_skills={31: 2}, bonus=0.5)


### PR DESCRIPTION
## Summary
- add lifestyle recovery actions and expose via API
- let skill service reduce burnout streaks through recovery
- document recovery mechanics and test burnout relief

## Testing
- `pytest` *(fails: unable to open database file, missing modules)*
- `PYTHONPATH=. pytest tests/test_skill_service.py::test_burnout_recovery -q`

------
https://chatgpt.com/codex/tasks/task_e_68babb4728f08325a53bbf6419ad57af