### PR TITLE
Add tests for streaming revenue and vinyl order workflows

### DIFF
--- a/tests/test_streaming_service.py
+++ b/tests/test_streaming_service.py
@@ -1,0 +1,104 @@
+import sqlite3
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+from backend import database
+
+
+def _setup_db(tmp_path):
+    db = tmp_path / "streaming.sqlite"
+    database.DB_PATH = str(db)
+
+    import backend.services.song_popularity_service as sps
+    import backend.services.streaming_service as ss
+    sps.DB_PATH = str(db)
+    ss.DB_PATH = str(db)
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE songs (
+            id INTEGER PRIMARY KEY,
+            title TEXT,
+            play_count INTEGER DEFAULT 0
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE streams (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            song_id INTEGER,
+            timestamp TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE royalties (
+            song_id INTEGER,
+            user_id INTEGER,
+            percent REAL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE earnings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            source_type TEXT,
+            source_id INTEGER,
+            amount REAL,
+            timestamp TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    return ss
+
+
+def test_stream_song_revenue_and_play_counts(tmp_path):
+    streaming_service = _setup_db(tmp_path)
+
+    conn = sqlite3.connect(database.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("INSERT INTO songs (id, title, play_count) VALUES (1, 'Song A', 0)")
+    cur.executemany(
+        "INSERT INTO royalties (song_id, user_id, percent) VALUES (1, ?, ?)",
+        [(10, 60), (20, 40)],
+    )
+    conn.commit()
+    conn.close()
+
+    result = streaming_service.stream_song(user_id=5, song_id=1)
+    assert result == {"status": "ok", "revenue": 0.003}
+
+    conn = sqlite3.connect(database.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT play_count FROM songs WHERE id = 1")
+    play_count = cur.fetchone()[0]
+    cur.execute(
+        "SELECT COUNT(*) FROM streams WHERE song_id = 1 AND user_id = 5"
+    )
+    stream_count = cur.fetchone()[0]
+    cur.execute(
+        "SELECT user_id, amount FROM earnings WHERE source_type = 'stream' AND source_id = 1 ORDER BY user_id"
+    )
+    earnings = cur.fetchall()
+    conn.close()
+
+    assert play_count == 1
+    assert stream_count == 1
+    assert earnings[0][0] == 10
+    assert earnings[1][0] == 20
+    assert earnings[0][1] == pytest.approx(0.0018)
+    assert earnings[1][1] == pytest.approx(0.0012)

--- a/tests/test_vinyl_orders.py
+++ b/tests/test_vinyl_orders.py
@@ -1,0 +1,56 @@
+import sqlite3
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+from backend.services.sales_service import SalesService
+
+
+def _create_service(tmp_path):
+    db = tmp_path / "sales.sqlite"
+    svc = SalesService(db_path=str(db))
+    svc.ensure_schema()
+    return db, svc
+
+
+def test_purchase_and_refund_vinyl_order(tmp_path):
+    db, svc = _create_service(tmp_path)
+
+    sku_id = svc.create_vinyl_sku(album_id=1, variant="standard", price_cents=1500, stock_qty=5)
+
+    order_id = svc.purchase_vinyl(
+        buyer_user_id=42,
+        items=[{"sku_id": sku_id, "qty": 2}],
+        shipping_address="123 Main St",
+    )
+
+    with sqlite3.connect(db) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT total_cents, status FROM vinyl_orders WHERE id = ?", (order_id,))
+        assert cur.fetchone() == (3000, "confirmed")
+        cur.execute(
+            "SELECT sku_id, qty FROM vinyl_order_items WHERE order_id = ?",
+            (order_id,),
+        )
+        assert cur.fetchone() == (sku_id, 2)
+
+    result = svc.refund_vinyl_order(order_id, reason="defective")
+    assert result == {"order_id": order_id, "refunded_cents": 3000}
+
+    with sqlite3.connect(db) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT status FROM vinyl_orders WHERE id = ?", (order_id,))
+        assert cur.fetchone()[0] == "refunded"
+        cur.execute(
+            "SELECT refunded_qty FROM vinyl_order_items WHERE order_id = ?",
+            (order_id,),
+        )
+        assert cur.fetchone()[0] == 2
+        cur.execute(
+            "SELECT amount_cents, reason FROM vinyl_refunds WHERE order_id = ?",
+            (order_id,),
+        )
+        assert cur.fetchone() == (3000, "defective")
+


### PR DESCRIPTION
## Summary
- add regression test for `stream_song` to ensure play counts and royalty earnings update
- cover `purchase_vinyl` and `refund_vinyl_order` flows with temporary SQLite DBs

## Testing
- `pytest tests/test_streaming_service.py tests/test_vinyl_orders.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bae17588608325ba2b6a31553f0f7f