### PR TITLE
Add permission-based RBAC and update route dependencies

### DIFF
--- a/backend/auth/routes.py
+++ b/backend/auth/routes.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Optional
 
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from auth.service import AuthService
 from fastapi import APIRouter, Depends, HTTPException, Request
 from models.admin import AdminSession, admin_sessions
@@ -96,7 +96,7 @@ async def logout(payload: LogoutIn):
     return await svc.logout(refresh_token=payload.refresh_token)
 
 
-@router.post("/tokens/revoke", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/tokens/revoke", dependencies=[Depends(require_permission(["admin"]))])
 async def revoke_token(payload: RevokeTokenIn):
     if not await svc.revoke_access_token(payload.jti):
         raise HTTPException(
@@ -130,7 +130,7 @@ class RoleAssignIn(BaseModel):
     user_id: int
     role: str
 
-@router.post("/roles/assign", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/roles/assign", dependencies=[Depends(require_permission(["admin"]))])
 async def assign_role(payload: RoleAssignIn):
     async with aget_conn() as conn:
         cur = await conn.execute("SELECT id FROM roles WHERE name=?", (payload.role,))
@@ -146,7 +146,7 @@ async def assign_role(payload: RoleAssignIn):
         )
         return {"ok": True}
 
-@router.post("/roles/revoke", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/roles/revoke", dependencies=[Depends(require_permission(["admin"]))])
 async def revoke_role(payload: RoleAssignIn):
     async with aget_conn() as conn:
         cur = await conn.execute("SELECT id FROM roles WHERE name=?", (payload.role,))

--- a/backend/migrations/sql/150_permissions.sql
+++ b/backend/migrations/sql/150_permissions.sql
@@ -1,0 +1,31 @@
+-- File: backend/migrations/sql/150_permissions.sql
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS permissions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+  role_id INTEGER NOT NULL,
+  permission_id INTEGER NOT NULL,
+  PRIMARY KEY (role_id, permission_id),
+  FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
+  FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE
+);
+
+-- Seed default permissions mirroring roles
+INSERT OR IGNORE INTO permissions (id, name, description) VALUES
+  (1, 'admin', 'Administrator'),
+  (2, 'moderator', 'Moderator'),
+  (3, 'band_member', 'Band member'),
+  (4, 'user', 'Regular user');
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES
+  (1, 1),
+  (2, 2),
+  (3, 3),
+  (4, 4);
+
+COMMIT;

--- a/backend/migrations/versions/0024_150_permissions.py
+++ b/backend/migrations/versions/0024_150_permissions.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '0024'
+down_revision = '0023'
+branch_labels = None
+depends_on = None
+
+SQL_FILE = Path(__file__).resolve().parent.parent / 'sql' / '150_permissions.sql'
+
+def upgrade() -> None:
+    op.execute(SQL_FILE.read_text())
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS role_permissions;")
+    op.execute("DROP TABLE IF EXISTS permissions;")

--- a/backend/realtime/admin_gateway.py
+++ b/backend/realtime/admin_gateway.py
@@ -10,9 +10,9 @@ from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from .gateway import hub, get_current_user_id_dep
 
 try:  # pragma: no cover - fallback during tests
-    from auth.dependencies import require_role
+    from auth.dependencies import require_permission
 except Exception:  # pragma: no cover
-    async def require_role(roles, user_id):  # type: ignore
+    async def require_permission(roles, user_id):  # type: ignore
         return True
 
 router = APIRouter(prefix="/admin/realtime", tags=["AdminRealtime"])
@@ -40,7 +40,7 @@ async def admin_ws(
     user_id: int = Depends(get_current_user_id_dep),
 ) -> None:
     await ws.accept()
-    await require_role(["admin", "moderator"], user_id)
+    await require_permission(["admin", "moderator"], user_id)
 
     topic_map = {"economy": ECONOMY_TOPIC, "moderation": MODERATION_TOPIC}
     topic = topic_map.get(channel)

--- a/backend/routes/admin_analytics_routes.py
+++ b/backend/routes/admin_analytics_routes.py
@@ -2,15 +2,15 @@
 from services.admin_audit_service import audit_dependency
 from services.admin_service import AdminService, AdminActionRepository
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.analytics_service import AnalyticsService
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 # Auth middleware / role dependency hook
 try:
-    from backend.auth.dependencies import require_role
+    from backend.auth.dependencies import require_permission
 except Exception:
-    def require_role(roles):
+    def require_permission(roles):
         async def _noop():
             return True
         return _noop
@@ -29,7 +29,7 @@ async def kpis(req: Request, period_start: str, period_end: str):
     """KPIs for streams, digital, vinyl, and tickets between [period_start, period_end]."""
     try:
         admin_id = await get_current_user_id(req)
-        await require_role(["admin", "moderator"], admin_id)
+        await require_permission(["admin", "moderator"], admin_id)
         result = svc.kpis(period_start, period_end)
         admin_logger.log_action(
             admin_id,
@@ -50,7 +50,7 @@ async def top_songs(
     """Top songs by streams and by digital revenue."""
     try:
         admin_id = await get_current_user_id(req)
-        await require_role(["admin", "moderator"], admin_id)
+        await require_permission(["admin", "moderator"], admin_id)
         result = svc.top_songs(period_start, period_end, limit)
         admin_logger.log_action(
             admin_id,
@@ -75,7 +75,7 @@ async def top_albums(
     """Top albums by digital revenue and by vinyl revenue."""
     try:
         admin_id = await get_current_user_id(req)
-        await require_role(["admin", "moderator"], admin_id)
+        await require_permission(["admin", "moderator"], admin_id)
         result = svc.top_albums(period_start, period_end, limit)
         admin_logger.log_action(
             admin_id,
@@ -95,7 +95,7 @@ async def recent_royalty_runs(req: Request, limit: int = 20):
     """Recent royalty runs."""
     try:
         admin_id = await get_current_user_id(req)
-        await require_role(["admin", "moderator"], admin_id)
+        await require_permission(["admin", "moderator"], admin_id)
         result = svc.recent_royalty_runs(limit)
         admin_logger.log_action(
             admin_id,
@@ -111,7 +111,7 @@ async def royalties_by_band(req: Request, run_id: int):
     """Sum of royalty amounts by band for a specific run."""
     try:
         admin_id = await get_current_user_id(req)
-        await require_role(["admin", "moderator"], admin_id)
+        await require_permission(["admin", "moderator"], admin_id)
         result = svc.royalties_summary_by_band(run_id)
         admin_logger.log_action(
             admin_id,

--- a/backend/routes/admin_apprenticeship_routes.py
+++ b/backend/routes/admin_apprenticeship_routes.py
@@ -2,7 +2,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.models.apprenticeship import Apprenticeship
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.apprenticeship_admin_service import (
@@ -29,7 +29,7 @@ class ApprenticeshipIn(BaseModel):
 
 async def _ensure_admin(req: Request) -> None:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
 
 
 @router.get("/")

--- a/backend/routes/admin_audit_routes.py
+++ b/backend/routes/admin_audit_routes.py
@@ -1,7 +1,7 @@
 """Routes for querying admin audit logs."""
 from fastapi import APIRouter, Depends
 
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from services.admin_audit_service import (
     AdminAuditService,
     audit_dependency,
@@ -20,5 +20,5 @@ async def list_audit_logs(
     admin_id: int = Depends(get_current_user_id),
     svc: AdminAuditService = Depends(get_admin_audit_service),
 ):
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.query(skip, limit)

--- a/backend/routes/admin_book_routes.py
+++ b/backend/routes/admin_book_routes.py
@@ -2,7 +2,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.models.book import Book
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.book_admin_service import BookAdminService, get_book_admin_service
@@ -22,7 +22,7 @@ class BookIn(BaseModel):
 
 async def _ensure_admin(req: Request) -> None:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
 
 
 @router.get("/")

--- a/backend/routes/admin_business_routes.py
+++ b/backend/routes/admin_business_routes.py
@@ -1,7 +1,7 @@
 """Administrative CRUD routes for businesses."""
 from fastapi import APIRouter, HTTPException, Request, Depends
 
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from services.business_service import BusinessService
 from services.admin_audit_service import audit_dependency
 
@@ -14,7 +14,7 @@ svc = BusinessService()
 @router.post("/")
 async def create_business(payload: dict, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.create_business(
         owner_id=payload.get("owner_id"),
         name=payload.get("name", ""),
@@ -28,14 +28,14 @@ async def create_business(payload: dict, req: Request):
 @router.get("/")
 async def list_businesses(req: Request, owner_id: int | None = None):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.list_businesses(owner_id)
 
 
 @router.put("/{business_id}")
 async def edit_business(business_id: int, payload: dict, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     biz = svc.update_business(business_id, payload)
     if not biz:
         raise HTTPException(status_code=404, detail="Business not found")
@@ -45,7 +45,7 @@ async def edit_business(business_id: int, payload: dict, req: Request):
 @router.delete("/{business_id}")
 async def delete_business(business_id: int, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     if not svc.delete_business(business_id):
         raise HTTPException(status_code=404, detail="Business not found")
     return {"status": "deleted"}

--- a/backend/routes/admin_city_shop_routes.py
+++ b/backend/routes/admin_city_shop_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.city_shop_service import CityShopService
 from backend.services.shop_restock_service import schedule_restock
@@ -13,7 +13,7 @@ svc = CityShopService()
 
 async def _ensure_admin(req: Request) -> None:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
 
 
 @router.post("/")

--- a/backend/routes/admin_course_routes.py
+++ b/backend/routes/admin_course_routes.py
@@ -1,7 +1,7 @@
 """Admin routes for managing courses."""
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.models.course import Course
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.course_admin_service import course_admin_service, CourseAdminService
@@ -23,14 +23,14 @@ class CourseIn(BaseModel):
 @router.get("/")
 async def list_courses(req: Request) -> list[Course]:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.list_courses()
 
 
 @router.post("/")
 async def create_course(payload: CourseIn, req: Request) -> Course:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     course = Course(id=0, **payload.dict())
     return svc.create_course(course)
 
@@ -38,7 +38,7 @@ async def create_course(payload: CourseIn, req: Request) -> Course:
 @router.put("/{course_id}")
 async def update_course(course_id: int, payload: CourseIn, req: Request) -> Course:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     try:
         return svc.update_course(course_id, **payload.dict())
     except ValueError as exc:
@@ -48,6 +48,6 @@ async def update_course(course_id: int, payload: CourseIn, req: Request) -> Cour
 @router.delete("/{course_id}")
 async def delete_course(course_id: int, req: Request) -> dict[str, str]:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     svc.delete_course(course_id)
     return {"status": "deleted"}

--- a/backend/routes/admin_economy_routes.py
+++ b/backend/routes/admin_economy_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.economy_admin_service import EconomyAdminService
 from backend.models.economy_config import EconomyConfig
 from backend.services.admin_audit_service import audit_dependency
@@ -23,14 +23,14 @@ class ConfigUpdateIn(BaseModel):
 @router.get("/config")
 async def get_config(req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.get_config()
 
 
 @router.put("/config")
 async def update_config(payload: ConfigUpdateIn, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     data = {k: v for k, v in payload.dict().items() if v is not None}
     try:
         return svc.update_config(**data)
@@ -41,7 +41,7 @@ async def update_config(payload: ConfigUpdateIn, req: Request):
 @router.put("/config/preview")
 async def preview_config(payload: ConfigUpdateIn, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     current = svc.get_config()
     preview = current.__dict__.copy()
     for k, v in payload.dict().items():
@@ -53,5 +53,5 @@ async def preview_config(payload: ConfigUpdateIn, req: Request):
 @router.get("/transactions")
 async def recent_transactions(req: Request, limit: int = 50):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.recent_transactions(limit=limit)

--- a/backend/routes/admin_job_routes.py
+++ b/backend/routes/admin_job_routes.py
@@ -1,6 +1,6 @@
 # File: backend/routes/admin_job_routes.py
 from fastapi import APIRouter, HTTPException, Request, Depends
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from utils.i18n import _
 from services.admin_audit_service import audit_dependency
 
@@ -11,9 +11,9 @@ except Exception:
     run_weekly_rollup = None
 
 try:
-    from auth.dependencies import require_role
+    from auth.dependencies import require_permission
 except Exception:
-    def require_role(_roles):
+    def require_permission(_roles):
         async def _ok():
             return True
         return _ok
@@ -27,7 +27,7 @@ async def trigger_world_pulse_daily(req: Request):
     if run_daily_world_pulse is None:
         raise HTTPException(status_code=501, detail=_("Daily job not available"))
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     await run_daily_world_pulse()
     return {"status": "ok", "job": "world_pulse_daily"}
 
@@ -36,6 +36,6 @@ async def trigger_world_pulse_weekly(req: Request):
     if run_weekly_rollup is None:
         raise HTTPException(status_code=501, detail=_("Weekly job not available"))
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     await run_weekly_rollup()
     return {"status": "ok", "job": "world_pulse_weekly"}

--- a/backend/routes/admin_loyalty_routes.py
+++ b/backend/routes/admin_loyalty_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.loyalty_service import loyalty_service
 from backend.services.admin_audit_service import audit_dependency
 
@@ -23,14 +23,14 @@ class TierIn(BaseModel):
 @router.get("/tiers")
 async def list_tiers(req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return loyalty_service.list_tiers()
 
 
 @router.post("/tiers")
 async def set_tier(payload: TierIn, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     loyalty_service.set_tier(payload.name, payload.threshold, payload.discount)
     return {"status": "ok"}
 
@@ -38,7 +38,7 @@ async def set_tier(payload: TierIn, req: Request):
 @router.delete("/tiers/{name}")
 async def delete_tier(name: str, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     if not loyalty_service.delete_tier(name):
         raise HTTPException(status_code=404, detail="tier not found")
     return {"status": "ok"}

--- a/backend/routes/admin_media_moderation_routes.py
+++ b/backend/routes/admin_media_moderation_routes.py
@@ -5,7 +5,7 @@ import json
 
 from fastapi import APIRouter, Depends, Request
 
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from services.admin_audit_service import audit_dependency
 from services.admin_service import AdminActionRepository, AdminService
 from services.storage_service import get_storage_backend
@@ -43,7 +43,7 @@ admin_logger = AdminService(AdminActionRepository())
 async def flag_media(media_id: int, req: Request):
     """Flag a piece of media for review."""
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     action = await asyncio.to_thread(
         admin_logger.log_action, admin_id, "media_flag", {"media_id": media_id}
     )
@@ -60,7 +60,7 @@ async def flag_media(media_id: int, req: Request):
 async def approve_media(media_id: int, req: Request):
     """Approve a media item."""
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     action = await asyncio.to_thread(
         admin_logger.log_action, admin_id, "media_approve", {"media_id": media_id}
     )

--- a/backend/routes/admin_monitoring_routes.py
+++ b/backend/routes/admin_monitoring_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Request
 
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from models.admin import admin_sessions
 
 try:  # optional psutil, fall back to zeros if unavailable
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/monitoring", tags=["AdminMonitoring"])
 async def metrics(req: Request) -> dict[str, float | int]:
     """Return basic CPU, memory, and active admin session counts."""
     admin_id = await get_current_user_id(req)
-    await require_role(["admin", "moderator"], admin_id)
+    await require_permission(["admin", "moderator"], admin_id)
 
     cpu = psutil.cpu_percent(interval=0.1) if psutil else 0.0
     mem = psutil.virtual_memory().percent if psutil else 0.0

--- a/backend/routes/admin_music_routes.py
+++ b/backend/routes/admin_music_routes.py
@@ -4,13 +4,13 @@ import backend.seeds.genre_seed as genre_seed
 import backend.seeds.skill_seed as skill_seed
 
 import backend.seeds.stage_equipment_seed as equipment_seed
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.models.genre import Genre
 from backend.models.skill import Skill
 from backend.models.stage_equipment import StageEquipment
 from backend.schemas.admin_music_schema import GenreSchema, SkillSchema, StageEquipmentSchema
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.models.genre import Genre
 from backend.models.skill import Skill
 from backend.schemas.admin_music_schema import GenreSchema, SkillSchema
@@ -25,7 +25,7 @@ router = APIRouter(
 
 async def _ensure_admin(req: Request) -> None:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
 
 
 @router.get("/skills")

--- a/backend/routes/admin_name_routes.py
+++ b/backend/routes/admin_name_routes.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services import name_dataset_service as dataset_service
 from backend.services.admin_audit_service import audit_dependency
 from pydantic import BaseModel
@@ -26,7 +26,7 @@ class SurnameIn(BaseModel):
 @router.post("/first")
 async def add_first_name(payload: FirstNameIn, req: Request) -> dict[str, str]:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     if not dataset_service.add_first_name(payload.name, payload.gender):
         raise HTTPException(status_code=409, detail="Name already exists")
     return {"status": "ok"}
@@ -35,7 +35,7 @@ async def add_first_name(payload: FirstNameIn, req: Request) -> dict[str, str]:
 @router.post("/surname")
 async def add_surname(payload: SurnameIn, req: Request) -> dict[str, str]:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     if not dataset_service.add_surname(payload.name):
         raise HTTPException(status_code=409, detail="Name already exists")
     return {"status": "ok"}

--- a/backend/routes/admin_npc_dialogue_routes.py
+++ b/backend/routes/admin_npc_dialogue_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.routes.admin_npc_routes import svc
 from backend.services.admin_audit_service import audit_dependency
 
@@ -12,7 +12,7 @@ router = APIRouter(
 @router.put("/{npc_id}")
 async def edit_dialogue(npc_id: int, tree: dict, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     result = svc.edit_dialogue(npc_id, tree)
     if not result:
         raise HTTPException(status_code=404, detail="NPC not found")
@@ -22,7 +22,7 @@ async def edit_dialogue(npc_id: int, tree: dict, req: Request):
 @router.post("/{npc_id}/preview")
 async def preview_dialogue(npc_id: int, data: dict, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     choices = data.get("choices", [])
     result = svc.preview_dialogue(npc_id, choices)
     if result is None:

--- a/backend/routes/admin_npc_routes.py
+++ b/backend/routes/admin_npc_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.npc_service import NPCService
 from backend.services.admin_audit_service import audit_dependency
 
@@ -13,7 +13,7 @@ svc = NPCService()
 @router.post("/")
 async def create_npc(data: dict, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.create_npc(
         identity=data.get("identity", "unknown"),
         npc_type=data.get("npc_type", "generic"),
@@ -25,7 +25,7 @@ async def create_npc(data: dict, req: Request):
 @router.put("/{npc_id}")
 async def edit_npc(npc_id: int, data: dict, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     npc = svc.update_npc(npc_id, **data)
     if not npc:
         raise HTTPException(status_code=404, detail="NPC not found")
@@ -35,7 +35,7 @@ async def edit_npc(npc_id: int, data: dict, req: Request):
 @router.delete("/{npc_id}")
 async def delete_npc(npc_id: int, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     if not svc.delete_npc(npc_id):
         raise HTTPException(status_code=404, detail="NPC not found")
     return {"status": "deleted"}
@@ -44,7 +44,7 @@ async def delete_npc(npc_id: int, req: Request):
 @router.post("/preview")
 async def preview_npc(data: dict, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.preview_npc(
         identity=data.get("identity", "unknown"),
         npc_type=data.get("npc_type", "generic"),
@@ -56,7 +56,7 @@ async def preview_npc(data: dict, req: Request):
 @router.post("/{npc_id}/simulate")
 async def simulate_npc(npc_id: int, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     result = svc.simulate_npc(npc_id)
     if not result:
         raise HTTPException(status_code=404, detail="NPC not found")

--- a/backend/routes/admin_online_tutorial_routes.py
+++ b/backend/routes/admin_online_tutorial_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.models.online_tutorial import OnlineTutorial
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.online_tutorial_admin_service import (
@@ -29,7 +29,7 @@ class OnlineTutorialIn(BaseModel):
 
 async def _ensure_admin(req: Request) -> None:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
 
 
 @router.get("/")

--- a/backend/routes/admin_player_shop_routes.py
+++ b/backend/routes/admin_player_shop_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.city_shop_service import CityShopService
 
@@ -14,7 +14,7 @@ svc = CityShopService()
 
 async def _current_user(req: Request) -> int:
     uid = await get_current_user_id(req)
-    await require_role(["user", "band_member", "moderator", "admin"], uid)
+    await require_permission(["user", "band_member", "moderator", "admin"], uid)
     return uid
 
 
@@ -28,7 +28,7 @@ async def _ensure_owner(shop_id: int, req: Request) -> int:
 
 async def _ensure_admin(req: Request) -> None:
     uid = await get_current_user_id(req)
-    await require_role(["admin"], uid)
+    await require_permission(["admin"], uid)
 
 
 @router.get("/")

--- a/backend/routes/admin_quest_routes.py
+++ b/backend/routes/admin_quest_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.quest_admin_service import QuestAdminService
 from backend.services.admin_audit_service import audit_dependency
 
@@ -12,7 +12,7 @@ svc = QuestAdminService()
 
 async def _require_admin(req: Request) -> int:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return admin_id
 
 

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends, Request
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.admin_analytics_service import fetch_shop_metrics
 from backend.services.admin_audit_service import audit_dependency
 
@@ -49,7 +49,7 @@ async def economy_analytics(
     """Summary of shop sales and top items."""
 
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return fetch_shop_metrics(period_start, period_end, limit)
 
 

--- a/backend/routes/admin_schema_routes.py
+++ b/backend/routes/admin_schema_routes.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Literal
 
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field, field_validator
 
@@ -116,7 +116,7 @@ router = APIRouter(prefix="/schema", tags=["AdminSchema"])
 
 async def _ensure_admin(req: Request) -> None:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
 
 
 @router.get("/npc")

--- a/backend/routes/admin_shop_event_routes.py
+++ b/backend/routes/admin_shop_event_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.event_service import list_shop_events, schedule_shop_event
 
@@ -24,7 +24,7 @@ class ShopEventIn(BaseModel):
 
 async def _ensure_admin(req: Request) -> None:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
 
 
 @router.get("/")

--- a/backend/routes/admin_song_popularity_routes.py
+++ b/backend/routes/admin_song_popularity_routes.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from auth.dependencies import require_role
+from auth.dependencies import require_permission
 from fastapi import APIRouter, Depends
 from services.media_event_service import media_event_service
 from services.media_monitor_service import media_monitor_service
@@ -18,28 +18,28 @@ class MediaEvent(BaseModel):
     platform: str = "any"
 
 
-@router.post("/film", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/film", dependencies=[Depends(require_permission(["admin"]))])
 async def film(evt: MediaEvent):
     return media_event_service.film_placement(
         evt.song_id, evt.boost, evt.region_code, evt.platform
     )
 
 
-@router.post("/tv", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/tv", dependencies=[Depends(require_permission(["admin"]))])
 async def tv(evt: MediaEvent):
     return media_event_service.tv_placement(
         evt.song_id, evt.boost, evt.region_code, evt.platform
     )
 
 
-@router.post("/tiktok", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/tiktok", dependencies=[Depends(require_permission(["admin"]))])
 async def tiktok(evt: MediaEvent):
     return media_event_service.tiktok_trend(
         evt.song_id, evt.boost, evt.region_code, evt.platform
     )
 
 
-@router.get("/events", dependencies=[Depends(require_role(["admin"]))])
+@router.get("/events", dependencies=[Depends(require_permission(["admin"]))])
 async def list_events(song_id: Optional[int] = None, source: Optional[str] = None):
     return {"events": song_popularity_service.list_events(song_id, source=source)}
 
@@ -50,11 +50,11 @@ class MediaAdjust(BaseModel):
     details: str = ""
 
 
-@router.post("/media/poll", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/media/poll", dependencies=[Depends(require_permission(["admin"]))])
 async def poll_media():
     return {"mentions": media_monitor_service.poll_feed()}
 
 
-@router.post("/media/adjust", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/media/adjust", dependencies=[Depends(require_permission(["admin"]))])
 async def media_adjust(evt: MediaAdjust):
     return media_monitor_service.manual_adjust(evt.song_id, evt.amount, evt.details)

--- a/backend/routes/admin_tutor_routes.py
+++ b/backend/routes/admin_tutor_routes.py
@@ -2,7 +2,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.models.tutor import Tutor
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.tutor_admin_service import (
@@ -25,7 +25,7 @@ class TutorIn(BaseModel):
 
 async def _ensure_admin(req: Request) -> None:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
 
 
 @router.get("/")

--- a/backend/routes/admin_venue_routes.py
+++ b/backend/routes/admin_venue_routes.py
@@ -1,7 +1,7 @@
 """Administrative CRUD routes for venues."""
 from fastapi import APIRouter, HTTPException, Request, Depends
 
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from services.venue_service import VenueService
 from services.admin_audit_service import audit_dependency
 from models.economy_config import set_config, EconomyConfig
@@ -16,7 +16,7 @@ svc = VenueService()
 @router.post("/")
 async def create_venue(payload: dict, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.create_venue(
         owner_id=payload.get("owner_id"),
         name=payload.get("name", ""),
@@ -30,14 +30,14 @@ async def create_venue(payload: dict, req: Request):
 @router.get("/")
 async def list_venues(req: Request, owner_id: int | None = None):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.list_venues(owner_id)
 
 
 @router.put("/{venue_id}")
 async def edit_venue(venue_id: int, payload: dict, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     venue = svc.update_venue(venue_id, payload)
     if not venue:
         raise HTTPException(status_code=404, detail="Venue not found")
@@ -47,7 +47,7 @@ async def edit_venue(venue_id: int, payload: dict, req: Request):
 @router.delete("/{venue_id}")
 async def delete_venue(venue_id: int, req: Request):
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     if not svc.delete_venue(venue_id):
         raise HTTPException(status_code=404, detail="Venue not found")
     return {"status": "deleted"}

--- a/backend/routes/admin_workshop_routes.py
+++ b/backend/routes/admin_workshop_routes.py
@@ -2,7 +2,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.models.workshop import Workshop
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.workshop_admin_service import (
@@ -27,7 +27,7 @@ class WorkshopIn(BaseModel):
 
 async def _ensure_admin(req: Request) -> None:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
 
 
 @router.get("/")

--- a/backend/routes/admin_xp_event_routes.py
+++ b/backend/routes/admin_xp_event_routes.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.models.xp_event import XPEvent
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.xp_event_service import XPEventService
@@ -26,14 +26,14 @@ class XPEventIn(BaseModel):
 @router.get("/")
 async def list_events(req: Request) -> list[XPEvent]:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.list_events()
 
 
 @router.post("/")
 async def create_event(payload: XPEventIn, req: Request) -> XPEvent:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     ev = XPEvent(id=None, **payload.dict())
     return svc.create_event(ev)
 
@@ -41,7 +41,7 @@ async def create_event(payload: XPEventIn, req: Request) -> XPEvent:
 @router.put("/{event_id}")
 async def update_event(event_id: int, payload: XPEventIn, req: Request) -> XPEvent:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     try:
         return svc.update_event(event_id, **payload.dict())
     except ValueError as exc:
@@ -51,6 +51,6 @@ async def update_event(event_id: int, payload: XPEventIn, req: Request) -> XPEve
 @router.delete("/{event_id}")
 async def delete_event(event_id: int, req: Request) -> dict[str, str]:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     svc.delete_event(event_id)
     return {"status": "deleted"}

--- a/backend/routes/admin_xp_item_routes.py
+++ b/backend/routes/admin_xp_item_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.models.xp_item import XPItem
 from backend.services.admin_audit_service import audit_dependency
 from backend.services.xp_item_service import XPItemService
@@ -24,14 +24,14 @@ class XPItemIn(BaseModel):
 @router.get("/")
 async def list_items(req: Request) -> list[XPItem]:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.list_items()
 
 
 @router.post("/")
 async def create_item(payload: XPItemIn, req: Request) -> XPItem:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     item = XPItem(id=None, **payload.dict())
     return svc.create_item(item)
 
@@ -39,7 +39,7 @@ async def create_item(payload: XPItemIn, req: Request) -> XPItem:
 @router.put("/{item_id}")
 async def update_item(item_id: int, payload: XPItemIn, req: Request) -> XPItem:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     try:
         return svc.update_item(item_id, **payload.dict())
     except ValueError as exc:
@@ -49,6 +49,6 @@ async def update_item(item_id: int, payload: XPItemIn, req: Request) -> XPItem:
 @router.delete("/{item_id}")
 async def delete_item(item_id: int, req: Request) -> dict[str, str]:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     svc.delete_item(item_id)
     return {"status": "deleted"}

--- a/backend/routes/admin_xp_routes.py
+++ b/backend/routes/admin_xp_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.xp_admin_service import XPAdminService
 from backend.models.xp_config import XPConfig
 from backend.services.admin_audit_service import audit_dependency
@@ -23,14 +23,14 @@ class ConfigUpdateIn(BaseModel):
 @router.get("/config")
 async def get_config(req: Request) -> XPConfig:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     return svc.get_config()
 
 
 @router.put("/config")
 async def update_config(payload: ConfigUpdateIn, req: Request) -> XPConfig:
     admin_id = await get_current_user_id(req)
-    await require_role(["admin"], admin_id)
+    await require_permission(["admin"], admin_id)
     data = {k: v for k, v in payload.dict().items() if v is not None}
     try:
         return svc.update_config(**data)

--- a/backend/routes/ai_manager_routes.py
+++ b/backend/routes/ai_manager_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from services.ai_manager_service import *
 

--- a/backend/routes/ai_tour_manager_routes.py
+++ b/backend/routes/ai_tour_manager_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.ai_tour_manager_service import AITourManagerService

--- a/backend/routes/ai_tour_scheduler_routes.py
+++ b/backend/routes/ai_tour_scheduler_routes.py
@@ -1,10 +1,10 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from core.ai_tour_scheduler import run_ai_scheduler, scheduled_tours
 
 router = APIRouter()
 
-@router.post("/ai_tour_scheduler/run", dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
+@router.post("/ai_tour_scheduler/run", dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))])
 def run_scheduler():
     results = run_ai_scheduler()
     return {"scheduled": results}

--- a/backend/routes/ai_transport_routes.py
+++ b/backend/routes/ai_transport_routes.py
@@ -1,10 +1,10 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from core.ai_transport_optimizer import optimize_transport_for_tour, get_transport_bookings
 
 router = APIRouter()
 
-@router.post("/ai_transport/optimize", dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
+@router.post("/ai_transport/optimize", dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))])
 def optimize_transport(band_id: int, gear_weight: float, crew_size: int, budget: float):
     result = optimize_transport_for_tour(band_id, gear_weight, crew_size, budget)
     if result:

--- a/backend/routes/analytics_routes.py
+++ b/backend/routes/analytics_routes.py
@@ -6,7 +6,7 @@ except Exception:  # pragma: no cover - fallback for stubs
     def Depends(dependency):  # type: ignore
         return dependency
 
-from backend.auth.dependencies import require_role
+from backend.auth.dependencies import require_permission
 from backend.models.analytics import (
     AggregatedMetrics,
     FanSegmentSummary,
@@ -24,7 +24,7 @@ fan_svc = FanInsightService()
 async def get_time_series(
     start_date: str,
     end_date: str,
-    _: bool = Depends(require_role(["admin"])),
+    _: bool = Depends(require_permission(["admin"])),
 ) -> AggregatedMetrics:
     """Return aggregated metrics across domains for the given date range."""
     return svc.time_series(start_date, end_date)
@@ -32,7 +32,7 @@ async def get_time_series(
 
 @router.get("/fans/segments")
 async def get_fan_segments(
-    _: bool = Depends(require_role(["admin"])),
+    _: bool = Depends(require_permission(["admin"])),
 ) -> FanSegmentSummary:
     """Return fan demographic and engagement segment counts."""
     return fan_svc.segment_summary()
@@ -42,7 +42,7 @@ async def get_fan_segments(
 async def get_fan_trends(
     start_date: str,
     end_date: str,
-    _: bool = Depends(require_role(["admin"])),
+    _: bool = Depends(require_permission(["admin"])),
 ) -> FanTrends:
     """Return fan engagement trends over time."""
     return fan_svc.trends(start_date, end_date)

--- a/backend/routes/avatar.py
+++ b/backend/routes/avatar.py
@@ -5,9 +5,9 @@ from services.avatar_service import AvatarService
 from services.lifestyle_service import calculate_lifestyle_score, evaluate_lifestyle_risks
 
 try:  # pragma: no cover - fallback for environments without auth module
-    from auth.dependencies import require_role
+    from auth.dependencies import require_permission
 except Exception:  # pragma: no cover
-    def require_role(roles):
+    def require_permission(roles):
         async def _noop():
             return True
 
@@ -28,29 +28,29 @@ class LifestylePayload(BaseModel):
     nutrition: int = 70
     fitness: int = 70
 
-@router.post("/", response_model=AvatarResponse, dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.post("/", response_model=AvatarResponse, dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def create_avatar(payload: AvatarCreate):
     return svc.create_avatar(payload)
 
-@router.get("/{avatar_id}", response_model=AvatarResponse, dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.get("/{avatar_id}", response_model=AvatarResponse, dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def get_avatar(avatar_id: int):
     avatar = svc.get_avatar(avatar_id)
     if not avatar:
         raise HTTPException(status_code=404, detail="Avatar not found")
     return avatar
 
-@router.get("/", response_model=list[AvatarResponse], dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.get("/", response_model=list[AvatarResponse], dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def list_avatars():
     return svc.list_avatars()
 
-@router.put("/{avatar_id}", response_model=AvatarResponse, dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.put("/{avatar_id}", response_model=AvatarResponse, dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def update_avatar(avatar_id: int, payload: AvatarUpdate):
     avatar = svc.update_avatar(avatar_id, payload)
     if not avatar:
         raise HTTPException(status_code=404, detail="Avatar not found")
     return avatar
 
-@router.delete("/{avatar_id}", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.delete("/{avatar_id}", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 def delete_avatar(avatar_id: int):
     if not svc.delete_avatar(avatar_id):
         raise HTTPException(status_code=404, detail="Avatar not found")
@@ -59,7 +59,7 @@ def delete_avatar(avatar_id: int):
 
 @router.get(
     "/{avatar_id}/mood",
-    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))],
 )
 def get_mood(avatar_id: int):
     mood = svc.get_mood(avatar_id)
@@ -71,7 +71,7 @@ def get_mood(avatar_id: int):
 @router.post(
     "/{avatar_id}/mood",
     response_model=AvatarResponse,
-    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))],
 )
 def influence_mood(avatar_id: int, payload: LifestylePayload):
     data = payload.model_dump()

--- a/backend/routes/awards.py
+++ b/backend/routes/awards.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from models.awards import SongAward

--- a/backend/routes/band.py
+++ b/backend/routes/band.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 
 from schemas.band import (
@@ -19,7 +19,7 @@ tour_service = TourService()
 @router.post(
     "/",
     response_model=BandResponse,
-    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))],
 )
 def create_band(band: BandCreate):
     created = band_service.create_band(band.founder_id, band.name, band.genre)

--- a/backend/routes/band_relationship_routes.py
+++ b/backend/routes/band_relationship_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.band_relationship_service import BandRelationshipService

--- a/backend/routes/band_social_routes.py
+++ b/backend/routes/band_social_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 
 router = APIRouter()

--- a/backend/routes/character.py
+++ b/backend/routes/character.py
@@ -1,6 +1,6 @@
 """Character API routes."""
 
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from schemas.character import CharacterCreate, CharacterResponse
 from services.character_service import character_service
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/characters", tags=["Characters"])
 @router.post(
     "/",
     response_model=CharacterResponse,
-    dependencies=[Depends(require_role(["admin", "player"]))],
+    dependencies=[Depends(require_permission(["admin", "player"]))],
 )
 def create_character(
     character: CharacterCreate, user_id: int = Depends(get_current_user_id)
@@ -24,7 +24,7 @@ def create_character(
 @router.get(
     "/{character_id}",
     response_model=CharacterResponse,
-    dependencies=[Depends(require_role(["admin", "player"]))],
+    dependencies=[Depends(require_permission(["admin", "player"]))],
 )
 def read_character(
     character_id: int, user_id: int = Depends(get_current_user_id)
@@ -39,7 +39,7 @@ def read_character(
 @router.get(
     "/",
     response_model=list[CharacterResponse],
-    dependencies=[Depends(require_role(["admin", "player"]))],
+    dependencies=[Depends(require_permission(["admin", "player"]))],
 )
 def list_characters(user_id: int = Depends(get_current_user_id)):
     """List all characters."""
@@ -49,7 +49,7 @@ def list_characters(user_id: int = Depends(get_current_user_id)):
 @router.put(
     "/{character_id}",
     response_model=CharacterResponse,
-    dependencies=[Depends(require_role(["admin", "player"]))],
+    dependencies=[Depends(require_permission(["admin", "player"]))],
 )
 def update_character(
     character_id: int,
@@ -65,7 +65,7 @@ def update_character(
 
 @router.delete(
     "/{character_id}",
-    dependencies=[Depends(require_role(["admin", "player"]))],
+    dependencies=[Depends(require_permission(["admin", "player"]))],
 )
 def delete_character(
     character_id: int, user_id: int = Depends(get_current_user_id)

--- a/backend/routes/charts.py
+++ b/backend/routes/charts.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from models.charts import ChartEntry
@@ -7,7 +7,7 @@ from database import get_db
 
 router = APIRouter()
 
-@router.post("/charts/add", dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
+@router.post("/charts/add", dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))])
 def add_chart_entry(entry: ChartEntryCreate, db: Session = Depends(get_db)):
     new_entry = ChartEntry(**entry.dict())
     db.add(new_entry)

--- a/backend/routes/chat_routes.py
+++ b/backend/routes/chat_routes.py
@@ -1,6 +1,6 @@
 from schemas.chat_schemas import GroupMessageSchema, MessageSchema
 
-from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from backend.services.chat_service import (
     get_user_chat_history,
     send_group_chat,
@@ -13,7 +13,7 @@ router = APIRouter()
 
 @router.post(
     "/chat/send_direct",
-    dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))],
+    dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))],
 )
 def send_direct_message(payload: MessageSchema):
     return send_message(payload.dict())

--- a/backend/routes/chemistry_routes.py
+++ b/backend/routes/chemistry_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.chemistry_service import ChemistryService
 
 router = APIRouter(prefix="/chemistry", tags=["chemistry"])
@@ -25,7 +25,7 @@ def list_chemistry(player_id: int, _uid: int = Depends(get_current_user_id)):
 
 @router.post(
     "/{player_a_id}/{player_b_id}/adjust",
-    dependencies=[Depends(require_role(["admin"]))],
+    dependencies=[Depends(require_permission(["admin"]))],
 )
 def adjust_pair(
     player_a_id: int,

--- a/backend/routes/construction_routes.py
+++ b/backend/routes/construction_routes.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from models.construction import Blueprint, BuildPhase
 from services.construction_service import ConstructionService
 from services.economy_service import EconomyService
@@ -24,7 +24,7 @@ class LandPurchaseIn(BaseModel):
     price: int
 
 
-@router.post("/land", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.post("/land", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def purchase_land(payload: LandPurchaseIn, owner_id: int = Depends(get_current_user_id)):
     try:
         parcel_id = svc.purchase_land(owner_id, payload.location, payload.size, payload.price)
@@ -48,7 +48,7 @@ class DesignIn(BaseModel):
     upgrade_effect: Dict[str, int]
 
 
-@router.post("/design", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.post("/design", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def submit_design(payload: DesignIn, owner_id: int = Depends(get_current_user_id)):
     blueprint = Blueprint(
         name=payload.name,
@@ -70,7 +70,7 @@ def submit_design(payload: DesignIn, owner_id: int = Depends(get_current_user_id
 
 @router.get(
     "/progress",
-    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))],
 )
 def progress() -> List[Dict[str, int]]:
     return svc.get_queue()

--- a/backend/routes/crafting_routes.py
+++ b/backend/routes/crafting_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from typing import Dict
@@ -14,7 +14,7 @@ class RecipePayload(BaseModel):
     components: Dict[int, int]
 
 
-@router.post("/recipes", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/recipes", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 def add_recipe(payload: RecipePayload):
     recipe = Recipe(**payload.model_dump())
     crafting_service.add_recipe(recipe)

--- a/backend/routes/dashboard_routes.py
+++ b/backend/routes/dashboard_routes.py
@@ -1,7 +1,7 @@
 # File: backend/routes/dashboard_routes.py
 from typing import Optional
 
-from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from backend.services.dashboard_service import DashboardService
 from fastapi import APIRouter, Depends, HTTPException, Query, Request  # noqa: F401
 

--- a/backend/routes/distribution.py
+++ b/backend/routes/distribution.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from database import get_db
@@ -13,7 +13,7 @@ STREAM_RATE = 0.005  # $0.005 per stream
 DIGITAL_PRICE = 1.29  # $1.29 per sale
 VINYL_PRICE = 20.00   # $20 per vinyl
 
-@router.post("/update", response_model=DistributionResponse, dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.post("/update", response_model=DistributionResponse, dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 def update_distribution(data: DistributionUpdate, db: Session = Depends(get_db)):
     dist = db.query(SongDistribution).filter_by(song_id=data.song_id).first()
     if not dist:

--- a/backend/routes/education_routes.py
+++ b/backend/routes/education_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.education_schema import EducationSessionCreate, EducationSessionResponse
 from datetime import date
@@ -8,7 +8,7 @@ router = APIRouter()
 education_sessions = []
 education_id_counter = 1
 
-@router.post("/education/", response_model=EducationSessionResponse, dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
+@router.post("/education/", response_model=EducationSessionResponse, dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))])
 def create_session(session: EducationSessionCreate):
     global education_id_counter
     new_session = session.dict()

--- a/backend/routes/elections_routes.py
+++ b/backend/routes/elections_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from services.election_service import *
 

--- a/backend/routes/emotes_routes.py
+++ b/backend/routes/emotes_routes.py
@@ -1,11 +1,11 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from services.emotes_service import *
 from schemas.emotes_schemas import EmoteTriggerSchema
 
 router = APIRouter()
 
-@router.post("/emotes/trigger", dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
+@router.post("/emotes/trigger", dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))])
 def trigger_emote(payload: EmoteTriggerSchema):
     return trigger_player_emote(payload.dict())
 

--- a/backend/routes/endorsement_routes.py
+++ b/backend/routes/endorsement_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.endorsement_schema import EndorsementCreate, EndorsementResponse
 from datetime import date
@@ -8,7 +8,7 @@ router = APIRouter()
 endorsements = []
 endorsement_id_counter = 1
 
-@router.post("/endorsements/", response_model=EndorsementResponse, dependencies=[Depends(require_role(["admin"]))])
+@router.post("/endorsements/", response_model=EndorsementResponse, dependencies=[Depends(require_permission(["admin"]))])
 def create_endorsement(endorsement: EndorsementCreate):
     global endorsement_id_counter
     new_endorsement = endorsement.dict()

--- a/backend/routes/events_routes.py
+++ b/backend/routes/events_routes.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends
 
-from auth.dependencies import require_role
+from auth.dependencies import require_permission
 from services.events_service import (
     cancel_scheduled_event,
     create_seasonal_event,
@@ -30,7 +30,7 @@ router = APIRouter()
 @router.post(
     "/events/create",
     response_model=EventResponse,
-    dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))],
+    dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))],
 )
 def create_event(payload: CreateEventSchema) -> EventResponse:
     """Create and start a new seasonal event."""
@@ -41,7 +41,7 @@ def create_event(payload: CreateEventSchema) -> EventResponse:
 @router.post(
     "/events/schedule",
     response_model=EventResponse,
-    dependencies=[Depends(require_role(["admin"]))],
+    dependencies=[Depends(require_permission(["admin"]))],
 )
 def schedule_event_route(payload: ScheduleEventSchema) -> EventResponse:
     """Schedule a seasonal event for future execution."""
@@ -59,7 +59,7 @@ def end_event(payload: EndEventSchema) -> EventResponse:
 @router.post(
     "/events/cancel",
     response_model=EventResponse,
-    dependencies=[Depends(require_role(["admin"]))],
+    dependencies=[Depends(require_permission(["admin"]))],
 )
 def cancel_event(payload: EndEventSchema) -> EventResponse:
     """Cancel a scheduled seasonal event."""
@@ -84,7 +84,7 @@ def get_event_history() -> EventHistoryResponse:
 @router.get(
     "/events/upcoming",
     response_model=UpcomingEventsResponse,
-    dependencies=[Depends(require_role(["admin"]))],
+    dependencies=[Depends(require_permission(["admin"]))],
 )
 def get_upcoming() -> UpcomingEventsResponse:
     """Preview upcoming scheduled events."""

--- a/backend/routes/fame_routes.py
+++ b/backend/routes/fame_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.fame_service import FameService

--- a/backend/routes/fan_club_routes.py
+++ b/backend/routes/fan_club_routes.py
@@ -1,11 +1,11 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, HTTPException
 from models.fan_club_models import *
 from schemas.fan_club_schemas import *
 
 router = APIRouter()
 
-@router.post("/fan_club/create", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.post("/fan_club/create", dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 def create_fan_club(fan_club: FanClubCreate):
     return {"message": f"Fan club '{fan_club.name}' created for band {fan_club.band_id}"}
 

--- a/backend/routes/fan_interaction_routes.py
+++ b/backend/routes/fan_interaction_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.fan_interaction_service import FanInteractionService

--- a/backend/routes/fan_logistics_routes.py
+++ b/backend/routes/fan_logistics_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from core.fan_logistics_engine import cast_vote, get_votes_for_band, get_top_petitions, trigger_engagement_bonus
 

--- a/backend/routes/fanclub_routes.py
+++ b/backend/routes/fanclub_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.fanclub_schema import FanClubCreate, FanClubResponse
 from datetime import date
@@ -8,7 +8,7 @@ router = APIRouter()
 fanclubs = []
 fanclub_id_counter = 1
 
-@router.post("/fanclubs/", response_model=FanClubResponse, dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.post("/fanclubs/", response_model=FanClubResponse, dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 def create_fanclub(fanclub: FanClubCreate):
     global fanclub_id_counter
     new_fc = fanclub.dict()

--- a/backend/routes/festival.py
+++ b/backend/routes/festival.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from pydantic import BaseModel
 from typing import List, Optional
 from datetime import date

--- a/backend/routes/festival_builder_routes.py
+++ b/backend/routes/festival_builder_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from backend.models.festival_builder import FestivalBuilder
 from backend.services.festival_builder_service import (
     BookingConflictError,
@@ -20,7 +20,7 @@ def get_service() -> FestivalBuilderService:
 
 
 # ----------- Admin endpoints -----------
-@router.post("/admin/festivals", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/admin/festivals", dependencies=[Depends(require_permission(["admin"]))])
 def create_festival(payload: dict, svc: FestivalBuilderService = Depends(get_service)) -> dict:
     fid = svc.create_festival(
         name=payload["name"],
@@ -35,7 +35,7 @@ def create_festival(payload: dict, svc: FestivalBuilderService = Depends(get_ser
 
 @router.post(
     "/admin/festivals/{festival_id}/book",
-    dependencies=[Depends(require_role(["admin"]))],
+    dependencies=[Depends(require_permission(["admin"]))],
 )
 def book_act(
     festival_id: int,
@@ -59,7 +59,7 @@ def book_act(
 
 @router.get(
     "/admin/festivals/{festival_id}/finances",
-    dependencies=[Depends(require_role(["admin"]))],
+    dependencies=[Depends(require_permission(["admin"]))],
 )
 def get_finances(
     festival_id: int, svc: FestivalBuilderService = Depends(get_service)

--- a/backend/routes/festival_history.py
+++ b/backend/routes/festival_history.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from pydantic import BaseModel
 from typing import List, Dict
 

--- a/backend/routes/gifting_routes.py
+++ b/backend/routes/gifting_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, conint
 from typing import List, Optional
@@ -48,7 +48,7 @@ class XPItemGiftPayload(BaseModel):
 
 
 # -------- endpoints --------
-@router.post("/digital", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.post("/digital", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def gift_digital(payload: DigitalGiftPayload):
     try:
         gift_id = svc.gift_digital(DigitalGiftIn(**payload.model_dump()))
@@ -57,7 +57,7 @@ def gift_digital(payload: DigitalGiftPayload):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.post("/tickets", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.post("/tickets", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def gift_tickets(payload: TicketGiftPayload):
     try:
         items = [TicketGiftItem(**i.model_dump()) for i in payload.items]
@@ -76,7 +76,7 @@ def gift_tickets(payload: TicketGiftPayload):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.post("/xp-item", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.post("/xp-item", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def gift_xp_item(payload: XPItemGiftPayload):
     try:
         xp_item_service.assign_to_user(payload.recipient_user_id, payload.item_id)
@@ -85,11 +85,11 @@ def gift_xp_item(payload: XPItemGiftPayload):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.get("/inbox/{user_id}", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.get("/inbox/{user_id}", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def gifts_inbox(user_id: int, limit: int = 50, offset: int = 0):
     return svc.list_inbox(user_id, limit, offset)
 
 
-@router.get("/sent/{user_id}", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.get("/sent/{user_id}", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def gifts_sent(user_id: int, limit: int = 50, offset: int = 0):
     return svc.list_sent(user_id, limit, offset)

--- a/backend/routes/gig.py
+++ b/backend/routes/gig.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from models.gig import Gig
@@ -21,7 +21,7 @@ router = APIRouter()
 @router.post(
     "/gigs/book",
     response_model=GigOut,
-    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))],
 )
 def book_gig(
     gig: GigCreate,

--- a/backend/routes/health_routes.py
+++ b/backend/routes/health_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 # File: backend/routes/health_routes.py
 from fastapi import APIRouter, Depends
 from utils.db import get_conn

--- a/backend/routes/jobs_charts_routes.py
+++ b/backend/routes/jobs_charts_routes.py
@@ -1,13 +1,13 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 # File: backend/routes/jobs_charts_routes.py
 from fastapi import APIRouter, HTTPException, Depends
 from services.jobs_charts import ChartsJobsService
 
 # Auth dep
 try:
-    from auth.dependencies import require_role
+    from auth.dependencies import require_permission
 except Exception:
-    def require_role(roles):
+    def require_permission(roles):
         async def _noop():
             return True
         return _noop
@@ -15,7 +15,7 @@ except Exception:
 router = APIRouter(prefix="/admin/jobs", tags=["Admin Jobs"])
 svc = ChartsJobsService()
 
-@router.post("/charts/daily", dependencies=[Depends(require_role(["admin","moderator"]))])
+@router.post("/charts/daily", dependencies=[Depends(require_permission(["admin","moderator"]))])
 def charts_daily(date: str):
     """
     Compute charts for a single day. date: 'YYYY-MM-DD'
@@ -25,7 +25,7 @@ def charts_daily(date: str):
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-@router.post("/charts/weekly", dependencies=[Depends(require_role(["admin","moderator"]))])
+@router.post("/charts/weekly", dependencies=[Depends(require_permission(["admin","moderator"]))])
 def charts_weekly(week_end_date: str):
     """
     Compute charts for the week ending on the given date (expected Sunday), format 'YYYY-MM-DD'.

--- a/backend/routes/karma_admin_routes.py
+++ b/backend/routes/karma_admin_routes.py
@@ -1,11 +1,11 @@
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.karma_extras import add_karma_vote, get_karma_leaderboard, get_karma_score
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 router = APIRouter(prefix="/karma", tags=["Karma"])
 
 
-@router.get("/score/{user_id}", dependencies=[Depends(require_role(["admin"]))])
+@router.get("/score/{user_id}", dependencies=[Depends(require_permission(["admin"]))])
 def read_karma_score(
     user_id: int, _req: Request, _: int = Depends(get_current_user_id)
 ):

--- a/backend/routes/karma_mentorship_routes.py
+++ b/backend/routes/karma_mentorship_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.karma_mentorship_service import KarmaMentorshipService

--- a/backend/routes/karma_routes.py
+++ b/backend/routes/karma_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.karma_db import KarmaDB

--- a/backend/routes/label_management_routes.py
+++ b/backend/routes/label_management_routes.py
@@ -1,8 +1,8 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 
 router = APIRouter()
 
-@router.get("/labels/status", dependencies=[Depends(require_role(["admin"]))])
+@router.get("/labels/status", dependencies=[Depends(require_permission(["admin"]))])
 async def check_label_status():
     return {"status": "Label & Management system operational."}

--- a/backend/routes/labels_routes.py
+++ b/backend/routes/labels_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 
-from auth.dependencies import require_role
+from auth.dependencies import require_permission
 from backend.schemas.labels_schemas import (
     LabelCreateSchema,
     OfferRequestSchema,
@@ -18,7 +18,7 @@ router = APIRouter()
 negotiation_service = ContractNegotiationService()
 
 
-@router.post("/labels/create", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/labels/create", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 def create_label(payload: LabelCreateSchema):
     return create_label_service(payload.name, payload.owner_id or 0)
 

--- a/backend/routes/live_performance.py
+++ b/backend/routes/live_performance.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from backend.services import live_performance_service

--- a/backend/routes/mailbox_routes.py
+++ b/backend/routes/mailbox_routes.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter
 from fastapi import Depends
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from services.mailbox_service import *
 
 router = APIRouter()
 
-@router.post("/mail/send", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/mail/send", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 def send_message(payload: dict, user_id: int = Depends(get_current_user_id)):
     return send_mail(payload)
 

--- a/backend/routes/major_role_routes.py
+++ b/backend/routes/major_role_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.major_role_schema import MajorCreate, RoleAssignmentCreate
 from models.major_role import Major, RoleAssignment
@@ -9,7 +9,7 @@ majors: List[Major] = []
 roles: List[RoleAssignment] = []
 major_id = 1
 
-@router.post("/majors/", response_model=Major, dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/majors/", response_model=Major, dependencies=[Depends(require_permission(["admin", "moderator"]))])
 def create_major(data: MajorCreate):
     global major_id
     new_major = Major(

--- a/backend/routes/management_routes.py
+++ b/backend/routes/management_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.management_schema import ManagerCreate, ManagerResponse
 from datetime import date
@@ -8,7 +8,7 @@ router = APIRouter()
 managers = []
 manager_id_counter = 1
 
-@router.post("/managers/", response_model=ManagerResponse, dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
+@router.post("/managers/", response_model=ManagerResponse, dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))])
 def hire_manager(manager: ManagerCreate):
     global manager_id_counter
     new_manager = manager.dict()

--- a/backend/routes/marketplace_routes.py
+++ b/backend/routes/marketplace_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.economy_service import EconomyService, EconomyError
 from backend.services.marketplace_service import MarketplaceService, MarketplaceError
 
@@ -12,7 +12,7 @@ _market = MarketplaceService(economy=_economy)
 _market.ensure_schema()
 
 async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
-    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    await require_permission(["user", "band_member", "moderator", "admin"], user_id)
     return user_id
 
 class ListingIn(BaseModel):

--- a/backend/routes/media_exposure_routes.py
+++ b/backend/routes/media_exposure_routes.py
@@ -1,11 +1,11 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, HTTPException
 from models.media_exposure_models import *
 from schemas.media_exposure_schemas import *
 
 router = APIRouter()
 
-@router.post("/media_exposure/post_social_media", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/media_exposure/post_social_media", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 def post_social_media(post: SocialMediaPost):
     # Placeholder logic for posting on social media
     return {"message": f"Posted {post.platform} update: {post.content}"}

--- a/backend/routes/media_publicity_routes.py
+++ b/backend/routes/media_publicity_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, HTTPException
 from models import media_publicity_models
 from schemas import media_publicity_schemas
@@ -8,7 +8,7 @@ from fastapi import Depends
 
 router = APIRouter()
 
-@router.post("/event/", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/event/", dependencies=[Depends(require_permission(["admin"]))])
 def create_media_event(event: media_publicity_schemas.MediaEventCreate, db: Session = Depends(get_db)):
     db_event = media_publicity_models.MediaEvent(**event.dict())
     db.add(db_event)

--- a/backend/routes/media_routes.py
+++ b/backend/routes/media_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from typing import List, Optional
 
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from services.media_event_service import media_event_service
 from services.media_moderation_service import media_moderation_service
@@ -23,7 +23,7 @@ _media_store: List[dict] = []
 async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
     """Ensure the caller is an authenticated user."""
 
-    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    await require_permission(["user", "band_member", "moderator", "admin"], user_id)
     return user_id
 
 

--- a/backend/routes/membership_routes.py
+++ b/backend/routes/membership_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.economy_service import EconomyError, EconomyService
 from backend.services.membership_service import membership_service
 
@@ -14,7 +14,7 @@ _economy.ensure_schema()
 
 
 async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
-    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    await require_permission(["user", "band_member", "moderator", "admin"], user_id)
     return user_id
 
 

--- a/backend/routes/merch_routes.py
+++ b/backend/routes/merch_routes.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from backend.services.economy_service import EconomyService
 from backend.services.merch_service import MerchError, MerchService
 from backend.models.merch import ProductIn, SKUIn
@@ -43,7 +43,7 @@ class PurchaseIn(BaseModel):
     shipping_address: str | None = None
 
 
-@router.post("/products", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/products", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 def create_product(payload: ProductCreateIn):
     try:
         pid = svc.create_product(ProductIn(**payload.model_dump()))
@@ -53,7 +53,7 @@ def create_product(payload: ProductCreateIn):
 
 
 @router.get(
-    "/products", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))]
+    "/products", dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))]
 )
 def list_products(
     only_active: bool = True, category: str | None = None, band_id: int | None = None
@@ -62,7 +62,7 @@ def list_products(
 
 
 @router.patch(
-    "/products/{product_id}", dependencies=[Depends(require_role(["admin", "moderator"]))]
+    "/products/{product_id}", dependencies=[Depends(require_permission(["admin", "moderator"]))]
 )
 def update_product(product_id: int, fields: dict):
     try:
@@ -72,7 +72,7 @@ def update_product(product_id: int, fields: dict):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.post("/skus", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/skus", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 def create_sku(payload: SKUCreateIn):
     try:
         sid = svc.create_sku(SKUIn(**payload.model_dump()))
@@ -83,13 +83,13 @@ def create_sku(payload: SKUCreateIn):
 
 @router.get(
     "/skus/{product_id}",
-    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))],
 )
 def list_skus(product_id: int, only_active: bool = True):
     return svc.list_skus(product_id, only_active=only_active)
 
 
-@router.patch("/skus/{sku_id}", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.patch("/skus/{sku_id}", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 def update_sku(sku_id: int, fields: dict):
     try:
         svc.update_sku(sku_id, **fields)
@@ -99,7 +99,7 @@ def update_sku(sku_id: int, fields: dict):
 
 
 @router.post(
-    "/purchase", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))]
+    "/purchase", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))]
 )
 def purchase(payload: PurchaseIn):
     try:
@@ -113,7 +113,7 @@ def purchase(payload: PurchaseIn):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.post("/refund/{order_id}", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/refund/{order_id}", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 def refund(order_id: int, reason: str = ""):
     try:
         return svc.refund_order(order_id, reason)
@@ -123,7 +123,7 @@ def refund(order_id: int, reason: str = ""):
 
 @router.get(
     "/orders/{order_id}",
-    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))],
 )
 def get_order(order_id: int):
     try:
@@ -134,7 +134,7 @@ def get_order(order_id: int):
 
 @router.get(
     "/orders/user/{buyer_user_id}",
-    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))],
 )
 def list_orders_for_user(buyer_user_id: int):
     return svc.list_orders_for_user(buyer_user_id)

--- a/backend/routes/merchandise_routes.py
+++ b/backend/routes/merchandise_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.merchandise_schema import MerchandiseCreate, MerchandiseResponse
 from typing import List
@@ -7,7 +7,7 @@ router = APIRouter()
 merch_db = []
 merch_id_counter = 1
 
-@router.post("/merchandise/", response_model=MerchandiseResponse, dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.post("/merchandise/", response_model=MerchandiseResponse, dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 def create_merch(merch: MerchandiseCreate):
     global merch_id_counter
     new_merch = merch.dict()

--- a/backend/routes/metrics_routes.py
+++ b/backend/routes/metrics_routes.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - fallback for stubs
     def Depends(dependency: Any) -> Any:  # type: ignore[misc]
         return dependency
 
-from auth.dependencies import require_role
+from auth.dependencies import require_permission
 from utils.db import get_conn
 
 router = APIRouter(prefix="/metrics", tags=["Metrics"])
@@ -22,7 +22,7 @@ router = APIRouter(prefix="/metrics", tags=["Metrics"])
 
 @router.get("/health")
 def health(
-    _: bool = Depends(require_role(["admin"])),
+    _: bool = Depends(require_permission(["admin"])),
     conn: Any = Depends(get_conn),
 ) -> Dict[str, Any]:
     """Return basic application health information.
@@ -36,7 +36,7 @@ def health(
 
 
 @router.get("/performance")
-def performance(_: bool = Depends(require_role(["admin"]))) -> Dict[str, Any]:
+def performance(_: bool = Depends(require_permission(["admin"]))) -> Dict[str, Any]:
     """Return lightweight process performance metrics."""
     load1, load5, load15 = os.getloadavg()
     usage = resource.getrusage(resource.RUSAGE_SELF)

--- a/backend/routes/music.py
+++ b/backend/routes/music.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import Depends
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from sqlalchemy.orm import Session
 
 from models.music import Song, Album, album_song_link
@@ -13,7 +13,7 @@ from utils.i18n import _
 
 router = APIRouter(prefix="/music", tags=["Music"])
 
-@router.post("/songs", response_model=SongResponse, dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
+@router.post("/songs", response_model=SongResponse, dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))])
 def create_song(song: SongCreate, db: Session = Depends(get_db, user_id: int = Depends(get_current_user_id))):
     if not (song.band_id or song.collaboration_id):
         raise HTTPException(status_code=400, detail=_("Must provide band_id or collaboration_id"))

--- a/backend/routes/music_metrics_routes.py
+++ b/backend/routes/music_metrics_routes.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 
-from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from backend.services import song_popularity_service
 from backend.services.song_popularity_service import (
     ALLOWED_REGION_CODES,

--- a/backend/routes/music_routes.py
+++ b/backend/routes/music_routes.py
@@ -1,7 +1,7 @@
 # File: backend/routes/music_routes.py
 from fastapi import APIRouter, HTTPException
 from fastapi import Depends
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from pydantic import BaseModel, Field
 from typing import Optional
 

--- a/backend/routes/notification_routes.py
+++ b/backend/routes/notification_routes.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter
 from fastapi import Depends
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from services.scheduler_service import *
 
 router = APIRouter()
 
-@router.post("/notify/send", dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
+@router.post("/notify/send", dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))])
 def send_notification(payload: dict, user_id: int = Depends(get_current_user_id)):
     return send_user_notification(payload)
 

--- a/backend/routes/promotion_routes.py
+++ b/backend/routes/promotion_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.promotion_schema import PromotionCreate, PromotionResponse
 from typing import List
@@ -7,7 +7,7 @@ router = APIRouter()
 promotions_db = []
 promotion_id_counter = 1
 
-@router.post("/promotions/", response_model=PromotionResponse, dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.post("/promotions/", response_model=PromotionResponse, dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 def create_promotion(promo: PromotionCreate):
     global promotion_id_counter
     new_promo = promo.dict()

--- a/backend/routes/property_routes.py
+++ b/backend/routes/property_routes.py
@@ -2,7 +2,7 @@ from services.achievement_service import AchievementService
 from services.economy_service import EconomyService
 from services.property_service import PropertyError, PropertyService
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
@@ -20,7 +20,7 @@ class PropertyPurchaseIn(BaseModel):
     base_rent: int
 
 
-@router.post("/buy", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.post("/buy", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def buy_property(
     payload: PropertyPurchaseIn, owner_id: int = Depends(get_current_user_id)
 ):
@@ -40,7 +40,7 @@ def buy_property(
 
 @router.post(
     "/upgrade/{property_id}",
-    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))],
 )
 def upgrade_property(property_id: int, owner_id: int = Depends(get_current_user_id)):
     try:
@@ -51,7 +51,7 @@ def upgrade_property(property_id: int, owner_id: int = Depends(get_current_user_
 
 @router.post(
     "/rent/{property_id}",
-    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))],
 )
 def rent_property(property_id: int, renter_id: int = Depends(get_current_user_id)):
     try:
@@ -62,7 +62,7 @@ def rent_property(property_id: int, renter_id: int = Depends(get_current_user_id
 
 @router.post(
     "/sell/{property_id}",
-    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))],
 )
 def sell_property(property_id: int, owner_id: int = Depends(get_current_user_id)):
     try:
@@ -72,6 +72,6 @@ def sell_property(property_id: int, owner_id: int = Depends(get_current_user_id)
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.get("/list", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.get("/list", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 def list_properties(owner_id: int = Depends(get_current_user_id)):
     return svc.list_properties(owner_id)

--- a/backend/routes/public_reactions_routes.py
+++ b/backend/routes/public_reactions_routes.py
@@ -1,9 +1,9 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 
 router = APIRouter()
 
-@router.post("/press/event", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/press/event", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 async def log_press_event(event: dict):
     return {"message": "Press event logged", "event": event}
 

--- a/backend/routes/replay_routes.py
+++ b/backend/routes/replay_routes.py
@@ -1,10 +1,10 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from services.replay_service import *
 
 router = APIRouter()
 
-@router.post("/replay/log", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/replay/log", dependencies=[Depends(require_permission(["admin"]))])
 def log_event(payload: dict):
     return log_player_event(payload)
 

--- a/backend/routes/sales.py
+++ b/backend/routes/sales.py
@@ -6,9 +6,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 try:
-    from auth.dependencies import require_role
+    from auth.dependencies import require_permission
 except Exception:  # pragma: no cover
-    def require_role(_: List[str]):
+    def require_permission(_: List[str]):
         async def _noop() -> None:  # type: ignore[return-value]
             return None
 
@@ -33,7 +33,7 @@ class DigitalSaleIn(BaseModel):
 
 @router.post(
     "/digital",
-    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))],
 )
 async def record_digital(payload: DigitalSaleIn) -> dict[str, int]:
     """Record a digital song or album sale."""
@@ -47,7 +47,7 @@ async def record_digital(payload: DigitalSaleIn) -> dict[str, int]:
 
 @router.get(
     "/digital/{work_type}/{work_id}",
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def list_digital_sales(work_type: str, work_id: int):
     """List digital sales for a work."""
@@ -76,7 +76,7 @@ class VinylPurchaseIn(BaseModel):
 
 @router.post(
     "/vinyl/sku",
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def create_vinyl_sku(payload: VinylSkuIn) -> dict[str, int]:
     try:
@@ -88,7 +88,7 @@ async def create_vinyl_sku(payload: VinylSkuIn) -> dict[str, int]:
 
 @router.get(
     "/vinyl/sku/{album_id}",
-    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))],
 )
 async def list_vinyl_skus(album_id: int):
     return svc.list_vinyl_skus(album_id)
@@ -96,7 +96,7 @@ async def list_vinyl_skus(album_id: int):
 
 @router.post(
     "/vinyl/purchase",
-    dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))],
 )
 async def purchase_vinyl(payload: VinylPurchaseIn) -> dict[str, int]:
     try:
@@ -112,7 +112,7 @@ async def purchase_vinyl(payload: VinylPurchaseIn) -> dict[str, int]:
 
 @router.post(
     "/vinyl/refund/{order_id}",
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def refund_vinyl(order_id: int, reason: str = "") -> dict[str, bool]:
     try:

--- a/backend/routes/shipping_routes.py
+++ b/backend/routes/shipping_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.shipping_service import ShippingService
 
 router = APIRouter(prefix="/shipping", tags=["Shipping"])
@@ -10,7 +10,7 @@ shipping_service = ShippingService()
 
 
 async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
-    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    await require_permission(["user", "band_member", "moderator", "admin"], user_id)
     return user_id
 
 

--- a/backend/routes/shop_routes.py
+++ b/backend/routes/shop_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.books_service import books_service
 from backend.services.city_shop_service import city_shop_service
 from backend.services.economy_service import EconomyError, EconomyService
@@ -18,7 +18,7 @@ _economy.ensure_schema()
 
 
 async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
-    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    await require_permission(["user", "band_member", "moderator", "admin"], user_id)
     return user_id
 
 

--- a/backend/routes/skin.py
+++ b/backend/routes/skin.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session, joinedload
 from models.skin import Skin, SkinInventory
@@ -8,7 +8,7 @@ from utils.i18n import _
 
 router = APIRouter(prefix="/skins", tags=["Skins"])
 
-@router.post("/", response_model=SkinResponse, dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.post("/", response_model=SkinResponse, dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 def submit_skin(skin: SkinCreate, db: Session = Depends(get_db)):
     new_skin = Skin(**skin.dict())
     db.add(new_skin)

--- a/backend/routes/skins_routes.py
+++ b/backend/routes/skins_routes.py
@@ -1,10 +1,10 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from services.skins_service import *
 
 router = APIRouter()
 
-@router.post("/skins/submit", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.post("/skins/submit", dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 def submit_skin(payload: dict):
     return submit_new_skin(payload)
 

--- a/backend/routes/sponsorship.py
+++ b/backend/routes/sponsorship.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from utils.i18n import _
 
-from backend.auth.dependencies import get_current_user_id, require_role  # noqa: F401
+from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from backend.services.sponsorship_service import SponsorshipService
 from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 from pydantic import BaseModel, Field

--- a/backend/routes/stream_routes.py
+++ b/backend/routes/stream_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.stream_service import StreamService

--- a/backend/routes/streaming.py
+++ b/backend/routes/streaming.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from database import get_db
@@ -10,7 +10,7 @@ from schemas.streaming import (
 
 router = APIRouter()
 
-@router.post("/sales/digital", response_model=DigitalSaleOut, dependencies=[Depends(require_role(["user", "band_member", "moderator", "admin"]))])
+@router.post("/sales/digital", response_model=DigitalSaleOut, dependencies=[Depends(require_permission(["user", "band_member", "moderator", "admin"]))])
 def record_digital_sale(sale: DigitalSaleCreate, db: Session = Depends(get_db)):
     new_sale = DigitalSale(**sale.dict())
     db.add(new_sale)

--- a/backend/routes/support_slot_routes.py
+++ b/backend/routes/support_slot_routes.py
@@ -8,9 +8,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 try:  # Authentication dependencies may not be available during tests
-    from auth.dependencies import get_current_user_id, require_role
+    from auth.dependencies import get_current_user_id, require_permission
 except Exception:  # pragma: no cover - fallback for docs builds
-    def require_role(_: List[str]):
+    def require_permission(_: List[str]):
         async def _noop() -> None:  # type: ignore[return-value]
             return None
 
@@ -44,7 +44,7 @@ class SupportSlotOut(SupportSlotIn):
 @router.post(
     "",
     response_model=SupportSlotOut,
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def create_slot(
     payload: SupportSlotIn, user_id: int = Depends(get_current_user_id)
@@ -60,7 +60,7 @@ async def create_slot(
 @router.get(
     "",
     response_model=List[SupportSlotOut],
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def list_slots() -> List[SupportSlotOut]:
     """Return all defined support slots."""
@@ -71,7 +71,7 @@ async def list_slots() -> List[SupportSlotOut]:
 @router.get(
     "/{slot_id}",
     response_model=SupportSlotOut,
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def get_slot(slot_id: int) -> SupportSlotOut:
     """Retrieve a single support slot by identifier."""
@@ -85,7 +85,7 @@ async def get_slot(slot_id: int) -> SupportSlotOut:
 @router.put(
     "/{slot_id}",
     response_model=SupportSlotOut,
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def update_slot(
     slot_id: int,
@@ -106,7 +106,7 @@ async def update_slot(
 
 @router.delete(
     "/{slot_id}",
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def delete_slot(slot_id: int) -> dict[str, bool]:
     """Delete a support slot."""

--- a/backend/routes/ticketing_routes.py
+++ b/backend/routes/ticketing_routes.py
@@ -6,9 +6,9 @@ from services.economy_service import EconomyService
 from services.ticketing_service import TicketingError, TicketingService
 
 try:
-    from auth.dependencies import require_role
+    from auth.dependencies import require_permission
 except Exception:  # pragma: no cover - fallback for tests
-    def require_role(roles):
+    def require_permission(roles):
         async def _noop():
             return True
         return _noop
@@ -42,12 +42,12 @@ class PurchaseIn(BaseModel):
     items: List[TicketItemIn]
 
 
-@router.get("/status", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.get("/status", dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 async def check_ticketing_status():
     return {"status": "Ticketing system operational."}
 
 
-@router.post("/types", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/types", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 async def create_ticket_type(payload: TicketTypeIn):
     try:
         tid = svc.create_ticket_type(**payload.model_dump())
@@ -56,12 +56,12 @@ async def create_ticket_type(payload: TicketTypeIn):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.get("/types/{event_id}", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.get("/types/{event_id}", dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 async def list_ticket_types(event_id: int):
     return svc.list_ticket_types(event_id)
 
 
-@router.post("/purchase", dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))])
+@router.post("/purchase", dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))])
 async def purchase_tickets(payload: PurchaseIn):
     try:
         oid = svc.purchase_tickets(
@@ -74,7 +74,7 @@ async def purchase_tickets(payload: PurchaseIn):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.post("/refund/{order_id}", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("/refund/{order_id}", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 async def refund_order(order_id: int, reason: str = ""):
     try:
         return svc.refund_order(order_id, reason)

--- a/backend/routes/tour_logistics_routes.py
+++ b/backend/routes/tour_logistics_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.tour_logistics_service import TourLogisticsService

--- a/backend/routes/tours.py
+++ b/backend/routes/tours.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 from fastapi import Depends
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from sqlalchemy.orm import Session
 from database import get_db
 from models.tours import Tour, TourStop
@@ -9,7 +9,7 @@ from datetime import datetime
 
 router = APIRouter()
 
-@router.post("/tours/create", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.post("/tours/create", dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 def create_tour(tour_data: TourCreate, db: Session = Depends(get_db, user_id: int = Depends(get_current_user_id))):
     new_tour = Tour(**tour_data.dict())
     db.add(new_tour)

--- a/backend/routes/trade_routes.py
+++ b/backend/routes/trade_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.trade_route_service import TradeRouteService
 
 router = APIRouter(prefix="/trade", tags=["Trade"])
@@ -10,7 +10,7 @@ trade_service = TradeRouteService()
 
 
 async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
-    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    await require_permission(["user", "band_member", "moderator", "admin"], user_id)
     return user_id
 
 

--- a/backend/routes/transport.py
+++ b/backend/routes/transport.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from database import get_db
@@ -7,7 +7,7 @@ from schemas.transport import TransportCreate
 
 router = APIRouter()
 
-@router.post("/transport/add", dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))])
+@router.post("/transport/add", dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))])
 def add_transport(transport_data: TransportCreate, db: Session = Depends(get_db)):
     new_vehicle = Transport(**transport_data.dict())
     db.add(new_vehicle)

--- a/backend/routes/transport_routes.py
+++ b/backend/routes/transport_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.transport_service import TransportService

--- a/backend/routes/tutorial_routes.py
+++ b/backend/routes/tutorial_routes.py
@@ -1,10 +1,10 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from services.tutorial_service import *
 
 router = APIRouter()
 
-@router.post("/tutorial/start", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/tutorial/start", dependencies=[Depends(require_permission(["admin"]))])
 def start_tutorial(user_id: int):
     return start_user_tutorial(user_id)
 

--- a/backend/routes/venue_routes.py
+++ b/backend/routes/venue_routes.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 # File: backend/routes/venue_routes.py
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field

--- a/backend/routes/venue_sponsorships_routes.py
+++ b/backend/routes/venue_sponsorships_routes.py
@@ -6,9 +6,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, HttpUrl
 
 try:
-    from auth.dependencies import get_current_user_id, require_role
+    from auth.dependencies import get_current_user_id, require_permission
 except Exception:  # pragma: no cover
-    def require_role(_: List[str]):
+    def require_permission(_: List[str]):
         async def _noop() -> None:  # type: ignore[return-value]
             return None
 
@@ -39,7 +39,7 @@ class SponsorshipInModel(BaseModel):
     is_active: bool = True
 
 
-@router.post("", dependencies=[Depends(require_role(["admin", "moderator"]))])
+@router.post("", dependencies=[Depends(require_permission(["admin", "moderator"]))])
 async def upsert_sponsorship(payload: SponsorshipInModel) -> Dict[str, int]:
     """Create or update a sponsorship for a venue."""
 
@@ -52,7 +52,7 @@ async def upsert_sponsorship(payload: SponsorshipInModel) -> Dict[str, int]:
 
 @router.get(
     "/{venue_id}",
-    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))],
 )
 async def get_sponsorship(venue_id: int) -> Dict[str, Any]:
     """Retrieve sponsorship details for a venue."""
@@ -65,7 +65,7 @@ async def get_sponsorship(venue_id: int) -> Dict[str, Any]:
 
 @router.post(
     "/{venue_id}/deactivate",
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def deactivate_sponsorship(venue_id: int) -> Dict[str, bool]:
     """Deactivate a sponsorship for a venue."""
@@ -84,7 +84,7 @@ class BrandingQuery(BaseModel):
 
 @router.post(
     "/{venue_id}/branding",
-    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))],
 )
 async def effective_branding(venue_id: int, query: BrandingQuery) -> Dict[str, Any]:
     """Return the effective branding for a venue."""
@@ -113,7 +113,7 @@ class CounterIn(BaseModel):
 
 @router.post(
     "/negotiations/offer",
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def create_offer(payload: OfferIn) -> Dict[str, Any]:
     negotiation = svc.create_offer(payload.venue_id, payload.sponsor_name, payload.terms.model_dump())
@@ -122,7 +122,7 @@ async def create_offer(payload: OfferIn) -> Dict[str, Any]:
 
 @router.post(
     "/negotiations/{negotiation_id}/counter",
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def counter_offer(negotiation_id: int, payload: CounterIn) -> Dict[str, Any]:
     try:
@@ -134,7 +134,7 @@ async def counter_offer(negotiation_id: int, payload: CounterIn) -> Dict[str, An
 
 @router.post(
     "/negotiations/{negotiation_id}/accept",
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def accept_offer(negotiation_id: int) -> Dict[str, Any]:
     try:
@@ -153,7 +153,7 @@ class ImpressionIn(BaseModel):
 
 @router.post(
     "/impressions",
-    dependencies=[Depends(require_role(["admin", "moderator", "band_member"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator", "band_member"]))],
 )
 async def record_impression(
     payload: ImpressionIn, user_id: int = Depends(get_current_user_id)
@@ -172,7 +172,7 @@ async def record_impression(
 
 @router.get(
     "/impressions/{sponsorship_id}",
-    dependencies=[Depends(require_role(["admin", "moderator"]))],
+    dependencies=[Depends(require_permission(["admin", "moderator"]))],
 )
 async def list_impressions(
     sponsorship_id: int, limit: int = 100

--- a/backend/routes/venues.py
+++ b/backend/routes/venues.py
@@ -1,4 +1,4 @@
-from auth.dependencies import get_current_user_id, require_role
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from database import get_db
@@ -7,7 +7,7 @@ from schemas.venues import VenueCreate
 
 router = APIRouter()
 
-@router.post("/venues/add", dependencies=[Depends(require_role(["admin"]))])
+@router.post("/venues/add", dependencies=[Depends(require_permission(["admin"]))])
 def add_venue(venue_data: VenueCreate, db: Session = Depends(get_db)):
     new_venue = Venue(**venue_data.dict())
     db.add(new_venue)

--- a/backend/routes/video_routes.py
+++ b/backend/routes/video_routes.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.economy_service import EconomyService
 from backend.services.video_service import VideoService
 
@@ -13,7 +13,7 @@ _video_service = VideoService(_economy)
 
 
 async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
-    await require_role(["user", "band_member", "moderator", "admin"], user_id)
+    await require_permission(["user", "band_member", "moderator", "admin"], user_id)
     return user_id
 
 

--- a/backend/tests/admin/test_admin_action_logging.py
+++ b/backend/tests/admin/test_admin_action_logging.py
@@ -18,11 +18,11 @@ def _setup(monkeypatch):
     async def fake_current_user(req: Request):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(media_routes, "get_current_user_id", fake_current_user)
-    monkeypatch.setattr(media_routes, "require_role", fake_require_role)
+    monkeypatch.setattr(media_routes, "require_permission", fake_require_permission)
 
     # fresh storage backend in a temp directory
     tmpdir = tempfile.TemporaryDirectory()

--- a/backend/tests/admin/test_audit_logging.py
+++ b/backend/tests/admin/test_audit_logging.py
@@ -26,11 +26,11 @@ def test_admin_route_logs_action(monkeypatch, tmp_path):
     async def fake_current_user(req: Request):
         return 99
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(media_routes, "get_current_user_id", fake_current_user)
-    monkeypatch.setattr(media_routes, "require_role", fake_require_role)
+    monkeypatch.setattr(media_routes, "require_permission", fake_require_permission)
     monkeypatch.setattr(
         "backend.services.admin_audit_service.get_current_user_id", fake_current_user
     )

--- a/backend/tests/admin/test_book_routes.py
+++ b/backend/tests/admin/test_book_routes.py
@@ -29,14 +29,14 @@ def test_admin_book_routes_crud(monkeypatch, tmp_path):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_book_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_book_routes.require_role", fake_require_role
+        "backend.routes.admin_book_routes.require_permission", fake_require_permission
     )
 
     # use temporary db

--- a/backend/tests/admin/test_content_preview.py
+++ b/backend/tests/admin/test_content_preview.py
@@ -25,15 +25,15 @@ def test_preview_endpoints_do_not_persist(monkeypatch):
     monkeypatch.setattr(
         "backend.routes.admin_npc_routes.get_current_user_id", _allow
     )
-    monkeypatch.setattr("backend.routes.admin_npc_routes.require_role", _role)
+    monkeypatch.setattr("backend.routes.admin_npc_routes.require_permission", _role)
     monkeypatch.setattr(
         "backend.routes.admin_quest_routes.get_current_user_id", _allow
     )
-    monkeypatch.setattr("backend.routes.admin_quest_routes.require_role", _role)
+    monkeypatch.setattr("backend.routes.admin_quest_routes.require_permission", _role)
     monkeypatch.setattr(
         "backend.routes.admin_economy_routes.get_current_user_id", _allow
     )
-    monkeypatch.setattr("backend.routes.admin_economy_routes.require_role", _role)
+    monkeypatch.setattr("backend.routes.admin_economy_routes.require_permission", _role)
 
     req = Request({})
 

--- a/backend/tests/admin/test_course_routes.py
+++ b/backend/tests/admin/test_course_routes.py
@@ -30,14 +30,14 @@ def test_course_crud(monkeypatch, tmp_path):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_course_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_course_routes.require_role", fake_require_role
+        "backend.routes.admin_course_routes.require_permission", fake_require_permission
     )
 
     svc.db_path = str(tmp_path / "courses.db")

--- a/backend/tests/admin/test_economy_routes.py
+++ b/backend/tests/admin/test_economy_routes.py
@@ -22,14 +22,14 @@ def test_admin_economy_config_updates(monkeypatch, tmp_path):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_economy_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_economy_routes.require_role", fake_require_role
+        "backend.routes.admin_economy_routes.require_permission", fake_require_permission
     )
 
     db_file = tmp_path / "econ.db"

--- a/backend/tests/admin/test_name_routes.py
+++ b/backend/tests/admin/test_name_routes.py
@@ -26,11 +26,11 @@ def test_append_names_and_generate(tmp_path, monkeypatch):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(admin_name_routes, "get_current_user_id", fake_current_user)
-    monkeypatch.setattr(admin_name_routes, "require_role", fake_require_role)
+    monkeypatch.setattr(admin_name_routes, "require_permission", fake_require_permission)
 
     req = Request({"type": "http"})
     asyncio.run(admin_name_routes.add_first_name(admin_name_routes.FirstNameIn(name="Testo", gender="male"), req))

--- a/backend/tests/admin/test_npc_dialogue_routes.py
+++ b/backend/tests/admin/test_npc_dialogue_routes.py
@@ -13,20 +13,20 @@ def _allow_admin(monkeypatch):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_npc_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_npc_routes.require_role", fake_require_role
+        "backend.routes.admin_npc_routes.require_permission", fake_require_permission
     )
     monkeypatch.setattr(
         "backend.routes.admin_npc_dialogue_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_npc_dialogue_routes.require_role", fake_require_role
+        "backend.routes.admin_npc_dialogue_routes.require_permission", fake_require_permission
     )
 
 

--- a/backend/tests/admin/test_npc_routes.py
+++ b/backend/tests/admin/test_npc_routes.py
@@ -28,14 +28,14 @@ def test_admin_npc_routes_flow(monkeypatch):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_npc_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_npc_routes.require_role", fake_require_role
+        "backend.routes.admin_npc_routes.require_permission", fake_require_permission
     )
 
     req = Request({})

--- a/backend/tests/admin/test_quest_routes.py
+++ b/backend/tests/admin/test_quest_routes.py
@@ -42,14 +42,14 @@ def test_admin_quest_create_and_update(monkeypatch):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_quest_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_quest_routes.require_role", fake_require_role
+        "backend.routes.admin_quest_routes.require_permission", fake_require_permission
     )
 
     req = Request({})
@@ -84,14 +84,14 @@ def test_preview_and_validate_graph(monkeypatch):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_quest_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_quest_routes.require_role", fake_require_role
+        "backend.routes.admin_quest_routes.require_permission", fake_require_permission
     )
 
     req = Request({})

--- a/backend/tests/admin/test_venue_business_routes.py
+++ b/backend/tests/admin/test_venue_business_routes.py
@@ -48,20 +48,20 @@ def test_admin_venue_business_flow(monkeypatch):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_venue_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_venue_routes.require_role", fake_require_role
+        "backend.routes.admin_venue_routes.require_permission", fake_require_permission
     )
     monkeypatch.setattr(
         "backend.routes.admin_business_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_business_routes.require_role", fake_require_role
+        "backend.routes.admin_business_routes.require_permission", fake_require_permission
     )
 
     req = Request({})

--- a/backend/tests/analytics/test_analytics.py
+++ b/backend/tests/analytics/test_analytics.py
@@ -6,7 +6,7 @@ from auth.service import AuthService
 from fastapi import HTTPException, Request
 from utils.db import get_conn
 
-from backend.auth.dependencies import get_current_user_id, require_role
+from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.analytics_service import SERVICE_LATENCY_MS, AnalyticsService
 from backend.utils.metrics import generate_latest
 
@@ -86,13 +86,13 @@ def test_metrics_and_permissions(tmp_path):
     user_req = Request(headers={"Authorization": f"Bearer {token(2, auth_svc)}"})
     uid = asyncio.run(get_current_user_id(user_req))
     with pytest.raises(HTTPException) as exc:
-        asyncio.run(require_role(["admin"], user_id=uid))
+        asyncio.run(require_permission(["admin"], user_id=uid))
     assert exc.value.status_code == 403
 
     # permission: admin succeeds
     admin_req = Request(headers={"Authorization": f"Bearer {token(1, auth_svc)}"})
     uid = asyncio.run(get_current_user_id(admin_req))
-    assert asyncio.run(require_role(["admin"], user_id=uid))
+    assert asyncio.run(require_permission(["admin"], user_id=uid))
 
 
 def test_kpis_latency_metric(tmp_path):

--- a/backend/tests/routes/test_gig_routes.py
+++ b/backend/tests/routes/test_gig_routes.py
@@ -27,13 +27,13 @@ def load_gig_module(monkeypatch):
     # Stub auth dependencies to avoid auth logic during import
     from auth import dependencies as deps
 
-    def fake_require_role(_roles):
+    def fake_require_permission(_roles):
         def _dep():
             return True
 
         return _dep
 
-    deps.require_role = fake_require_role
+    deps.require_permission = fake_require_permission
     deps.get_current_user_id = lambda: 1
 
     # Provide a simple Gig model to bypass SQLAlchemy

--- a/backend/tests/routes/test_merch_routes.py
+++ b/backend/tests/routes/test_merch_routes.py
@@ -8,14 +8,14 @@ import backend.auth.dependencies as auth_dep
 from typing import List
 
 
-def _fake_require_role(_: List[str]):
+def _fake_require_permission(_: List[str]):
     async def _noop() -> None:
         return None
 
     return _noop
 
 
-auth_dep.require_role = _fake_require_role
+auth_dep.require_permission = _fake_require_permission
 
 from routes import merch_routes
 

--- a/backend/tests/video/test_video_routes.py
+++ b/backend/tests/video/test_video_routes.py
@@ -7,12 +7,12 @@ from services.economy_service import EconomyService
 from services.video_service import VideoService
 
 
-async def _require_role_stub(roles, user_id):
+async def _require_permission_stub(roles, user_id):
     return True
 
 
 def setup_services():
-    video_routes.require_role = _require_role_stub
+    video_routes.require_permission = _require_permission_stub
 
     tmp = tempfile.NamedTemporaryFile(delete=False)
     tmp.close()

--- a/tests/admin/test_admin_schema_routes.py
+++ b/tests/admin/test_admin_schema_routes.py
@@ -40,14 +40,14 @@ def test_admin_schema_available(monkeypatch, func):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_schema_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_schema_routes.require_role", fake_require_role
+        "backend.routes.admin_schema_routes.require_permission", fake_require_permission
     )
 
     req = Request({"type": "http", "headers": []})

--- a/tests/admin/test_apprenticeship_routes.py
+++ b/tests/admin/test_apprenticeship_routes.py
@@ -43,14 +43,14 @@ def test_apprenticeship_routes_crud(monkeypatch, tmp_path):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_apprenticeship_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_apprenticeship_routes.require_role", fake_require_role
+        "backend.routes.admin_apprenticeship_routes.require_permission", fake_require_permission
     )
 
     svc.db_path = str(tmp_path / "apprenticeships.db")

--- a/tests/admin/test_online_tutorial_routes.py
+++ b/tests/admin/test_online_tutorial_routes.py
@@ -43,7 +43,7 @@ def test_online_tutorial_routes_crud(monkeypatch, tmp_path):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
@@ -51,7 +51,7 @@ def test_online_tutorial_routes_crud(monkeypatch, tmp_path):
         fake_current_user,
     )
     monkeypatch.setattr(
-        "backend.routes.admin_online_tutorial_routes.require_role", fake_require_role
+        "backend.routes.admin_online_tutorial_routes.require_permission", fake_require_permission
     )
 
     svc.db_path = str(tmp_path / "tutorials.db")

--- a/tests/admin/test_tutor_routes.py
+++ b/tests/admin/test_tutor_routes.py
@@ -41,14 +41,14 @@ def test_tutor_routes_crud(monkeypatch, tmp_path):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
         "backend.routes.admin_tutor_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_tutor_routes.require_role", fake_require_role
+        "backend.routes.admin_tutor_routes.require_permission", fake_require_permission
     )
 
     svc.db_path = str(tmp_path / "tutors.db")

--- a/tests/admin/test_workshop_routes.py
+++ b/tests/admin/test_workshop_routes.py
@@ -44,7 +44,7 @@ def test_workshop_routes_crud(monkeypatch, tmp_path):
     async def fake_current_user(req):
         return 1
 
-    async def fake_require_role(roles, user_id):
+    async def fake_require_permission(roles, user_id):
         return True
 
     monkeypatch.setattr(
@@ -52,8 +52,8 @@ def test_workshop_routes_crud(monkeypatch, tmp_path):
         fake_current_user,
     )
     monkeypatch.setattr(
-        "backend.routes.admin_workshop_routes.require_role",
-        fake_require_role,
+        "backend.routes.admin_workshop_routes.require_permission",
+        fake_require_permission,
     )
 
     svc.db_path = str(tmp_path / "workshops.db")

--- a/tests/test_band_recording_slots.py
+++ b/tests/test_band_recording_slots.py
@@ -15,7 +15,7 @@ import types
 auth_mod = types.ModuleType("auth")
 deps_mod = types.ModuleType("auth.dependencies")
 deps_mod.get_current_user_id = lambda: 1
-deps_mod.require_role = lambda roles: (lambda: None)
+deps_mod.require_permission = lambda roles: (lambda: None)
 auth_mod.dependencies = deps_mod
 sys.modules["auth"] = auth_mod
 sys.modules["auth.dependencies"] = deps_mod


### PR DESCRIPTION
## Summary
- add permissions and role_permissions migrations with seed data
- implement cached permission checks and has_permission helper
- introduce require_permission dependency and update routes/tests to use it

## Testing
- `ruff check .` (fails: many style issues)
- `pytest` (fails: multiple errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68bade896b5083259550544b51152fed