### PR TITLE
feat: add drug inventory support

### DIFF
--- a/backend/models/drug.py
+++ b/backend/models/drug.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .item import Item
+
+
+@dataclass
+class Drug(Item):
+    """Specialised :class:`Item` with drug-specific attributes."""
+
+    effects: List[str] = field(default_factory=list)
+    addiction_rate: float = 0.0
+    duration: int = 0
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        # Ensure drug attributes are mirrored in stats for persistence
+        self.stats.setdefault("effects", self.effects)
+        self.stats.setdefault("addiction_rate", self.addiction_rate)
+        self.stats.setdefault("duration", self.duration)
+
+
+__all__ = ["Drug"]

--- a/backend/routes/shop_routes.py
+++ b/backend/routes/shop_routes.py
@@ -10,6 +10,7 @@ from backend.services.item_service import item_service
 from backend.services.loyalty_service import loyalty_service
 from backend.services.membership_service import membership_service
 from backend.services.shop_npc_service import shop_npc_service
+from backend.services.city_shop_service import city_shop_service
 
 router = APIRouter(prefix="/shop", tags=["Shop"])
 
@@ -121,6 +122,22 @@ def sell_item(shop_id: int, item_id: int, payload: SellIn, user_id: int = Depend
     return {"status": "ok", "payout_cents": payout}
 
 
+@router.post("/city/{shop_id}/drugs/{drug_id}/purchase")
+def purchase_drug(
+    shop_id: int,
+    drug_id: int,
+    payload: PurchaseIn,
+    user_id: int = Depends(_current_user),
+):
+    try:
+        total = shop_npc_service.purchase_drug(
+            shop_id, user_id, drug_id, payload.quantity
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok", "total_cents": total}
+
+
 @router.post("/city/{shop_id}/bundles/{bundle_id}/purchase")
 def purchase_bundle(
     shop_id: int,
@@ -170,6 +187,15 @@ def purchase_book(book_id: int, payload: PurchaseIn, user_id: int = Depends(_cur
 def sell_book(shop_id: int, book_id: int, payload: SellIn, user_id: int = Depends(_current_user)):
     try:
         payout = city_shop_service.sell_book(shop_id, user_id, book_id, payload.quantity)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok", "payout_cents": payout}
+
+
+@router.post("/city/{shop_id}/drugs/{drug_id}/sell")
+def sell_drug(shop_id: int, drug_id: int, payload: SellIn, user_id: int = Depends(_current_user)):
+    try:
+        payout = city_shop_service.sell_drug(shop_id, user_id, drug_id, payload.quantity)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     return {"status": "ok", "payout_cents": payout}

--- a/backend/services/shop_npc_service.py
+++ b/backend/services/shop_npc_service.py
@@ -5,6 +5,8 @@ from typing import Dict, List, Optional
 
 from backend.models.npc_dialogue import DialogueNode, DialogueResponse, DialogueTree
 from backend.services.npc_service import NPCService
+from backend.services.city_shop_service import CityShopService, city_shop_service
+from backend.services.item_service import item_service as default_item_service, ItemService
 
 
 class ShopNPCService:
@@ -16,15 +18,26 @@ class ShopNPCService:
     tests and the demo front end.
     """
 
-    def __init__(self, npc_service: Optional[NPCService] = None):
+    def __init__(
+        self,
+        npc_service: Optional[NPCService] = None,
+        shop_service: Optional[CityShopService] = None,
+        item_service: Optional[ItemService] = None,
+    ):
         self._npc_service = npc_service or NPCService()
+        self._shop_service = shop_service or city_shop_service
+        self._item_service = item_service or default_item_service
         # create a default shop NPC with a tiny dialogue tree
         tree = self._default_dialogue()
         dialogue = tree.dict()
         npc = self._npc_service.create_npc("Shopkeeper", "merchant", dialogue_hooks=dialogue)
         self._npc_id = npc["id"]
-        # keep a copy of the tree so we can expose specific nodes later
         self._dialogue_tree = tree
+        # add a simple drug dealer NPC
+        dealer_tree = self._dealer_dialogue()
+        dealer = self._npc_service.create_npc("Dealer", "merchant", dialogue_hooks=dealer_tree.dict())
+        self._dealer_id = dealer["id"]
+        self._dealer_tree = dealer_tree
         # rotating promotions
         self._promotions: List[Dict[str, str]] = [
             {"item": "Guitar Strings", "description": "10% off all strings today!"},
@@ -72,28 +85,30 @@ class ShopNPCService:
             },
         )
 
-    # ------------------------------------------------------------------
-    def get_dialogue(self, choices: Optional[List[int]] = None) -> Dict[str, List[str]]:
-        """Return dialogue lines and response options following ``choices``.
+    def _dealer_dialogue(self) -> DialogueTree:
+        return DialogueTree(
+            root="start",
+            nodes={
+                "start": DialogueNode(
+                    id="start",
+                    text="Looking for something... special?",
+                    responses=[
+                        DialogueResponse(text="What do you have?", next_id="end"),
+                        DialogueResponse(text="No thanks.", next_id="end"),
+                    ],
+                ),
+                "end": DialogueNode(id="end", text="Stay safe out there."),
+            },
+        )
 
-        Args:
-            choices: optional sequence of response indices indicating the path
-                taken through the dialogue tree.
-
-        Returns:
-            Dict containing ``lines`` encountered so far and the available
-            ``options`` for the next step. If the dialogue has ended the
-            options list will be empty.
-        """
-
+    def _run_dialogue(
+        self, npc_id: int, tree: DialogueTree, choices: Optional[List[int]]
+    ) -> Dict[str, List[str]]:
         choices = choices or []
-        npc = self._npc_service.db.get(self._npc_id)
+        npc = self._npc_service.db.get(npc_id)
         if not npc or not npc.dialogue_hooks:
             return {"lines": [], "options": []}
-        tree = DialogueTree(**npc.dialogue_hooks)
         lines = tree.traverse(choices)
-
-        # determine current node after choices to expose available responses
         current = tree.nodes.get(tree.root)
         for idx in choices:
             if not current or idx < 0 or idx >= len(current.responses):
@@ -104,11 +119,41 @@ class ShopNPCService:
                 current = None
                 break
             current = tree.nodes.get(resp.next_id)
-
         options: List[str] = []
         if current:
             options = [resp.text for resp in current.responses]
         return {"lines": lines, "options": options}
+
+    # ------------------------------------------------------------------
+    def get_dialogue(self, choices: Optional[List[int]] = None) -> Dict[str, List[str]]:
+        """Return dialogue lines and response options for the shop keeper."""
+
+        return self._run_dialogue(self._npc_id, self._dialogue_tree, choices)
+
+    def get_dealer_dialogue(
+        self, choices: Optional[List[int]] = None
+    ) -> Dict[str, List[str]]:
+        """Return dialogue lines and options for the drug dealer NPC."""
+
+        return self._run_dialogue(self._dealer_id, self._dealer_tree, choices)
+
+    def list_drug_offers(self, shop_id: int) -> List[Dict[str, int]]:
+        """Expose available drug items in a shop."""
+
+        return self._shop_service.list_drugs(shop_id)
+
+    def purchase_drug(
+        self, shop_id: int, user_id: int, drug_id: int, quantity: int = 1
+    ) -> int:
+        """Delegate purchase of a drug item enforcing simple restrictions."""
+
+        item = self._item_service.get_item(drug_id)
+        if item.category != "drug":
+            raise ValueError("not a drug")
+        addiction = float(item.stats.get("addiction_rate", 0))
+        if addiction > 0.5 and quantity > 1:
+            raise ValueError("purchase limit exceeded")
+        return self._shop_service.purchase_drug(shop_id, user_id, drug_id, quantity)
 
     # ------------------------------------------------------------------
     def get_haggle_dialogue(self, success: bool) -> Dict[str, List[str]]:

--- a/backend/tests/test_drug_transactions.py
+++ b/backend/tests/test_drug_transactions.py
@@ -1,0 +1,78 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routes import shop_routes
+from services.item_service import ItemService
+from services.city_shop_service import CityShopService
+from services.loyalty_service import LoyaltyService
+from services.membership_service import MembershipService
+from services.shop_npc_service import ShopNPCService
+from services.npc_service import NPCService
+from services.economy_service import EconomyService
+from models.item import ItemCategory
+from models.drug import Drug
+
+
+def create_app(tmp_path):
+    db = tmp_path / "test.db"
+    item_svc = ItemService(str(db))
+    city_svc = CityShopService(str(db))
+    loyalty = LoyaltyService(str(db))
+    membership = MembershipService(str(db))
+    economy = EconomyService(str(db))
+    economy.ensure_schema()
+    npc_svc = NPCService()
+    npc_shop = ShopNPCService(npc_svc, city_svc, item_svc)
+
+    shop_routes.item_service = item_svc
+    shop_routes.city_shop_service = city_svc
+    shop_routes.loyalty_service = loyalty
+    shop_routes.membership_service = membership
+    shop_routes.shop_npc_service = npc_shop
+    shop_routes._economy = economy
+    # ensure city shop service uses the test item service
+    from services import city_shop_service as city_module
+
+    city_module.item_service = item_svc
+    city_module._economy = economy
+
+    app = FastAPI()
+    app.include_router(shop_routes.router)
+    app.dependency_overrides[shop_routes._current_user] = lambda: 1
+    return app, item_svc, city_svc, economy
+
+
+def test_purchase_drug(tmp_path):
+    app, item_svc, city_svc, economy = create_app(tmp_path)
+    client = TestClient(app)
+
+    # create category and drug item
+    item_svc.create_category(ItemCategory("drug", "Drugs"))
+    drug = Drug(
+        id=None,
+        name="Joy Pill",
+        category="drug",
+        effects=["happiness"],
+        addiction_rate=0.6,
+        duration=10,
+        price_cents=100,
+        stock=10,
+    )
+    item_svc.create_item(drug)
+
+    # create shop and add drug
+    shop = city_svc.create_shop("NYC", "Underground", owner_user_id=2)
+    city_svc.add_drug(shop["id"], drug.id, quantity=5, price_cents=drug.price_cents)
+    # ensure price remains stable for test
+    city_svc.update_drug(shop["id"], drug.id, price_cents=drug.price_cents)
+
+    economy.deposit(1, 1000)
+
+    r = client.post(
+        f"/shop/city/{shop['id']}/drugs/{drug.id}/purchase",
+        json={"owner_user_id": 2, "quantity": 1},
+    )
+    assert r.status_code == 200
+    assert r.json()["total_cents"] == 100
+    inv = item_svc.get_inventory_item(1, drug.id)
+    assert inv["quantity"] == 1


### PR DESCRIPTION
## Summary
- add Drug model with effects, addiction rate and duration
- allow city shops and NPCs to trade drug items
- test purchasing drug items from NPCs

## Testing
- `pytest backend/tests/test_drug_transactions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bae6f3c2808325937ad8eb96fcae45