### PR TITLE
feat: add recording markers to tour planner

### DIFF
--- a/backend/services/tour_service.py
+++ b/backend/services/tour_service.py
@@ -200,6 +200,25 @@ class TourService:
             c.execute("UPDATE tour_stops SET status=? WHERE id=?", (status, stop_id))
         return self.get_stop(stop_id)
 
+    def update_stop_recording(self, stop_id: int, is_recorded: bool) -> Dict[str, Any]:
+        """Toggle the recording flag for a tour stop.
+
+        This verifies that the band is eligible to record the stop when
+        setting ``is_recorded`` to ``True`` and then persists the change.
+        """
+
+        stop = self.get_stop(stop_id)
+        tour = self.get_tour(stop["tour_id"])
+        if is_recorded:
+            self._assert_recording_allowed(tour["band_id"], stop["date_start"])
+        with get_conn(self.db_path) as conn:
+            c = conn.cursor()
+            c.execute(
+                "UPDATE tour_stops SET is_recorded=? WHERE id=?",
+                (int(is_recorded), stop_id),
+            )
+        return self.get_stop(stop_id)
+
     def get_stop(self, stop_id: int) -> Dict[str, Any]:
         with get_conn(self.db_path) as conn:
             c = conn.cursor()

--- a/frontend/pages/tour_planner.html
+++ b/frontend/pages/tour_planner.html
@@ -80,12 +80,57 @@ document.getElementById('tourForm').addEventListener('submit', async (e) => {
   });
 
   const result = await res.json();
-  document.getElementById('itinerary').innerHTML = `
+  const itineraryDiv = document.getElementById('itinerary');
+  let remainingSlots = 5;
+  itineraryDiv.innerHTML = `
     <h3>Optimized Itinerary</h3>
-    <p>${result.itinerary.join(' -> ')}</p>
+    <p id="recordSlots">Recording slots remaining: ${remainingSlots}</p>
+    <ul id="itineraryList">
+      ${result.itinerary
+        .map(
+          (city, idx) =>
+            `<li><label><input type="checkbox" data-idx="${idx}"> ${city}</label></li>`
+        )
+        .join('')}
+    </ul>
     <p>Total Distance: ${result.total_distance.toFixed(2)} km</p>
     <p>Total Time: ${result.total_time.toFixed(2)} hrs</p>
     <p>Estimated Cost: $${result.total_cost.toFixed(2)}</p>
+    <button type="button" id="saveRecordings">Save Recording Choices</button>
   `;
+
+  const updateSlots = () => {
+    document.getElementById('recordSlots').innerText = `Recording slots remaining: ${remainingSlots}`;
+    document
+      .querySelectorAll('#itineraryList input[type="checkbox"]')
+      .forEach((cb) => {
+        if (!cb.checked) {
+          cb.disabled = remainingSlots <= 0;
+        }
+      });
+  };
+
+  document
+    .querySelectorAll('#itineraryList input[type="checkbox"]')
+    .forEach((cb) => {
+      cb.addEventListener('change', () => {
+        remainingSlots += cb.checked ? -1 : 1;
+        updateSlots();
+      });
+    });
+
+  document.getElementById('saveRecordings').addEventListener('click', async () => {
+    const recordStops = Array.from(
+      document.querySelectorAll('#itineraryList input[type="checkbox"]')
+    )
+      .filter((cb) => cb.checked)
+      .map((cb) => parseInt(cb.dataset.idx));
+    await fetch('/api/tour-planner/schedule/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ updates: recordStops.map((id) => ({ stop_id: id, is_recorded: true })) }),
+    });
+    alert('Recording preferences saved');
+  });
 });
 </script>


### PR DESCRIPTION
## Summary
- allow choosing tour stops to record from the tour planner UI
- track remaining recording slots and persist flag via new API handler

## Testing
- `pytest` (fails: unable to open database / other operational errors)
- `npm test` (fails: vitest not found)
- `npm install` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68bac8094df08325b3d02e5408a4bc91