### PR TITLE
Add drug consumption endpoint and addiction tracking

### DIFF
--- a/backend/routes/item_routes.py
+++ b/backend/routes/item_routes.py
@@ -1,0 +1,20 @@
+"""Routes for item interactions such as consuming drugs."""
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.auth.dependencies import get_current_user_id, require_permission
+from backend.services.item_service import item_service
+
+router = APIRouter(prefix="/items", tags=["Items"])
+
+
+async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:
+    await require_permission(["user", "band_member", "moderator", "admin"], user_id)
+    return user_id
+
+
+@router.post("/consume-drug/{item_id}")
+def consume_drug(item_id: int, user_id: int = Depends(_current_user)):
+    try:
+        return item_service.consume_drug(user_id, item_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))

--- a/backend/services/addiction_service.py
+++ b/backend/services/addiction_service.py
@@ -68,6 +68,12 @@ class AddictionService:
             conn.commit()
         return level
 
+    def update_addiction(self, user_id: int, substance: str) -> dict[str, object]:
+        """Increase addiction level and return immediate buffs."""
+
+        level = self.use(user_id, substance)
+        return {"addiction_level": level, "buffs": [substance]}
+
     def apply_withdrawal(self, user_id: int, decay: int = 5) -> None:
         """Apply daily withdrawal decay to all addictions."""
 

--- a/backend/services/item_service.py
+++ b/backend/services/item_service.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from backend.models.item import Item, ItemCategory
+from backend.services.addiction_service import addiction_service
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 
@@ -233,6 +234,15 @@ class ItemService:
                     (user_id, item_id),
                 )
             conn.commit()
+
+    def consume_drug(self, user_id: int, item_id: int) -> Dict[str, object]:
+        """Consume a drug item and apply its effects."""
+
+        item = self.get_item(item_id)
+        if item.category != "drug":
+            raise ValueError("not a drug")
+        self.remove_from_inventory(user_id, item_id, 1)
+        return addiction_service.update_addiction(user_id, item.name)
 
     def get_inventory(self, user_id: int) -> Dict[int, int]:
         with sqlite3.connect(self.db_path) as conn:

--- a/tests/test_consume_drug.py
+++ b/tests/test_consume_drug.py
@@ -1,0 +1,92 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import sys
+import types
+
+# Stub out heavy dependencies required by auth
+
+fake_jwt = types.SimpleNamespace(
+    decode=lambda *args, **kwargs: {"sub": "1", "jti": "x"}
+)
+sys.modules.setdefault("auth", types.SimpleNamespace(jwt=fake_jwt))
+sys.modules.setdefault("auth.jwt", fake_jwt)
+sys.modules.setdefault(
+    "core.config",
+    types.SimpleNamespace(
+        settings=types.SimpleNamespace(
+            auth=types.SimpleNamespace(jwt_secret="", jwt_iss="", jwt_aud="")
+        )
+    ),
+)
+sys.modules.setdefault(
+    "services.rbac_service", types.SimpleNamespace(has_permission=lambda *a, **k: True)
+)
+
+class _Conn:
+    async def execute(self, *args, **kwargs):
+        class _Cur:
+            async def fetchone(self):
+                return {"revoked_at": None}
+
+        return _Cur()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+async def aget_conn():
+    return _Conn()
+
+
+sys.modules.setdefault("utils.db", types.SimpleNamespace(aget_conn=aget_conn))
+
+from backend.routes import item_routes
+from backend.services.item_service import ItemService
+from backend.services.addiction_service import AddictionService
+from backend.models.item import ItemCategory
+from backend.models.drug import Drug
+
+
+def create_app(tmp_path):
+    db = tmp_path / "test.db"
+    item_svc = ItemService(str(db))
+    addiction_svc = AddictionService(str(db))
+    # Patch the global services used by the route
+    item_routes.item_service = item_svc
+    from backend.services import item_service as item_service_module
+
+    item_service_module.addiction_service = addiction_svc
+    app = FastAPI()
+    app.include_router(item_routes.router)
+    app.dependency_overrides[item_routes._current_user] = lambda: 1
+    return app, item_svc, addiction_svc
+
+
+def test_consume_drug(tmp_path):
+    app, item_svc, addiction_svc = create_app(tmp_path)
+    client = TestClient(app)
+
+    item_svc.create_category(ItemCategory("drug", "Drugs"))
+    drug = Drug(
+        id=None,
+        name="speed",
+        category="drug",
+        effects=["speed"],
+        addiction_rate=0.5,
+        duration=5,
+        price_cents=0,
+        stock=0,
+    )
+    item_svc.create_item(drug)
+    item_svc.add_to_inventory(1, drug.id)
+
+    r = client.post(f"/items/consume-drug/{drug.id}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["buffs"] == ["speed"]
+    assert body["addiction_level"] == 10
+    assert item_svc.get_inventory(1).get(drug.id, 0) == 0
+    assert addiction_svc.get_level(1, "speed") == 10


### PR DESCRIPTION
## Summary
- extend addiction service with `update_addiction` returning buffs
- allow item service to consume drug items and update addiction levels
- add `/items/consume-drug/{item_id}` route with auth requirement
- cover drug consumption flow with new test

## Testing
- `PYTHONPATH=. pytest tests/test_consume_drug.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68baf18464dc8325aecb778f4c0d9dd1