### PR TITLE
Ensure lifestyle scheduler shares DB connection

### DIFF
--- a/backend/services/lifestyle_scheduler.py
+++ b/backend/services/lifestyle_scheduler.py
@@ -139,14 +139,15 @@ def apply_lifestyle_decay_and_xp_effects() -> int:
                 "nutrition": nutrition,
                 "fitness": fitness,
             }
-            grant_daily_xp(user_id, data)
+            grant_daily_xp(user_id, data, conn)
+
+            conn.commit()
 
             # Daily lifestyle decay affects skills slightly
             skill_service.apply_daily_decay(user_id)
 
             count += 1
 
-        conn.commit()
         return count
 
 # Optional: simulate daily task

--- a/backend/services/lifestyle_service.py
+++ b/backend/services/lifestyle_service.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 import random
+import sqlite3
 
 from .skill_service import skill_service
 from .xp_reward_service import xp_reward_service
@@ -84,7 +85,9 @@ def apply_recovery_action(user_id: int, data: dict, action: str) -> dict:
     return data
 
 
-def grant_daily_xp(user_id: int, data: dict) -> int:
+def grant_daily_xp(
+    user_id: int, data: dict, conn: sqlite3.Connection | None = None
+) -> int:
     """Grant daily XP based on the user's lifestyle score.
 
     The ``xp_reward_service`` is used to award XP scaled by the calculated
@@ -97,7 +100,9 @@ def grant_daily_xp(user_id: int, data: dict) -> int:
     # Scale 0-100 score into a small XP reward range (0-20)
     amount = max(0, int(score / 5))
     try:
-        xp_reward_service.grant_hidden_xp(user_id, reason="lifestyle", amount=amount)
+        xp_reward_service.grant_hidden_xp(
+            user_id, reason="lifestyle", amount=amount, conn=conn
+        )
     except Exception:
         pass
     return amount

--- a/backend/services/xp_reward_service.py
+++ b/backend/services/xp_reward_service.py
@@ -42,7 +42,7 @@ class XPRewardService:
             )
             if cur.fetchone():
                 cur.execute(
-                    "SELECT created_at FROM accounts WHERE user_id = ?", (user_id,)
+                    "SELECT created_at FROM accounts WHERE user_id = ?", (user_id,),
                 )
                 row = cur.fetchone()
                 if row is None:
@@ -63,7 +63,7 @@ class XPRewardService:
             )
             if cur.fetchone():
                 cur.execute(
-                    "SELECT level FROM user_levels WHERE user_id = ?", (user_id,)
+                    "SELECT level FROM user_levels WHERE user_id = ?", (user_id,),
                 )
                 row = cur.fetchone()
                 if row and int(row[0]) <= 5:
@@ -73,7 +73,13 @@ class XPRewardService:
         return False
 
     # ------------------------------------------------------------------
-    def grant_hidden_xp(self, user_id: int, reason: str, amount: int = 10) -> bool:
+    def grant_hidden_xp(
+        self,
+        user_id: int,
+        reason: str,
+        amount: int = 10,
+        conn: sqlite3.Connection | None = None,
+    ) -> bool:
         """Grant hidden XP to the given user if they qualify.
 
         Parameters
@@ -84,38 +90,66 @@ class XPRewardService:
             Context for auditing, e.g. ``gift`` or ``transfer``.
         amount:
             Amount of XP to award. Defaults to 10.
