### PR TITLE
Refactor sales and streaming services to use aiosqlite

### DIFF
--- a/backend/routes/sales.py
+++ b/backend/routes/sales.py
@@ -14,12 +14,13 @@ except Exception:  # pragma: no cover
 
         return _noop
 
+import asyncio
 from services.sales_service import SalesError, SalesService
 
 router = APIRouter(prefix="/sales", tags=["Sales"])
 
 svc = SalesService()
-svc.ensure_schema()
+asyncio.run(svc.ensure_schema())
 
 
 class DigitalSaleIn(BaseModel):
@@ -39,7 +40,7 @@ async def record_digital(payload: DigitalSaleIn) -> dict[str, int]:
     """Record a digital song or album sale."""
 
     try:
-        sid = svc.record_digital_sale(**payload.model_dump())
+        sid = await svc.record_digital_sale(**payload.model_dump())
     except SalesError as exc:  # pragma: no cover
         raise HTTPException(status_code=400, detail=str(exc))
     return {"sale_id": sid}
@@ -52,7 +53,7 @@ async def record_digital(payload: DigitalSaleIn) -> dict[str, int]:
 async def list_digital_sales(work_type: str, work_id: int):
     """List digital sales for a work."""
 
-    return svc.list_digital_sales_for_work(work_type, work_id)
+    return await svc.list_digital_sales_for_work(work_type, work_id)
 
 
 class VinylSkuIn(BaseModel):
@@ -80,7 +81,7 @@ class VinylPurchaseIn(BaseModel):
 )
 async def create_vinyl_sku(payload: VinylSkuIn) -> dict[str, int]:
     try:
-        sku_id = svc.create_vinyl_sku(**payload.model_dump())
+        sku_id = await svc.create_vinyl_sku(**payload.model_dump())
     except SalesError as exc:  # pragma: no cover
         raise HTTPException(status_code=400, detail=str(exc))
     return {"sku_id": sku_id}
@@ -91,7 +92,7 @@ async def create_vinyl_sku(payload: VinylSkuIn) -> dict[str, int]:
     dependencies=[Depends(require_role(["band_member", "admin", "moderator"]))],
 )
 async def list_vinyl_skus(album_id: int):
-    return svc.list_vinyl_skus(album_id)
+    return await svc.list_vinyl_skus(album_id)
 
 
 @router.post(
@@ -100,7 +101,7 @@ async def list_vinyl_skus(album_id: int):
 )
 async def purchase_vinyl(payload: VinylPurchaseIn) -> dict[str, int]:
     try:
