### PR TITLE
Add event notification service and user notifications endpoint

### DIFF
--- a/backend/routes/user_routes.py
+++ b/backend/routes/user_routes.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends
+
+from auth.dependencies import get_current_user_id
+from services.notifications_service import NotificationsService
+
+
+router = APIRouter(prefix="/user", tags=["User"])
+svc = NotificationsService()
+
+
+@router.get("/notifications")
+def list_notifications(
+    limit: int = 50,
+    offset: int = 0,
+    user_id: int = Depends(get_current_user_id),
+):
+    items = svc.list(user_id, limit=limit, offset=offset)
+    return {"notifications": items, "unread": svc.unread_count(user_id)}
+
+
+__all__ = ["router"]
+

--- a/backend/services/item_service.py
+++ b/backend/services/item_service.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 
 from backend.models.item import Item, ItemCategory
 from backend.services.addiction_service import addiction_service
+from backend.models import notification_models
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 
@@ -242,7 +243,11 @@ class ItemService:
         if item.category != "drug":
             raise ValueError("not a drug")
         self.remove_from_inventory(user_id, item_id, 1)
-        return addiction_service.update_addiction(user_id, item.name)
+        result = addiction_service.update_addiction(user_id, item.name)
+        notification_models.notifications.record_event(
+            user_id, "Missed show due to addiction"
+        )
+        return result
 
     def get_inventory(self, user_id: int) -> Dict[int, int]:
         with sqlite3.connect(self.db_path) as conn:

--- a/backend/services/lifestyle_service.py
+++ b/backend/services/lifestyle_service.py
@@ -5,6 +5,7 @@ import random
 import sqlite3
 
 from backend.database import DB_PATH
+from backend.models import notification_models
 
 from .skill_service import skill_service
 from .xp_reward_service import xp_reward_service
@@ -73,6 +74,10 @@ def log_exercise_session(
     conn.commit()
     if own_conn:
         conn.close()
+    if full_benefit:
+        notification_models.notifications.record_event(
+            user_id, "Appearance buff gained"
+        )
     return full_benefit
 
 def calculate_lifestyle_score(data):


### PR DESCRIPTION
## Summary
- record event notifications with timestamps via `NotificationsService`
- send notifications for exercise buffs and drug addiction penalties
- expose `/user/notifications` endpoint
- test exercise and drug actions trigger notifications

## Testing
- `PYTHONPATH=$PWD pytest -q tests/test_exercise_cooldown.py tests/test_consume_drug.py`
- `PYTHONPATH=$PWD pytest` *(fails: unable to open database / missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68baf8877a008325999b49408848a524