### PR TITLE
Add lifestyle metrics and drug schema

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -59,6 +59,9 @@ def init_db():
             mental_health REAL DEFAULT 100.0,
             nutrition REAL DEFAULT 70.0,
             fitness REAL DEFAULT 70.0,
+            appearance_score REAL DEFAULT 50.0,
+            exercise_minutes REAL DEFAULT 0.0,
+            last_exercise TEXT,
             last_updated TEXT,
             FOREIGN KEY(user_id) REFERENCES users(id)
         )
@@ -552,6 +555,40 @@ def init_db():
                 user_id INTEGER PRIMARY KEY,
                 energy INTEGER NOT NULL DEFAULT 100,
                 FOREIGN KEY(user_id) REFERENCES users(id)
+            )
+            """
+        )
+
+        # Substance tracking
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS drug_categories (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS drugs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                category_id INTEGER NOT NULL,
+                description TEXT,
+                FOREIGN KEY(category_id) REFERENCES drug_categories(id)
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS addictions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                drug_id INTEGER NOT NULL,
+                severity INTEGER NOT NULL DEFAULT 0,
+                started_at TEXT DEFAULT (datetime('now')),
+                FOREIGN KEY(user_id) REFERENCES users(id),
+                FOREIGN KEY(drug_id) REFERENCES drugs(id)
             )
             """
         )

--- a/backend/db/README.md
+++ b/backend/db/README.md
@@ -1,0 +1,12 @@
+# Database Migrations
+
+This package contains lightweight SQL migrations for the SQLite database
+used by Rockmundo.  Migrations are stored in the `migrations/` directory
+and executed in filename order by `apply_migrations`.
+
+## New schema additions
+
+- **Lifestyle:** Added `appearance_score`, `exercise_minutes`, and
+  `last_exercise` columns for tracking player wellbeing.
+- **Drug system:** Introduced `drug_categories`, `drugs`, and
+  `addictions` tables to model substances and player dependencies.

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -1,0 +1,47 @@
+"""Simple SQLite migration runner for Rockmundo.
+
+This module applies SQL files stored in the ``migrations`` directory in
+filename order.  A ``schema_migrations`` table tracks which scripts have
+been executed so migrations are idempotent.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+MIGRATIONS_DIR = Path(__file__).resolve() / "migrations"
+
+
+def _iter_migrations() -> Iterable[Path]:
+    """Yield migration files in sorted order."""
+    return sorted(MIGRATIONS_DIR.glob("*.sql"))
+
+
+def apply_migrations(db_path: Path | None = None) -> None:
+    """Apply any pending migrations to the SQLite database.
+
+    Parameters
+    ----------
+    db_path:
+        Optional path to the SQLite database file.  When omitted, the default
+        ``rockmundo.db`` alongside the backend package is used.
+    """
+    path = Path(db_path or DB_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS schema_migrations (filename TEXT PRIMARY KEY)"
+        )
+        applied = {row[0] for row in cur.execute("SELECT filename FROM schema_migrations")}
+        for migration in _iter_migrations():
+            if migration.name in applied:
+                continue
+            cur.executescript(migration.read_text())
+            cur.execute(
+                "INSERT INTO schema_migrations (filename) VALUES (?)",
+                (migration.name,),
+            )
+        conn.commit()

--- a/backend/db/migrations/170_lifestyle_exercise.sql
+++ b/backend/db/migrations/170_lifestyle_exercise.sql
@@ -1,0 +1,8 @@
+-- File: backend/db/migrations/170_lifestyle_exercise.sql
+BEGIN;
+
+ALTER TABLE lifestyle ADD COLUMN appearance_score REAL DEFAULT 50.0;
+ALTER TABLE lifestyle ADD COLUMN exercise_minutes REAL DEFAULT 0.0;
+ALTER TABLE lifestyle ADD COLUMN last_exercise TEXT;
+
+COMMIT;

--- a/backend/db/migrations/180_drug_tables.sql
+++ b/backend/db/migrations/180_drug_tables.sql
@@ -1,0 +1,27 @@
+-- File: backend/db/migrations/180_drug_tables.sql
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS drug_categories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS drugs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    category_id INTEGER NOT NULL,
+    description TEXT,
+    FOREIGN KEY (category_id) REFERENCES drug_categories(id)
+);
+
+CREATE TABLE IF NOT EXISTS addictions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    drug_id INTEGER NOT NULL,
+    severity INTEGER NOT NULL DEFAULT 0,
+    started_at TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (drug_id) REFERENCES drugs(id)
+);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add lifestyle appearance_score and exercise tracking migrations
- introduce drug, drug category, and addiction tables
- provide migration runner and docs for new schema

## Testing
- `pytest -q` *(fails: email-validator, boto3 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68baf00147388325b26dce4709b56bd8