### PR TITLE
Add RPG stats to avatars and integrate into gameplay

### DIFF
--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -56,6 +56,9 @@ class Avatar(Base):
     # lightweight persistence of how an avatar is feeling which can then be
     # influenced by lifestyle scores and random events.
     mood = Column(Integer, default=50)
+    stamina = Column(Integer, default=50)
+    charisma = Column(Integer, default=50)
+    intelligence = Column(Integer, default=50)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -25,6 +25,9 @@ class AvatarBase(BaseModel):
     experience: int = 0
     health: int = 100
     mood: int = 50
+    stamina: int = 50
+    charisma: int = 50
+    intelligence: int = 50
 
 
 class AvatarCreate(AvatarBase):
@@ -50,6 +53,9 @@ class AvatarUpdate(BaseModel):
     experience: Optional[int] = None
     health: Optional[int] = None
     mood: Optional[int] = None
+    stamina: Optional[int] = None
+    charisma: Optional[int] = None
+    intelligence: Optional[int] = None
 
 
 class AvatarResponse(AvatarBase):

--- a/backend/tests/avatars/test_avatar_service.py
+++ b/backend/tests/avatars/test_avatar_service.py
@@ -43,6 +43,9 @@ def test_crud_lifecycle():
     assert avatar.id is not None
     # Default mood should be neutral (50)
     assert avatar.mood == 50
+    assert avatar.stamina == 50
+    assert avatar.charisma == 50
+    assert avatar.intelligence == 50
 
     fetched = svc.get_avatar(avatar.id)
     assert fetched and fetched.nickname == "Hero"

--- a/backend/tests/social/test_fan_charisma.py
+++ b/backend/tests/social/test_fan_charisma.py
@@ -1,0 +1,58 @@
+import asyncio
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.avatar import Base as AvatarBase
+from models.character import Base as CharacterBase, Character
+from backend.schemas.avatar import AvatarCreate
+from backend.services.avatar_service import AvatarService
+from backend.services.fan_club_service import FanClubService
+
+
+@pytest.fixture
+def avatar_service():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    CharacterBase.metadata.create_all(bind=engine)
+    AvatarBase.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    svc = AvatarService(SessionLocal)
+    with SessionLocal() as session:
+        char = Character(name="Hero", genre="rock", trait="bold", birthplace="Earth")
+        session.add(char)
+        session.commit()
+        cid = char.id
+    svc.create_avatar(
+        AvatarCreate(
+            character_id=cid,
+            nickname="Hero",
+            body_type="slim",
+            skin_tone="pale",
+            face_shape="oval",
+            hair_style="short",
+            hair_color="black",
+            top_clothing="tshirt",
+            bottom_clothing="jeans",
+            shoes="boots",
+            charisma=80,
+        )
+    )
+    return svc
+
+
+def test_charisma_increases_post_engagement(avatar_service, monkeypatch):
+    async def fake_publish(*args, **kwargs):
+        return 0
+
+    monkeypatch.setattr(
+        "backend.services.fan_club_service.publish_fan_club_post", fake_publish
+    )
+
+    fan_svc = FanClubService(avatar_service=avatar_service)
+    club = fan_svc.create_club(owner_id=1, name="Fans")
+    fan_svc.join_club(club.id, 1)
+    thread = fan_svc.create_thread(club.id, 1, "Welcome")
+    post = asyncio.get_event_loop().run_until_complete(
+        fan_svc.add_post(thread.id, author_id=1, content="Hi")
+    )
+    assert post.engagement == 8

--- a/tests/test_tutor_service.py
+++ b/tests/test_tutor_service.py
@@ -1,23 +1,55 @@
 import pytest
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
 from backend.models.learning_method import METHOD_PROFILES, LearningMethod
 from backend.models.skill import Skill
 from backend.models.tutor import Tutor
+from models.avatar import Base as AvatarBase
+from models.character import Base as CharacterBase, Character
 from backend.services.economy_service import EconomyService
 from backend.services.skill_service import SkillService
 from backend.services.tutor_service import TutorService
+from backend.services.avatar_service import AvatarService
+from backend.schemas.avatar import AvatarCreate, AvatarUpdate
 
 
 def _setup_services(tmp_path):
     db = tmp_path / "db.sqlite"
     economy = EconomyService(db_path=db)
     skills = SkillService()
-    svc = TutorService(economy, skills)
-    return svc, economy, skills
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    CharacterBase.metadata.create_all(bind=engine)
+    AvatarBase.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    avatar_svc = AvatarService(SessionLocal)
+    svc = TutorService(economy, skills, avatar_service=avatar_svc)
+    with SessionLocal() as session:
+        char = Character(name="Tester", genre="rock", trait="brave", birthplace="Earth")
+        session.add(char)
+        session.commit()
+        cid = char.id
+    avatar_svc.create_avatar(
+        AvatarCreate(
+            character_id=cid,
+            nickname="Hero",
+            body_type="slim",
+            skin_tone="pale",
+            face_shape="oval",
+            hair_style="short",
+            hair_color="black",
+            top_clothing="tshirt",
+            bottom_clothing="jeans",
+            shoes="boots",
+            stamina=100,
+        )
+    )
+    return svc, economy, skills, avatar_svc
 
 
 def test_tutor_requires_level(tmp_path):
-    svc, economy, skills = _setup_services(tmp_path)
+    svc, economy, skills, _ = _setup_services(tmp_path)
     tutor = svc.create_tutor(
         Tutor(
             id=None,
@@ -39,7 +71,7 @@ def test_tutor_requires_level(tmp_path):
 
 
 def test_tutor_session_cost_and_xp(tmp_path):
-    svc, economy, skills = _setup_services(tmp_path)
+    svc, economy, skills, avatar_svc = _setup_services(tmp_path)
     tutor = svc.create_tutor(
         Tutor(
             id=None,
@@ -64,3 +96,11 @@ def test_tutor_session_cost_and_xp(tmp_path):
 
     assert result["xp_per_hour"] == METHOD_PROFILES[LearningMethod.TUTOR].xp_per_hour
     assert result["xp_gained"] == METHOD_PROFILES[LearningMethod.TUTOR].xp_per_hour * 2
+
+    # Lower stamina should increase session cost
+    avatar_svc.update_avatar(1, AvatarUpdate(stamina=50))
+    balance_before = economy.get_balance(1)
+    svc.schedule_session(1, skill, tutor.id, 2)
+    balance_after = economy.get_balance(1)
+    expected_cost = tutor.hourly_rate * 2 * (200 - 50) // 100
+    assert balance_after == balance_before - expected_cost


### PR DESCRIPTION
## Summary
- extend Avatar with stamina, charisma and intelligence stats
- use stamina to modify tutor session costs
- apply charisma and intelligence to fan club engagement and songwriting quality

## Testing
- `pytest backend/tests/avatars/test_avatar_service.py tests/test_tutor_service.py backend/tests/social/test_fan_charisma.py backend/tests/songwriting/test_songwriting_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbe31e67308325af631e252c51230d