### PR TITLE
Add live album compilation service and API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -43,6 +43,7 @@ from routes import (
     social_routes,
     song_forecast_routes,
     sponsorship,
+    live_album_routes,
     support_slot_routes,
     tour_collab_routes,
     tour_planner_routes,
@@ -146,6 +147,7 @@ app.include_router(tour_planner_routes.router, prefix="/api", tags=["TourPlanner
 app.include_router(university_routes.router, prefix="/api", tags=["University"])
 app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])
 app.include_router(user_settings_routes.router, prefix="/api", tags=["UserSettings"])
+app.include_router(live_album_routes.router, prefix="/api", tags=["LiveAlbums"])
 app.include_router(avatar.router, prefix="/api", tags=["Avatars"])
 app.include_router(character.router, prefix="/api", tags=["Characters"])
 app.include_router(playlist_routes.router, prefix="/api", tags=["Playlists"])

--- a/backend/models/live_performance.py
+++ b/backend/models/live_performance.py
@@ -1,8 +1,23 @@
 
 from datetime import datetime
 
+
 class LivePerformance:
-    def __init__(self, id, band_id, city, venue, date, setlist, crowd_size, fame_earned, revenue_earned, skill_gain, merch_sold):
+    def __init__(
+        self,
+        id,
+        band_id,
+        city,
+        venue,
+        date,
+        setlist,
+        crowd_size,
+        fame_earned,
+        revenue_earned,
+        skill_gain,
+        merch_sold,
+        performance_score: float | None = None,
+    ):
         self.id = id
         self.band_id = band_id
         self.city = city
@@ -14,6 +29,8 @@ class LivePerformance:
         self.revenue_earned = revenue_earned
         self.skill_gain = skill_gain
         self.merch_sold = merch_sold
+        # Optional quality metric for comparing performances
+        self.performance_score = performance_score
 
     def to_dict(self):
         return self.__dict__

--- a/backend/routes/live_album_routes.py
+++ b/backend/routes/live_album_routes.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from services.live_album_service import LiveAlbumService
+
+router = APIRouter()
+service = LiveAlbumService()
+
+
+class CompileRequest(BaseModel):
+    show_ids: List[int]
+    album_title: str = "Live Compilation"
+
+
+@router.post("/live_albums/compile")
+def compile_live_album(payload: CompileRequest):
+    try:
+        return service.compile_live_album(payload.show_ids, payload.album_title)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc))

