### PR TITLE
Add addiction mechanics with related events

### DIFF
--- a/backend/models/addiction.py
+++ b/backend/models/addiction.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class Addiction(BaseModel):
+    """Represents a user's addiction to a particular substance."""
+
+    user_id: int
+    substance: str
+    level: int = 0
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    def touch(self) -> None:
+        now = datetime.utcnow()
+        if self.created_at is None:
+            self.created_at = now
+        self.updated_at = now
+
+
+__all__ = ["Addiction"]

--- a/backend/models/daily_schedule.py
+++ b/backend/models/daily_schedule.py
@@ -39,6 +39,17 @@ def remove_entry(user_id: int, date: str, slot: int) -> None:
         conn.commit()
 
 
+def clear_day(user_id: int, date: str) -> None:
+    """Remove all schedule entries for a user on a given day."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "DELETE FROM daily_schedule WHERE user_id = ? AND date = ?",
+            (user_id, date),
+        )
+        conn.commit()
+
+
 def find_conflicts(
     user_id: int, date: str, start_slot: int, duration_slots: int
 ) -> List[int]:
@@ -101,4 +112,11 @@ def get_schedule(user_id: int, date: str) -> List[Dict]:
     ]
 
 
-__all__ = ["add_entry", "update_entry", "remove_entry", "find_conflicts", "get_schedule"]
+__all__ = [
+    "add_entry",
+    "update_entry",
+    "remove_entry",
+    "clear_day",
+    "find_conflicts",
+    "get_schedule",
+]

--- a/backend/models/random_events.py
+++ b/backend/models/random_events.py
@@ -20,3 +20,12 @@ class ActiveEvent(BaseModel):
     skill_affected: Optional[str]
     start_date: date
     duration_days: int
+
+# Events related to addiction mechanics
+ADDICTION_EVENTS = [
+    "missed_event",
+    "overdose",
+    "police_intervention",
+]
+
+__all__ = ["Event", "ActiveEvent", "ADDICTION_EVENTS"]

--- a/backend/services/addiction_service.py
+++ b/backend/services/addiction_service.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from backend.database import DB_PATH
+
+
+class AddictionService:
+    """Basic persistence and logic for user addictions."""
+
+    def __init__(self, db_path: str | Path = DB_PATH):
+        self.db_path = str(db_path)
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS addiction (
+                    user_id INTEGER NOT NULL,
+                    substance TEXT NOT NULL,
+                    level INTEGER NOT NULL DEFAULT 0,
+                    last_used TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (user_id, substance)
+                )
+                """
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def use(self, user_id: int, substance: str, amount: int = 10) -> int:
+        """Record substance use and increase addiction level."""
+
+        now = datetime.utcnow().isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT level FROM addiction WHERE user_id = ? AND substance = ?",
+                (user_id, substance),
+            )
+            row = cur.fetchone()
+            if row:
+                level = min(100, row[0] + amount)
+                cur.execute(
+                    """UPDATE addiction
+                    SET level = ?, last_used = ?, updated_at = ?
+                    WHERE user_id = ? AND substance = ?""",
+                    (level, now, now, user_id, substance),
+                )
+            else:
+                level = min(100, amount)
+                cur.execute(
+                    """INSERT INTO addiction
+                    (user_id, substance, level, last_used, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?)""",
+                    (user_id, substance, level, now, now, now),
+                )
+            conn.commit()
+        return level
+
+    def apply_withdrawal(self, user_id: int, decay: int = 5) -> None:
+        """Apply daily withdrawal decay to all addictions."""
+
+        now = datetime.utcnow().isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT substance, level FROM addiction WHERE user_id = ?",
+                (user_id,),
+            )
+            rows = cur.fetchall()
+            for substance, level in rows:
+                new_level = max(0, level - decay)
+                cur.execute(
+                    """UPDATE addiction
+                    SET level = ?, updated_at = ?
+                    WHERE user_id = ? AND substance = ?""",
+                    (new_level, now, user_id, substance),
+                )
+            conn.commit()
+
+    def get_level(self, user_id: int, substance: str) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT level FROM addiction WHERE user_id = ? AND substance = ?",
+                (user_id, substance),
+            )
+            row = cur.fetchone()
+            return row[0] if row else 0
+
+    def get_highest_level(self, user_id: int) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT MAX(level) FROM addiction WHERE user_id = ?",
+                (user_id,),
+            )
+            row = cur.fetchone()
+            return row[0] if row and row[0] is not None else 0
+
+
+# Singleton instance
+addiction_service = AddictionService()

