### PR TITLE
Add live album publishing endpoint with sales and chart integration

### DIFF
--- a/backend/routes/live_album_routes.py
+++ b/backend/routes/live_album_routes.py
@@ -31,3 +31,12 @@ def update_live_album_tracks(album_id: int, payload: TrackUpdateRequest):
         return service.update_tracks(album_id, payload.track_ids)
     except ValueError as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.post("/live_albums/{album_id}/publish")
+def publish_live_album(album_id: int):
+    try:
+        new_id = service.publish_album(album_id)
+        return {"album_id": new_id}
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=404, detail=str(exc))


### PR DESCRIPTION
## Summary
- add `publish_album` to persist drafted live albums and register sales/chart updates
- expose `POST /live_albums/{album_id}/publish` endpoint to finalize releases

## Testing
- `pytest backend/tests/live_album/test_live_album_service.py backend/tests/live_album/test_live_album_routes.py tests/test_live_album_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bad1754e648325a34af4f10b518b34