### PR TITLE
Ensure recorded tracks exist for live album mixing

### DIFF
--- a/backend/services/live_album_service.py
+++ b/backend/services/live_album_service.py
@@ -84,6 +84,16 @@ class LiveAlbumService:
             common &= set(p["songs"])
         if not common:
             raise ValueError("No common songs across performances")
+        # Ensure every candidate performance has a recording for each song in
+        # the intersection.  Without this validation we'd risk generating
+        # tracks from performances lacking recorded audio, leading to
+        # placeholder mixes.
+        for p in performances:
+            missing = [sid for sid in common if sid not in p["song_scores"]]
+            if missing:
+                raise ValueError(
+                    f"Performance {p['id']} missing recorded tracks for songs {missing}"
+                )
         order = [s for s in performances[0]["order"] if s in common]
         songs: List[dict] = []
         tracks: List[dict] = []

--- a/backend/tests/live_album/test_live_album_service.py
+++ b/backend/tests/live_album/test_live_album_service.py
@@ -249,3 +249,63 @@ def test_update_tracks_validation(tmp_path):
     updated = service.update_tracks(album_id, [1])
     assert updated["song_ids"] == [1]
 
+
+def test_compile_live_album_missing_recordings(tmp_path):
+    db_file = tmp_path / "perf.db"
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE live_performances (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            band_id INTEGER,
+            city TEXT,
+            venue TEXT,
+            date TEXT,
+            setlist TEXT,
+            crowd_size INTEGER,
+            fame_earned INTEGER,
+            revenue_earned INTEGER,
+            skill_gain REAL,
+            merch_sold INTEGER
+        )
+        """,
+    )
+    cur.execute(
+        """
+        CREATE TABLE recorded_tracks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            performance_id INTEGER,
+            song_id INTEGER,
+            performance_score REAL,
+            created_at TEXT
+        )
+        """,
+    )
+    setlist = {
+        "setlist": [
+            {"type": "song", "reference": "1"},
+            {"type": "song", "reference": "2"},
+        ],
+        "encore": [],
+    }
+    for idx in range(1, 6):
+        _insert_performance(cur, 1, setlist, 0.0)
+        cur.execute(
+            "INSERT INTO recorded_tracks (performance_id, song_id, performance_score, created_at) VALUES (?, 1, ?, '')",
+            (idx, 10),
+        )
+        if idx != 4:
+            cur.execute(
+                "INSERT INTO recorded_tracks (performance_id, song_id, performance_score, created_at) VALUES (?, 2, ?, '')",
+                (idx, 10),
+            )
+    conn.commit()
+    conn.close()
+
+    service = LiveAlbumService(str(db_file))
+    with pytest.raises(ValueError) as exc:
+        service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
+    assert "4" in str(exc.value)
+    assert "2" in str(exc.value)
+


### PR DESCRIPTION
## Summary
- validate that each performance in a live album has recorded tracks for every common song
- raise clear error when a recording is missing to avoid mixing nonexistent audio
- test coverage for missing recordings

## Testing
- `pytest` *(fails: unable to open database file, missing AWS credentials, etc.)*
- `pytest tests/live_album/test_audio_mixing.py backend/tests/live_album/test_live_album_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68bada2959e0832587db7f7e5f7a6eed