### PR TITLE
Add level cap to skill progression

### DIFF
--- a/backend/models/xp_config.py
+++ b/backend/models/xp_config.py
@@ -13,6 +13,7 @@ class XPConfig:
     """Runtime tunable experience settings."""
 
     daily_cap: int = 0
+    level_cap: int = 100
     new_player_multiplier: float = 1.0
     rested_xp_rate: float = 1.0
 

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -139,6 +139,9 @@ class SkillService:
 
     def _check_level(self, skill: Skill) -> None:
         level = skill.xp // 100 + 1
+        cap = get_config().level_cap
+        if cap:
+            level = min(level, cap)
         if level != skill.level:
             skill.level = level
 

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -77,6 +77,20 @@ def test_skill_daily_cap() -> None:
     set_config(old_cfg)
 
 
+def test_skill_level_cap() -> None:
+    old_cfg = get_config()
+    set_config(XPConfig(level_cap=5))
+    svc = SkillService(xp_events=DummyXPEvents(1.0))
+    skill = Skill(id=25, name="piano", category="instrument")
+
+    updated = svc.train(1, skill, 600)
+    assert updated.level == 5
+
+    updated = svc.train(1, skill, 400)
+    assert updated.level == 5
+    set_config(old_cfg)
+
+
 def test_skill_decay() -> None:
     svc = SkillService(xp_events=DummyXPEvents(1.0))
     skill = Skill(id=3, name="vocals", category="performance")


### PR DESCRIPTION
## Summary
- add `level_cap` to `XPConfig`
- clamp skill levels to the configured cap
- test that XP beyond the cap doesn't increase skill level

## Testing
- `python3 -m py_compile backend/models/xp_config.py backend/services/skill_service.py tests/test_skill_service.py`
- `python3 -m pytest tests/test_skill_service.py -q` *(fails: No module named pytest)*
- `python3 -m ruff backend/models/xp_config.py backend/services/skill_service.py tests/test_skill_service.py` *(fails: No module named ruff)*


------
https://chatgpt.com/codex/tasks/task_e_68bbe0a8d9ec832599f351814f6d3205