+        conn:
+            Optional existing SQLite connection to use. When provided, the
+            caller is responsible for committing.
         Returns
         -------
         bool
             ``True`` if XP was granted, ``False`` otherwise.
         """
-        with sqlite3.connect(self.db_path) as conn:
-            cur = conn.cursor()
-            self._ensure_schema(cur)
-            if not self._is_new_or_low_level(cur, user_id):
-                return False
-            cur.execute(
-                "INSERT INTO hidden_xp_rewards (user_id, amount, reason) VALUES (?, ?, ?)",
-                (user_id, amount, reason),
-            )
-            # Update user_xp table if present
-            try:
+        if conn is None:
+            with sqlite3.connect(self.db_path) as conn:
+                cur = conn.cursor()
+                self._ensure_schema(cur)
+                if not self._is_new_or_low_level(cur, user_id):
+                    return False
                 cur.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name='user_xp'"
+                    "INSERT INTO hidden_xp_rewards (user_id, amount, reason) VALUES (?, ?, ?)",
+                    (user_id, amount, reason),
                 )
-                if cur.fetchone():
+                try:
                     cur.execute(
-                        """
-                        INSERT INTO user_xp(user_id, xp)
-                        VALUES (?, ?)
-                        ON CONFLICT(user_id) DO UPDATE SET xp = xp + excluded.xp
-                        """,
-                        (user_id, amount),
+                        "SELECT name FROM sqlite_master WHERE type='table' AND name='user_xp'",
                     )
-            except Exception:
-                pass
-            conn.commit()
-            return True
+                    if cur.fetchone():
+                        cur.execute(
+                            """
+                            INSERT INTO user_xp(user_id, xp)
+                            VALUES (?, ?)
+                            ON CONFLICT(user_id) DO UPDATE SET xp = xp + excluded.xp
+                            """,
+                            (user_id, amount),
+                        )
+                except Exception:
+                    pass
+                conn.commit()
+                return True
+
+        cur = conn.cursor()
+        self._ensure_schema(cur)
+        if not self._is_new_or_low_level(cur, user_id):
+            return False
+        cur.execute(
+            "INSERT INTO hidden_xp_rewards (user_id, amount, reason) VALUES (?, ?, ?)",
+            (user_id, amount, reason),
+        )
+        try:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='user_xp'",
+            )
+            if cur.fetchone():
+                cur.execute(
+                    """
+                    INSERT INTO user_xp(user_id, xp)
+                    VALUES (?, ?)
+                    ON CONFLICT(user_id) DO UPDATE SET xp = xp + excluded.xp
+                    """,
+                    (user_id, amount),
+                )
+        except Exception:
+            pass
+        return True
 
     # ------------------------------------------------------------------
     def grant_daily_reward(self, user_id: int, tier: int) -> bool:
@@ -130,3 +164,4 @@ class XPRewardService:
 xp_reward_service = XPRewardService()
 
 __all__ = ["XPRewardService", "xp_reward_service"]
+

--- a/tests/test_lifestyle_scheduler.py
+++ b/tests/test_lifestyle_scheduler.py
@@ -1,0 +1,65 @@
+import sqlite3
+from datetime import datetime
+
+from backend.services import lifestyle_scheduler, xp_reward_service
+
+
+def test_scheduler_applies_xp_without_lock(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+
+    monkeypatch.setattr(lifestyle_scheduler, "DB_PATH", db_path)
+    monkeypatch.setattr(xp_reward_service.xp_reward_service, "db_path", str(db_path))
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE lifestyle (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            sleep_hours REAL,
+            drinking TEXT,
+            stress REAL,
+            training_discipline REAL,
+            mental_health REAL,
+            nutrition REAL,
+            fitness REAL,
+            last_updated TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE xp_modifiers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            modifier REAL NOT NULL,
+            date TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE user_levels (
+            user_id INTEGER PRIMARY KEY,
+            level INTEGER NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        "INSERT INTO lifestyle (user_id, sleep_hours, drinking, stress, training_discipline, mental_health, nutrition, fitness, last_updated) VALUES (?,?,?,?,?,?,?,?,?)",
+        (1, 8, "none", 10, 50, 70, 50, 50, datetime.utcnow().isoformat()),
+    )
+    cur.execute("INSERT INTO user_levels (user_id, level) VALUES (?, ?)", (1, 1))
+    conn.commit()
+    conn.close()
+
+    # Should not raise "database is locked" and should award XP
+    assert lifestyle_scheduler.apply_lifestyle_decay_and_xp_effects() == 1
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT amount FROM hidden_xp_rewards WHERE user_id = ?", (1,))
+    assert cur.fetchone() is not None
+    conn.close()
+

--- a/tests/test_lifestyle_xp.py
+++ b/tests/test_lifestyle_xp.py
@@ -4,7 +4,7 @@ from backend.services import lifestyle_service
 def _collect(monkeypatch):
     awarded = []
 
-    def fake_grant(user_id, reason, amount):
+    def fake_grant(user_id, reason, amount, conn=None):
         awarded.append(amount)
         return True
 


### PR DESCRIPTION
## Summary
- Commit lifestyle data and XP writes per-user within `apply_lifestyle_decay_and_xp_effects`
- Allow `grant_daily_xp` and `grant_hidden_xp` to use a provided SQLite connection
- Add regression test verifying scheduler awards XP without database lock

## Testing
- `PYTHONPATH=. pytest tests/test_lifestyle_xp.py tests/test_lifestyle_scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68baec1b1db883259433909b738252a1