-        order_id = svc.purchase_vinyl(
+        order_id = await svc.purchase_vinyl(
             buyer_user_id=payload.buyer_user_id,
             items=[i.model_dump() for i in payload.items],
             shipping_address=payload.shipping_address,
@@ -116,7 +117,7 @@ async def purchase_vinyl(payload: VinylPurchaseIn) -> dict[str, int]:
 )
 async def refund_vinyl(order_id: int, reason: str = "") -> dict[str, bool]:
     try:
-        svc.refund_vinyl_order(order_id, reason)
+        await svc.refund_vinyl_order(order_id, reason)
     except SalesError as exc:  # pragma: no cover
         raise HTTPException(status_code=400, detail=str(exc))
     return {"ok": True}

--- a/backend/services/live_album_service.py
+++ b/backend/services/live_album_service.py
@@ -303,13 +303,15 @@ class LiveAlbumService:
         # auxiliary for this service.
         try:
             sales = SalesService(self.db_path)
-            sales.ensure_schema()
-            sales.record_digital_sale(
-                buyer_user_id=0,
-                work_type="album",
-                work_id=release_id,
-                price_cents=0,
-                album_type=album["album_type"],
+            asyncio.run(sales.ensure_schema())
+            asyncio.run(
+                sales.record_digital_sale(
+                    buyer_user_id=0,
+                    work_type="album",
+                    work_id=release_id,
+                    price_cents=0,
+                    album_type=album["album_type"],
+                )
             )
         except Exception:
             pass

--- a/backend/services/streaming_service.py
+++ b/backend/services/streaming_service.py
@@ -1,91 +1,102 @@
-import sqlite3
+# File: backend/services/streaming_service.py
+import aiosqlite
 from datetime import datetime
 from backend.database import DB_PATH
 from backend.services.song_popularity_service import add_event
 
 
-def stream_song(user_id: int, song_id: int) -> dict:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-
-    # Record stream
-    cur.execute("""
-        INSERT INTO streams (user_id, song_id, timestamp)
-        VALUES (?, ?, ?)
-    """, (user_id, song_id, datetime.now()))
-
-    # Increment play count
-    cur.execute("""
-        UPDATE songs
-        SET play_count = play_count + 1
-        WHERE id = ?
-    """, (song_id,))
-
-    # Simulate revenue (e.g., $0.003 per stream)
-    revenue = 0.003
-    cur.execute("""
-        SELECT user_id, percent FROM royalties WHERE song_id = ?
-    """, (song_id,))
-    royalty_rows = cur.fetchall()
-
-    for row in royalty_rows:
-        receiver_id, percent = row
-        amount = revenue * (percent / 100)
-        cur.execute("""
-            INSERT INTO earnings (user_id, source_type, source_id, amount, timestamp)
-            VALUES (?, 'stream', ?, ?, ?)
-        """, (receiver_id, song_id, amount, datetime.now()))
-
-    conn.commit()
-    conn.close()
-
-    # Boost popularity for the streamed song
+async def stream_song(user_id: int, song_id: int) -> dict:
+    conn = await aiosqlite.connect(DB_PATH)
+    try:
+        await conn.execute(
+            """
+            INSERT INTO streams (user_id, song_id, timestamp)
+            VALUES (?, ?, ?)
+            """,
+            (user_id, song_id, datetime.now()),
+        )
+        await conn.execute(
+            """
+            UPDATE songs
+            SET play_count = play_count + 1
+            WHERE id = ?
+            """,
+            (song_id,),
+        )
+        revenue = 0.003
+        cur = await conn.execute(
+            "SELECT user_id, percent FROM royalties WHERE song_id = ?",
+            (song_id,),
+        )
+        royalty_rows = await cur.fetchall()
+        for receiver_id, percent in royalty_rows:
+            amount = revenue * (percent / 100)
+            await conn.execute(
+                """
+                INSERT INTO earnings (user_id, source_type, source_id, amount, timestamp)
+                VALUES (?, 'stream', ?, ?, ?)
+                """,
+                (receiver_id, song_id, amount, datetime.now()),
+            )
+        await conn.commit()
+    finally:
+        await conn.close()
     add_event(song_id, 1.0, "stream")
-
     return {"status": "ok", "revenue": round(revenue, 4)}
 
 
-def get_stream_count(song_id: int) -> int:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute("SELECT COUNT(*) FROM streams WHERE song_id = ?", (song_id,))
-    count = cur.fetchone()[0]
-    conn.close()
-    return count
+async def get_stream_count(song_id: int) -> int:
+    conn = await aiosqlite.connect(DB_PATH)
+    try:
+        cur = await conn.execute(
+            "SELECT COUNT(*) FROM streams WHERE song_id = ?",
+            (song_id,),
+        )
+        row = await cur.fetchone()
+        return int(row[0]) if row else 0
+    finally:
+        await conn.close()
 
 
-def calculate_stream_revenue(song_id: int) -> float:
-    total_streams = get_stream_count(song_id)
+async def calculate_stream_revenue(song_id: int) -> float:
+    total_streams = await get_stream_count(song_id)
     return round(total_streams * 0.003, 2)
 
 
-def list_top_streamed_songs(limit=10) -> list:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute("""
-        SELECT s.id, s.title, s.play_count, b.name
-        FROM songs s
-        JOIN bands b ON s.band_id = b.id
-        ORDER BY s.play_count DESC
-        LIMIT ?
-    """, (limit,))
-    rows = cur.fetchall()
-    conn.close()
+async def list_top_streamed_songs(limit: int = 10) -> list:
+    conn = await aiosqlite.connect(DB_PATH)
+    try:
+        cur = await conn.execute(
+            """
+            SELECT s.id, s.title, s.play_count, b.name
+            FROM songs s
+            JOIN bands b ON s.band_id = b.id
+            ORDER BY s.play_count DESC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+        rows = await cur.fetchall()
+        return [dict(zip(["song_id", "title", "play_count", "band_name"], row)) for row in rows]
+    finally:
+        await conn.close()
 
-    return [dict(zip(["song_id", "title", "play_count", "band_name"], row)) for row in rows]
 
-
-def get_user_stream_history(user_id: int) -> list:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute("""
-        SELECT s.title, str.timestamp
-        FROM streams str
-        JOIN songs s ON str.song_id = s.id
-        WHERE str.user_id = ?
-        ORDER BY str.timestamp DESC
-        LIMIT 50
-    """, (user_id,))
-    rows = cur.fetchall()
-    conn.close()
-    return [dict(zip(["song_title", "timestamp"], row)) for row in rows]
+async def get_user_stream_history(user_id: int) -> list:
+    conn = await aiosqlite.connect(DB_PATH)
+    try:
+        cur = await conn.execute(
+            """
+            SELECT s.title, str.timestamp
+            FROM streams str
+            JOIN songs s ON str.song_id = s.id
+            WHERE str.user_id = ?
+            ORDER BY str.timestamp DESC
+            LIMIT 50
+            """,
+            (user_id,),
+        )
+        rows = await cur.fetchall()
+        return [dict(zip(["song_title", "timestamp"], row)) for row in rows]
+    finally:
+        await conn.close()

--- a/tests/test_live_album_integration.py
+++ b/tests/test_live_album_integration.py
@@ -1,10 +1,12 @@
 import sqlite3
 from pathlib import Path
 import sys
+import asyncio
 
 BASE_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(BASE_DIR))
-sys.path.append(str(BASE_DIR / "backend"))
+sv = sys.path
+sv.append(str(BASE_DIR))
+sv.append(str(BASE_DIR / "backend"))
 
 from backend.services.sales_service import SalesService
 from backend.services.economy_service import EconomyService
@@ -61,8 +63,8 @@ def test_live_album_sale_updates_bank(tmp_path):
         conn.commit()
 
     sales = SalesService(db_path=db, economy=economy)
-    sales.ensure_schema()
-    sales.record_digital_sale(2, "album", 1, 1500, album_type="live")
+    asyncio.run(sales.ensure_schema())
+    asyncio.run(sales.record_digital_sale(2, "album", 1, 1500, album_type="live"))
 
     assert economy.get_balance(1) == 1500
 
@@ -81,8 +83,8 @@ def test_live_album_chart_entry(tmp_path):
         conn.commit()
 
     sales = SalesService(db_path=db, economy=economy)
-    sales.ensure_schema()
-    sales.record_digital_sale(2, "album", 1, 1500, album_type="live")
+    asyncio.run(sales.ensure_schema())
+    asyncio.run(sales.record_digital_sale(2, "album", 1, 1500, album_type="live"))
 
     chart_service.DB_PATH = db
     fame = DummyFameService()

--- a/tests/test_sales_concurrency.py
+++ b/tests/test_sales_concurrency.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from backend.services.sales_service import SalesService, SalesError
+from backend.services.economy_service import EconomyService
+
+
+def test_concurrent_vinyl_purchase(tmp_path):
+    async def run():
+        db = tmp_path / "sales.db"
+        economy = EconomyService(db_path=db)
+        economy.ensure_schema()
+
+        sales = SalesService(db_path=db, economy=economy)
+        await sales.ensure_schema()
+        sku_id = await sales.create_vinyl_sku(album_id=1, variant="std", price_cents=1000, stock_qty=1)
+
+        async def purchase():
+            return await sales.purchase_vinyl(
+                buyer_user_id=1, items=[{"sku_id": sku_id, "qty": 1}]
+            )
+
+        results = await asyncio.gather(purchase(), purchase(), return_exceptions=True)
+        success = [r for r in results if isinstance(r, int)]
+        failures = [r for r in results if isinstance(r, SalesError)]
+        assert len(success) == 1
+        assert len(failures) == 1
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- replace raw sqlite3 access with aiosqlite in sales and streaming services
- update sales API routes and live album publisher to await async DB operations
- add concurrency-focused vinyl purchase test exercising async implementation

## Testing
- `pytest tests/test_live_album_integration.py tests/test_sales_concurrency.py`
- `pytest` *(fails: OperationalError unable to open database file and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68badf9bdc108325adc17978ff1d2d78