### PR TITLE
Add appearance score and activity bonuses for exercise

### DIFF
--- a/backend/models/activity.py
+++ b/backend/models/activity.py
@@ -1,7 +1,19 @@
 import sqlite3
+from dataclasses import dataclass
 from typing import List, Optional, Dict
 
 from backend.database import DB_PATH
+
+
+@dataclass(frozen=True)
+class Activity:
+    name: str
+    appearance_bonus: int
+
+
+gym = Activity("gym", appearance_bonus=5)
+running = Activity("running", appearance_bonus=3)
+yoga = Activity("yoga", appearance_bonus=4)
 
 
 def create_activity(
@@ -127,6 +139,10 @@ def delete_activity(activity_id: int) -> None:
 
 
 __all__ = [
+    "Activity",
+    "gym",
+    "running",
+    "yoga",
     "create_activity",
     "get_activity",
     "list_activities",

--- a/backend/models/lifestyle.py
+++ b/backend/models/lifestyle.py
@@ -12,4 +12,7 @@ class Lifestyle(BaseModel):
     mental_health: float = 100.0
     nutrition: float = 70.0
     fitness: float = 70.0
+    appearance_score: float = 50.0
+    exercise_minutes: float = 0.0
+    last_exercise: Optional[str] = None
     lifestyle_score: Optional[float] = None

--- a/tests/test_exercise_cooldown.py
+++ b/tests/test_exercise_cooldown.py
@@ -3,6 +3,9 @@ import sys
 import types
 from datetime import datetime, timedelta
 
+import pytest
+from backend.models.activity import gym, running, yoga
+
 utils_mod = types.ModuleType("utils")
 utils_db_mod = types.ModuleType("utils.db")
 utils_db_mod.get_conn = sqlite3.connect
@@ -27,13 +30,14 @@ def test_exercise_cooldown(monkeypatch, tmp_path):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER UNIQUE NOT NULL,
             fitness REAL DEFAULT 50.0,
+            appearance_score REAL DEFAULT 50.0,
             exercise_minutes REAL DEFAULT 0.0,
             last_exercise TEXT
         )
         """
     )
     cur.execute(
-        "INSERT INTO lifestyle (user_id, fitness, exercise_minutes) VALUES (1, 50, 0)"
+        "INSERT INTO lifestyle (user_id, fitness, appearance_score, exercise_minutes) VALUES (1, 50, 50, 0)"
     )
     cur.execute(
         """
@@ -69,8 +73,10 @@ def test_exercise_cooldown(monkeypatch, tmp_path):
 
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
-    cur.execute("SELECT fitness FROM lifestyle WHERE user_id = 1")
-    assert cur.fetchone()[0] == 50 + lifestyle_service.EXERCISE_FITNESS_BONUS
+    cur.execute("SELECT fitness, appearance_score FROM lifestyle WHERE user_id = 1")
+    fitness, appearance = cur.fetchone()
+    assert fitness == 50 + lifestyle_service.EXERCISE_FITNESS_BONUS
+    assert appearance == 50 + gym.appearance_bonus
     cur.execute("SELECT title FROM notifications WHERE user_id = 1")
     assert cur.fetchone()[0] == "Appearance buff gained"
     conn.close()
@@ -89,9 +95,66 @@ def test_exercise_cooldown(monkeypatch, tmp_path):
 
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
-    cur.execute("SELECT fitness FROM lifestyle WHERE user_id = 1")
-    assert cur.fetchone()[0] == 50 + lifestyle_service.EXERCISE_FITNESS_BONUS
+    cur.execute("SELECT fitness, appearance_score FROM lifestyle WHERE user_id = 1")
+    fitness, appearance = cur.fetchone()
+    assert fitness == 50 + lifestyle_service.EXERCISE_FITNESS_BONUS
+    assert appearance == 50 + gym.appearance_bonus
     cur.execute("SELECT COUNT(*) FROM notifications WHERE user_id = 1")
     assert cur.fetchone()[0] == 1
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    "activity_obj",
+    [gym, running, yoga],
+)
+def test_appearance_bonus(monkeypatch, tmp_path, activity_obj):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(lifestyle_service, "DB_PATH", db_path)
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE lifestyle (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER UNIQUE NOT NULL,
+            fitness REAL DEFAULT 50.0,
+            appearance_score REAL DEFAULT 50.0,
+            exercise_minutes REAL DEFAULT 0.0,
+            last_exercise TEXT
+        )
+        """
+    )
+    cur.execute(
+        "INSERT INTO lifestyle (user_id, fitness, appearance_score, exercise_minutes) VALUES (1, 50, 50, 0)"
+    )
+    conn.commit()
+    conn.close()
+
+    class DummyNotifications:
+        def record_event(self, user_id, title):
+            pass
+
+    notification_models.notifications = DummyNotifications()
+
+    base = datetime(2024, 1, 1, 8, 0, 0)
+
+    class T:
+        @staticmethod
+        def utcnow():
+            return base
+
+        @staticmethod
+        def fromisoformat(val):
+            return datetime.fromisoformat(val)
+
+    monkeypatch.setattr(lifestyle_service, "datetime", T)
+    assert lifestyle_service.log_exercise_session(1, 30, activity_obj.name) is True
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT appearance_score FROM lifestyle WHERE user_id = 1")
+    assert cur.fetchone()[0] == 50 + activity_obj.appearance_bonus
     conn.close()
 


### PR DESCRIPTION
## Summary
- track appearance_score, exercise_minutes, last_exercise in Lifestyle
- define gym, running, yoga activities with appearance bonuses
- update exercise logging and scheduler to apply appearance bonuses
- expand tests to verify appearance gains for each activity type

## Testing
- `PYTHONPATH=. pytest tests/test_exercise_cooldown.py tests/test_lifestyle_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_68bbdfe2fc948325b99f07a87b27f7fd