--- a/backend/services/live_album_service.py
+++ b/backend/services/live_album_service.py
@@ -1,0 +1,96 @@
+import json
+import sqlite3
+from typing import Dict, List
+
+from models.album import Album
+
+from backend.database import DB_PATH
+
+
+class LiveAlbumService:
+    """Compile live albums from existing performance recordings."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        self.db_path = db_path or str(DB_PATH)
+
+    # ------------------------------------------------------------------
+    def _has_performance_score(self, cur: sqlite3.Cursor) -> bool:
+        cur.execute("PRAGMA table_info(live_performances)")
+        return any(row[1] == "performance_score" for row in cur.fetchall())
+
+    # ------------------------------------------------------------------
+    def compile_live_album(self, performance_ids: List[int], title: str) -> Dict:
+        if len(performance_ids) != 5:
+            raise ValueError("Exactly five performance IDs are required")
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        has_score = self._has_performance_score(cur)
+
+        performances = []
+        for pid in performance_ids:
+            if has_score:
+                cur.execute(
+                    "SELECT rowid, band_id, setlist, skill_gain, performance_score FROM live_performances WHERE rowid = ?",
+                    (pid,),
+                )
+            else:
+                cur.execute(
+                    "SELECT rowid, band_id, setlist, skill_gain FROM live_performances WHERE rowid = ?",
+                    (pid,),
+                )
+            row = cur.fetchone()
+            if not row:
+                conn.close()
+                raise ValueError(f"Performance {pid} not found")
+            if has_score:
+                rowid, band_id, setlist_json, skill_gain, perf_score = row
+            else:
+                rowid, band_id, setlist_json, skill_gain = row
+                perf_score = None
+            setlist_data = json.loads(setlist_json)
+            actions = setlist_data.get("setlist", []) + setlist_data.get("encore", [])
+            songs: List[int] = []
+            for action in actions:
+                if action.get("type") in ("song", "encore"):
+                    ref = action.get("reference")
+                    try:
+                        songs.append(int(ref))
+                    except (TypeError, ValueError):
+                        continue
+            performances.append(
+                {
+                    "id": rowid,
+                    "band_id": band_id,
+                    "songs": songs,
+                    "metric": perf_score if perf_score is not None else skill_gain,
+                    "order": songs,
+                }
+            )
+        conn.close()
+        band_ids = {p["band_id"] for p in performances}
+        if len(band_ids) != 1:
+            raise ValueError("All performances must belong to the same band")
+        common = set(performances[0]["songs"])
+        for p in performances[1:]:
+            common &= set(p["songs"])
+        if not common:
+            raise ValueError("No common songs across performances")
+        order = [s for s in performances[0]["order"] if s in common]
+        tracks = []
+        for song_id in order:
+            best = max(
+                (p for p in performances if song_id in p["songs"]),
+                key=lambda p: p["metric"],
+            )
+            tracks.append({"song_id": song_id, "performance_id": best["id"]})
+        album = Album(
+            id=0,
+            title=title,
+            album_type="live",
+            genre_id=0,
+            band_id=performances[0]["band_id"],
+            song_ids=[t["song_id"] for t in tracks],
+        )
+        data = album.to_dict()
+        data["tracks"] = tracks
+        return data

--- a/backend/tests/live_album/test_live_album_routes.py
+++ b/backend/tests/live_album/test_live_album_routes.py
@@ -1,0 +1,59 @@
+import json
+import sqlite3
+
+from fastapi import FastAPI
+
+from backend.routes import live_album_routes
+
+
+def _insert_performance(cur, band_id, setlist, skill_gain, perf_score):
+    cur.execute(
+        """
+        INSERT INTO live_performances (
+            band_id, city, venue, date, setlist, crowd_size, fame_earned,
+            revenue_earned, skill_gain, merch_sold, performance_score
+        ) VALUES (?, '', '', '', ?, 0, 0, 0, ?, 0, ?)
+        """,
+        (band_id, json.dumps(setlist), skill_gain, perf_score),
+    )
+
+
+def test_compile_route(tmp_path, client_factory):
+    db_file = tmp_path / "perf.db"
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE live_performances (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            band_id INTEGER,
+            city TEXT,
+            venue TEXT,
+            date TEXT,
+            setlist TEXT,
+            crowd_size INTEGER,
+            fame_earned INTEGER,
+            revenue_earned INTEGER,
+            skill_gain REAL,
+            merch_sold INTEGER,
+            performance_score REAL
+        )
+        """
+    )
+    setlist = {"setlist": [{"type": "song", "reference": "1"}, {"type": "song", "reference": "2"}], "encore": []}
+    scores = [50, 60, 55, 40, 80]
+    for score in scores:
+        _insert_performance(cur, 1, setlist, 0.0, score)
+    conn.commit()
+    conn.close()
+
+    live_album_routes.service.db_path = str(db_file)
+    app = FastAPI()
+    app.include_router(live_album_routes.router, prefix="/api")
+    client = client_factory(app)
+
+    resp = client.post("/api/live_albums/compile", json={"show_ids": [1, 2, 3, 4, 5], "album_title": "Best Live"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["song_ids"] == [1, 2]
+    assert all(t["performance_id"] == 5 for t in data["tracks"])

--- a/backend/tests/live_album/test_live_album_service.py
+++ b/backend/tests/live_album/test_live_album_service.py
@@ -1,0 +1,54 @@
+import json
+import sqlite3
+
+from backend.services.live_album_service import LiveAlbumService
+
+
+def _insert_performance(cur, band_id, setlist, skill_gain, perf_score):
+    cur.execute(
+        """
+        INSERT INTO live_performances (
+            band_id, city, venue, date, setlist, crowd_size, fame_earned,
+            revenue_earned, skill_gain, merch_sold, performance_score
+        ) VALUES (?, '', '', '', ?, 0, 0, 0, ?, 0, ?)
+        """,
+        (band_id, json.dumps(setlist), skill_gain, perf_score),
+    )
+
+
+def test_compile_live_album(tmp_path):
+    db_file = tmp_path / "perf.db"
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE live_performances (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            band_id INTEGER,
+            city TEXT,
+            venue TEXT,
+            date TEXT,
+            setlist TEXT,
+            crowd_size INTEGER,
+            fame_earned INTEGER,
+            revenue_earned INTEGER,
+            skill_gain REAL,
+            merch_sold INTEGER,
+            performance_score REAL
+        )
+        """
+    )
+    setlist = {"setlist": [{"type": "song", "reference": "1"}, {"type": "song", "reference": "2"}], "encore": []}
+    scores = [50, 60, 55, 40, 80]
+    for score in scores:
+        _insert_performance(cur, 1, setlist, 0.0, score)
+    conn.commit()
+    conn.close()
+
+    service = LiveAlbumService(str(db_file))
+    album = service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
+
+    assert album["album_type"] == "live"
+    assert album["song_ids"] == [1, 2]
+    # Performance 5 has highest score (80)
+    assert all(t["performance_id"] == 5 for t in album["tracks"])


### PR DESCRIPTION
## Summary
- add `LiveAlbumService` to compile a live album from five performances
- expose `POST /live_albums/compile` FastAPI route
- record optional `performance_score` on `LivePerformance`
- wire router into main app and add tests

## Testing
- `pytest backend/tests/live_album -q`
- `ruff check backend/services/live_album_service.py backend/routes/live_album_routes.py backend/tests/live_album/test_live_album_service.py backend/tests/live_album/test_live_album_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68babe0b30c8832594958cc698bda303