### PR TITLE
Include show metadata in live album tracks

### DIFF
--- a/backend/services/live_album_service.py
+++ b/backend/services/live_album_service.py
@@ -114,7 +114,7 @@ class LiveAlbumService:
         )
         for track, mixed_id in zip(tracks, mixed_ids):
             track["track_id"] = mixed_id
-            del track["performance_id"]
+            track["show_id"] = track.pop("performance_id")
 
         themes = list(cities | venues)
         try:
@@ -238,7 +238,9 @@ class LiveAlbumService:
             """
             CREATE TABLE IF NOT EXISTS release_tracks (
                 release_id INTEGER,
-                song_id INTEGER
+                song_id INTEGER,
+                show_id INTEGER,
+                performance_score REAL
             )
             """
         )
@@ -274,8 +276,13 @@ class LiveAlbumService:
 
         for track in album["tracks"]:
             cur.execute(
-                "INSERT INTO release_tracks (release_id, song_id) VALUES (?, ?)",
-                (release_id, track["song_id"]),
+                "INSERT INTO release_tracks (release_id, song_id, show_id, performance_score) VALUES (?, ?, ?, ?)",
+                (
+                    release_id,
+                    track["song_id"],
+                    track.get("show_id"),
+                    track.get("performance_score"),
+                ),
             )
 
         conn.commit()

--- a/backend/tests/live_album/test_live_album_routes.py
+++ b/backend/tests/live_album/test_live_album_routes.py
@@ -89,6 +89,7 @@ def test_compile_route(tmp_path, client_factory, monkeypatch):
     assert data["song_ids"] == [1, 2]
     assert called["ids"] == [5, 5]
     assert all(t["track_id"] == 1005 for t in data["tracks"])
+    assert all(t["show_id"] == 5 for t in data["tracks"])
     assert data["cover_art"]
 
 
@@ -129,7 +130,7 @@ def test_patch_tracks_route(tmp_path, client_factory):
         "CREATE TABLE releases (id INTEGER PRIMARY KEY AUTOINCREMENT, format TEXT)"
     )
     cur.execute(
-        "CREATE TABLE release_tracks (release_id INTEGER, song_id INTEGER)"
+        "CREATE TABLE release_tracks (release_id INTEGER, song_id INTEGER, show_id INTEGER, performance_score REAL)"
     )
     setlist = {"setlist": [{"type": "song", "reference": "1"}, {"type": "song", "reference": "2"}], "encore": []}
     scores = [50, 60, 55, 40, 80]


### PR DESCRIPTION
## Summary
- Track compiled shows by carrying show_id into draft track info
- Persist show_id and performance_score in release_tracks when publishing a live album
- Test publishing stores show metadata and update existing tests for new schema

## Testing
- `pytest backend/tests/live_album/test_live_album_service.py::test_publish_album_records_show_data -q`
- `pytest backend/tests/live_album/test_live_album_service.py -q`
- `pytest backend/tests/live_album/test_live_album_routes.py -q`
- `pytest` *(fails: ERROR backend/tests/auth/test_admin_mfa.py, backend/tests/test_auth_flow.py, backend/tests/test_health.py, backend/tests/test_i18n.py, backend/tests/test_metrics_smoke.py, backend/tests/test_storage_s3_mock.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bad84b8ff48325a314f9ffef85c62f