### PR TITLE
Expose recording slot quota and integrate with tour planner

### DIFF
--- a/backend/routes/band.py
+++ b/backend/routes/band.py
@@ -9,9 +9,12 @@ from schemas.band import (
     BandCollaborationResponse,
 )
 from services import band_service
+from services.tour_service import TourService, MAX_RECORDINGS_PER_YEAR
 from utils.i18n import _
 
 router = APIRouter(prefix="/bands", tags=["Bands"])
+
+tour_service = TourService()
 
 @router.post(
     "/",
@@ -57,6 +60,14 @@ def create_collaboration(collab: BandCollaborationCreate):
 @router.get("/{band_id}/collaborations", response_model=list[BandCollaborationResponse])
 def list_collaborations(band_id: int):
     return band_service.list_collaborations(band_id)
+
+
+@router.get("/{band_id}/recording-slots")
+def get_recording_slots(band_id: int):
+    """Return remaining yearly recording slots for the band."""
+    used = tour_service.get_band_recorded_count(band_id)
+    remaining = max(0, MAX_RECORDINGS_PER_YEAR - used)
+    return {"remaining_slots": remaining}
 
 
 @router.get("/", response_model=list[BandResponse])

--- a/frontend/pages/tour_planner.html
+++ b/frontend/pages/tour_planner.html
@@ -80,8 +80,10 @@ document.getElementById('tourForm').addEventListener('submit', async (e) => {
   });
 
   const result = await res.json();
+  const quotaRes = await fetch(`/api/bands/${payload.band_id}/recording-slots`);
+  const { remaining_slots } = await quotaRes.json();
   const itineraryDiv = document.getElementById('itinerary');
-  let remainingSlots = 5;
+  let remainingSlots = remaining_slots;
   itineraryDiv.innerHTML = `
     <h3>Optimized Itinerary</h3>
     <p id="recordSlots">Recording slots remaining: ${remainingSlots}</p>
@@ -118,6 +120,7 @@ document.getElementById('tourForm').addEventListener('submit', async (e) => {
         updateSlots();
       });
     });
+  updateSlots();
 
   document.getElementById('saveRecordings').addEventListener('click', async () => {
     const recordStops = Array.from(

--- a/tests/test_band_recording_slots.py
+++ b/tests/test_band_recording_slots.py
@@ -1,0 +1,60 @@
+import pathlib
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ensure backend package importable
+root_path = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(root_path))
+sys.path.append(str(root_path / "backend"))
+
+# Stub auth dependency modules expected by band routes
+import types
+
+auth_mod = types.ModuleType("auth")
+deps_mod = types.ModuleType("auth.dependencies")
+deps_mod.get_current_user_id = lambda: 1
+deps_mod.require_role = lambda roles: (lambda: None)
+auth_mod.dependencies = deps_mod
+sys.modules["auth"] = auth_mod
+sys.modules["auth.dependencies"] = deps_mod
+
+# Stub services package to avoid database initialisation
+services_pkg = types.ModuleType("services")
+band_service_stub = types.ModuleType("band_service")
+services_pkg.band_service = band_service_stub
+tour_service_stub = types.ModuleType("tour_service")
+
+class _TourService:
+    def get_band_recorded_count(self, band_id: int) -> int:  # pragma: no cover - stub
+        return 0
+
+tour_service_stub.TourService = _TourService
+tour_service_stub.MAX_RECORDINGS_PER_YEAR = 5
+services_pkg.tour_service = tour_service_stub
+
+sys.modules["services"] = services_pkg
+sys.modules["services.band_service"] = band_service_stub
+sys.modules["services.tour_service"] = tour_service_stub
+
+from backend.routes import band  # type: ignore
+MAX_RECORDINGS_PER_YEAR = band.MAX_RECORDINGS_PER_YEAR
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(band.router)
+    return app
+
+
+def test_recording_slots(monkeypatch):
+    app = create_app()
+    client = TestClient(app)
+
+    # simulate that the band has already recorded two shows this year
+    monkeypatch.setattr(band.tour_service, "get_band_recorded_count", lambda band_id: 2)
+
+    res = client.get("/bands/1/recording-slots")
+    assert res.status_code == 200
+    assert res.json() == {"remaining_slots": MAX_RECORDINGS_PER_YEAR - 2}


### PR DESCRIPTION
## Summary
- add `/bands/{band_id}/recording-slots` endpoint in tour service to report remaining recording quota
- fetch recording slot quota in tour planner frontend for accurate remaining count
- test recording slots endpoint

## Testing
- `pytest tests/test_band_recording_slots.py -q`
- `pytest tests/realtime/test_polling_ws.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68badb1805d883259985be7bf6dc04d1