### PR TITLE
Add stamina and charisma game mechanics

### DIFF
--- a/backend/seeds/demo_data.sql
+++ b/backend/seeds/demo_data.sql
@@ -21,4 +21,12 @@ INSERT INTO tour_stops (tour_id, venue_id, date_start, date_end, order_index, st
 INSERT INTO notifications (user_id, type, title, body) VALUES
   (1, 'system', 'Welcome to RockMundo', 'Your account was created.');
 
+-- Demo avatar showcasing new stamina/charisma stats
+INSERT INTO avatars (
+  character_id, nickname, body_type, skin_tone, face_shape, hair_style,
+  hair_color, top_clothing, bottom_clothing, shoes, stamina, charisma
+) VALUES
+  (1, 'DemoHero', 'slim', 'pale', 'oval', 'short', 'black',
+   'tshirt', 'jeans', 'boots', 50, 50);
+
 COMMIT;

--- a/backend/tests/skills/test_stamina_decay.py
+++ b/backend/tests/skills/test_stamina_decay.py
@@ -1,0 +1,70 @@
+import sqlite3
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.avatar import Base as AvatarBase
+from models.character import Base as CharacterBase, Character
+from backend.models.skill import Skill
+from backend.schemas.avatar import AvatarCreate
+from backend.services.avatar_service import AvatarService
+from backend.services.skill_service import SkillService
+
+
+def _setup_avatar_service(stamina1: int, stamina2: int) -> AvatarService:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    CharacterBase.metadata.create_all(bind=engine)
+    AvatarBase.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    svc = AvatarService(SessionLocal)
+    with SessionLocal() as session:
+        c1 = Character(name="A", genre="rock", trait="brave", birthplace="Earth")
+        c2 = Character(name="B", genre="rock", trait="calm", birthplace="Mars")
+        session.add_all([c1, c2])
+        session.commit()
+        id1, id2 = c1.id, c2.id
+    svc.create_avatar(
+        AvatarCreate(
+            character_id=id1,
+            nickname="A",
+            body_type="slim",
+            skin_tone="pale",
+            face_shape="oval",
+            hair_style="short",
+            hair_color="black",
+            top_clothing="t",
+            bottom_clothing="j",
+            shoes="b",
+            stamina=stamina1,
+        )
+    )
+    svc.create_avatar(
+        AvatarCreate(
+            character_id=id2,
+            nickname="B",
+            body_type="slim",
+            skin_tone="pale",
+            face_shape="oval",
+            hair_style="short",
+            hair_color="black",
+            top_clothing="t",
+            bottom_clothing="j",
+            shoes="b",
+            stamina=stamina2,
+        )
+    )
+    return svc
+
+
+def test_stamina_scales_daily_decay():
+    avatar_service = _setup_avatar_service(20, 80)
+    skills = SkillService(avatar_service=avatar_service)
+    skill = Skill(id=1, name="guitar", category="music")
+
+    low = skills.train(1, skill, 100)
+    high = skills.train(2, skill, 100)
+
+    skills.apply_daily_decay(1, amount=10)
+    skills.apply_daily_decay(2, amount=10)
+
+    assert low.xp == 84
+    assert high.xp == 90

--- a/backend/tests/social/test_fan_service_charisma.py
+++ b/backend/tests/social/test_fan_service_charisma.py
@@ -1,0 +1,73 @@
+import sqlite3
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.avatar import Base as AvatarBase
+from models.character import Base as CharacterBase, Character
+from backend.schemas.avatar import AvatarCreate
+from backend.services.avatar_service import AvatarService
+from backend.services import fan_service
+
+
+def _setup_avatar(charisma: int) -> AvatarService:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    CharacterBase.metadata.create_all(bind=engine)
+    AvatarBase.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    svc = AvatarService(SessionLocal)
+    with SessionLocal() as session:
+        char = Character(name="Hero", genre="rock", trait="bold", birthplace="Earth")
+        session.add(char)
+        session.commit()
+        cid = char.id
+    svc.create_avatar(
+        AvatarCreate(
+            character_id=cid,
+            nickname="Hero",
+            body_type="slim",
+            skin_tone="pale",
+            face_shape="oval",
+            hair_style="short",
+            hair_color="black",
+            top_clothing="t",
+            bottom_clothing="j",
+            shoes="b",
+            charisma=charisma,
+        )
+    )
+    return svc
+
+
+def test_charisma_impacts_fan_loyalty(tmp_path, monkeypatch):
+    db_file = tmp_path / "fans.db"
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE fans (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            band_id INTEGER,
+            location TEXT,
+            loyalty INTEGER,
+            source TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    avatar_service = _setup_avatar(80)
+    monkeypatch.setattr(fan_service, "DB_PATH", db_file)
+    monkeypatch.setattr(fan_service, "avatar_service", avatar_service)
+
+    fan_service.add_fan(user_id=42, band_id=1, location="web")
+    fan_service.add_fan(user_id=42, band_id=1, location="web")
+
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute("SELECT loyalty FROM fans WHERE band_id = 1")
+    loyalty = cur.fetchone()[0]
+    conn.close()
+
+    assert loyalty == 47


### PR DESCRIPTION
## Summary
- scale daily skill decay based on an avatar's stamina
- let avatar charisma influence fan loyalty and gig fan gains
- seed demo avatar with stamina/charisma and add unit tests

## Testing
- `pytest backend/tests/avatars/test_avatar_service.py backend/tests/social/test_fan_charisma.py backend/tests/social/test_fan_service_charisma.py backend/tests/skills/test_stamina_decay.py backend/tests/services/test_event_service.py backend/tests/songwriting/test_songwriting_service.py::test_xp_gain_and_quality_modifier -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9b1e8df883259b53df4aec1acb1d