--- a/tests/test_addiction.py
+++ b/tests/test_addiction.py
@@ -1,0 +1,60 @@
+
+import types, sys, os
+from backend.services import addiction_service as global_addiction_service
+
+# Provide a minimal seeds.skill_seed stub required by random_event_service imports
+skill_seed = types.SimpleNamespace(SKILL_NAME_TO_ID={})
+sys.modules.setdefault("seeds", types.SimpleNamespace(skill_seed=skill_seed))
+sys.modules.setdefault("seeds.skill_seed", skill_seed)
+
+# Stub for notifications_service dependency
+discord_stub = types.SimpleNamespace(
+    DiscordServiceError=Exception, send_message=lambda *args, **kwargs: None
+)
+sys.modules.setdefault("services", types.SimpleNamespace(discord_service=discord_stub))
+sys.modules.setdefault("services.discord_service", discord_stub)
+# Minimal utils.db stub
+sys.modules.setdefault("utils", types.SimpleNamespace(db=types.SimpleNamespace(get_conn=lambda: None)))
+sys.modules.setdefault("utils.db", types.SimpleNamespace(get_conn=lambda: None))
+
+import backend.services.random_event_service as random_event_module
+from backend.services.random_event_service import random_event_service
+
+
+def _service(tmp_path, monkeypatch):
+    db_file = tmp_path / "addiction.db"
+    svc = global_addiction_service.AddictionService(db_path=str(db_file))
+    monkeypatch.setattr(global_addiction_service, "addiction_service", svc)
+    return svc
+
+
+def test_addiction_accumulation(tmp_path, monkeypatch):
+    svc = _service(tmp_path, monkeypatch)
+    level1 = svc.use(1, "drug", amount=20)
+    level2 = svc.use(1, "drug", amount=30)
+    assert level1 == 20
+    assert level2 == 50
+
+
+def test_withdrawal_reduces_level(tmp_path, monkeypatch):
+    svc = _service(tmp_path, monkeypatch)
+    svc.use(1, "drug", amount=40)
+    svc.apply_withdrawal(1, decay=10)
+    assert svc.get_level(1, "drug") == 30
+
+
+def test_negative_event_trigger(tmp_path, monkeypatch):
+    svc = _service(tmp_path, monkeypatch)
+    monkeypatch.setattr(random_event_module, "addiction_service", svc)
+    monkeypatch.setattr(random_event_service, "db", None)
+    called = []
+
+    def fake_clear(user_id, day):
+        called.append((user_id, day))
+
+    monkeypatch.setattr(random_event_module, "clear_day", fake_clear)
+
+    svc.use(1, "drug", amount=80)
+    event = random_event_service.trigger_addiction_event(1, date="2024-01-01")
+    assert event["type"] == "police_intervention"
+    assert called == [(1, "2024-01-01")]


### PR DESCRIPTION
## Summary
- track user addiction levels and withdrawals
- trigger overdose, police intervention, or missed events and clear schedules
- apply addiction penalties during lifestyle decay
- add tests for addiction progression and negative events

## Testing
- `PYTHONPATH=. pytest tests/test_addiction.py`


------
https://chatgpt.com/codex/tasks/task_e_68bae90283c48325a527e59a550bfe79