### PR TITLE
feat: add exercise cooldowns and limits

### DIFF
--- a/backend/models/daily_schedule.py
+++ b/backend/models/daily_schedule.py
@@ -1,13 +1,59 @@
 import sqlite3
-from typing import List, Dict
+from typing import Dict, List
 
 from backend.database import DB_PATH
+
+# Maximum number of exercise activities permitted in a single day.
+# Additional exercise sessions beyond this limit are rejected when
+# attempting to add or update entries.
+MAX_EXERCISE_ACTIVITIES_PER_DAY = 1
+
+
+def _check_exercise_limit(cur: sqlite3.Cursor, user_id: int, date: str, activity_id: int) -> None:
+    """Ensure the user has not exceeded their daily exercise allowance.
+
+    Parameters
+    ----------
+    cur:
+        Open database cursor.
+    user_id:
+        The id of the user being scheduled.
+    date:
+        The schedule date in ISO format.
+    activity_id:
+        The id of the activity being scheduled.
+
+    Raises
+    ------
+    ValueError
+        If scheduling the activity would exceed the allowed number of
+        exercise sessions for the specified day.
+    """
+
+    cur.execute("SELECT category FROM activities WHERE id = ?", (activity_id,))
+    row = cur.fetchone()
+    if not row or row[0] != "exercise":
+        return
+
+    cur.execute(
+        """
+        SELECT COUNT(*)
+        FROM daily_schedule ds
+        JOIN activities a ON ds.activity_id = a.id
+        WHERE ds.user_id = ? AND ds.date = ? AND a.category = 'exercise'
+        """,
+        (user_id, date),
+    )
+    count = cur.fetchone()[0]
+    if count >= MAX_EXERCISE_ACTIVITIES_PER_DAY:
+        raise ValueError("daily exercise activity limit reached")
 
 
 def add_entry(user_id: int, date: str, slot: int, activity_id: int) -> None:
     """Insert or update a schedule entry for a user."""
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
+        _check_exercise_limit(cur, user_id, date, activity_id)
         cur.execute(
             """
             INSERT INTO daily_schedule (user_id, date, slot, hour, activity_id)
@@ -22,6 +68,7 @@ def add_entry(user_id: int, date: str, slot: int, activity_id: int) -> None:
 def update_entry(user_id: int, date: str, slot: int, activity_id: int) -> None:
     with sqlite3.connect(DB_PATH) as conn:
         cur = conn.cursor()
+        _check_exercise_limit(cur, user_id, date, activity_id)
         cur.execute(
             "UPDATE daily_schedule SET activity_id = ?, hour = ? WHERE user_id = ? AND date = ? AND slot = ?",
             (activity_id, slot, user_id, date, slot),

--- a/tests/test_exercise_cooldown.py
+++ b/tests/test_exercise_cooldown.py
@@ -1,0 +1,67 @@
+import sqlite3
+from datetime import datetime, timedelta
+
+from backend.services import lifestyle_service
+
+
+def test_exercise_cooldown(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(lifestyle_service, "DB_PATH", db_path)
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE lifestyle (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER UNIQUE NOT NULL,
+            fitness REAL DEFAULT 50.0,
+            exercise_minutes REAL DEFAULT 0.0,
+            last_exercise TEXT
+        )
+        """
+    )
+    cur.execute(
+        "INSERT INTO lifestyle (user_id, fitness, exercise_minutes) VALUES (1, 50, 0)"
+    )
+    conn.commit()
+    conn.close()
+
+    base = datetime(2024, 1, 1, 8, 0, 0)
+
+    class T1:
+        @staticmethod
+        def utcnow():
+            return base
+
+        @staticmethod
+        def fromisoformat(val):
+            return datetime.fromisoformat(val)
+
+    monkeypatch.setattr(lifestyle_service, "datetime", T1)
+    assert lifestyle_service.log_exercise_session(1, 30) is True
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT fitness FROM lifestyle WHERE user_id = 1")
+    assert cur.fetchone()[0] == 50 + lifestyle_service.EXERCISE_FITNESS_BONUS
+    conn.close()
+
+    class T2:
+        @staticmethod
+        def utcnow():
+            return base + timedelta(hours=2)
+
+        @staticmethod
+        def fromisoformat(val):
+            return datetime.fromisoformat(val)
+
+    monkeypatch.setattr(lifestyle_service, "datetime", T2)
+    assert lifestyle_service.log_exercise_session(1, 30) is False
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT fitness FROM lifestyle WHERE user_id = 1")
+    assert cur.fetchone()[0] == 50 + lifestyle_service.EXERCISE_FITNESS_BONUS
+    conn.close()
+


### PR DESCRIPTION
## Summary
- enforce per-day exercise limits in `daily_schedule`
- add cooldown-aware exercise logging and buffs
- apply exercise cooldowns in lifestyle scheduler
- test exercise cooldown behavior

## Testing
- `PYTHONPATH=. pytest tests/test_exercise_cooldown.py tests/test_lifestyle_scheduler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf60f73e883258606ca7da83fd394