### PR TITLE
feat: embed show metadata in live albums

### DIFF
--- a/backend/models/album.py
+++ b/backend/models/album.py
@@ -1,15 +1,26 @@
 
 class Album:
-    def __init__(self, id, title, album_type, genre_id, band_id, release_date=None,
-                 song_ids=None, distribution_channels=None, cover_art=None):
+    def __init__(
+        self,
+        id,
+        title,
+        album_type,
+        genre_id,
+        band_id,
+        release_date=None,
+        songs=None,
+        distribution_channels=None,
+        cover_art=None,
+    ):
         self.id = id
         self.title = title
         self.album_type = album_type
         self.genre_id = genre_id
         self.band_id = band_id
         self.release_date = release_date
-        self.song_ids = song_ids or []
-        self.distribution_channels = distribution_channels or ['digital']
+        # ``songs`` is a list of dicts: {"song_id", "show_id", "performance_score"}
+        self.songs = songs or []
+        self.distribution_channels = distribution_channels or ["digital"]
         self.cover_art = cover_art
 
     def to_dict(self):

--- a/backend/services/live_album_service.py
+++ b/backend/services/live_album_service.py
@@ -76,21 +76,25 @@ class LiveAlbumService:
         if not common:
             raise ValueError("No common songs across performances")
         order = [s for s in performances[0]["order"] if s in common]
-        tracks = []
+        songs: List[dict] = []
         for song_id in order:
             best = max(
                 (p for p in performances if song_id in p["songs"]),
                 key=lambda p: p["metric"],
             )
-            tracks.append({"song_id": song_id, "performance_id": best["id"]})
+            songs.append(
+                {
+                    "song_id": song_id,
+                    "show_id": best["id"],
+                    "performance_score": best["metric"],
+                }
+            )
         album = Album(
             id=0,
             title=title,
             album_type="live",
             genre_id=0,
             band_id=performances[0]["band_id"],
-            song_ids=[t["song_id"] for t in tracks],
+            songs=songs,
         )
-        data = album.to_dict()
-        data["tracks"] = tracks
-        return data
+        return album.to_dict()

--- a/backend/tests/live_album/test_live_album_routes.py
+++ b/backend/tests/live_album/test_live_album_routes.py
@@ -55,5 +55,6 @@ def test_compile_route(tmp_path, client_factory):
     resp = client.post("/api/live_albums/compile", json={"show_ids": [1, 2, 3, 4, 5], "album_title": "Best Live"})
     assert resp.status_code == 200
     data = resp.json()
-    assert data["song_ids"] == [1, 2]
-    assert all(t["performance_id"] == 5 for t in data["tracks"])
+    assert [s["song_id"] for s in data["songs"]] == [1, 2]
+    assert all(s["show_id"] == 5 for s in data["songs"])
+    assert all(s["performance_score"] == 80 for s in data["songs"])

--- a/backend/tests/live_album/test_live_album_service.py
+++ b/backend/tests/live_album/test_live_album_service.py
@@ -49,6 +49,7 @@ def test_compile_live_album(tmp_path):
     album = service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
 
     assert album["album_type"] == "live"
-    assert album["song_ids"] == [1, 2]
+    assert [s["song_id"] for s in album["songs"]] == [1, 2]
     # Performance 5 has highest score (80)
-    assert all(t["performance_id"] == 5 for t in album["tracks"])
+    assert all(s["show_id"] == 5 for s in album["songs"])
+    assert all(s["performance_score"] == 80 for s in album["songs"])


### PR DESCRIPTION
## Summary
- expand Album model songs to include show and performance score metadata
- compile live albums with detailed song entries
- adjust live album tests for new structure

## Testing
- `ruff check backend/models/album.py backend/services/live_album_service.py backend/tests/live_album/test_live_album_service.py backend/tests/live_album/test_live_album_routes.py`
- `pytest backend/tests/live_album/test_live_album_service.py backend/tests/live_album/test_live_album_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68bac1e1b7c48325acc7d453c85b4338