### PR TITLE
Add image skills and training services

### DIFF
--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -30,6 +30,9 @@ SEED_SKILLS = [
     Skill(id=22, name="mastering", category="creative", parent_id=20),
     Skill(id=23, name="music_theory", category="creative"),
     Skill(id=24, name="ear_training", category="creative"),
+    # Image and style skills
+    Skill(id=25, name="fashion", category="image"),
+    Skill(id=26, name="image_management", category="image"),
 ]
 
 SKILL_NAME_TO_ID = {skill.name: skill.id for skill in SEED_SKILLS}

--- a/backend/services/image_training_service.py
+++ b/backend/services/image_training_service.py
@@ -1,0 +1,82 @@
+"""Training helpers for image and style related skills."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from backend.models.skill import Skill
+from backend.models.learning_method import LearningMethod
+from backend.services.economy_service import EconomyService
+from backend.services.skill_service import skill_service
+
+
+# ---------------------------------------------------------------------------
+# Online tutorials
+# ---------------------------------------------------------------------------
+
+def study_image_tutorial(user_id: int, skill: Skill, hours: int) -> Skill:
+    """Train an image related skill via online tutorials."""
+    return skill_service.train_with_method(
+        user_id, skill, LearningMethod.YOUTUBE, hours
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stylist NPC training
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Stylist:
+    id: int | None
+    name: str
+    specialization: str
+    hourly_rate: int
+
+
+class StylistService:
+    """Simple service for hiring stylists to train image skills."""
+
+    def __init__(
+        self,
+        economy: Optional[EconomyService] = None,
+        skills=skill_service,
+    ) -> None:
+        self.economy = economy or EconomyService()
+        self.skills = skills
+        self._stylists: Dict[int, Stylist] = {}
+        self._id_seq = 1
+
+    def create_stylist(self, stylist: Stylist) -> Stylist:
+        stylist.id = self._id_seq
+        self._stylists[stylist.id] = stylist
+        self._id_seq += 1
+        return stylist
+
+    def list_stylists(self) -> list[Stylist]:
+        return list(self._stylists.values())
+
+    def schedule_session(
+        self, user_id: int, skill: Skill, stylist_id: int, hours: int
+    ) -> dict:
+        stylist = self._stylists.get(stylist_id)
+        if not stylist or stylist.specialization != skill.name:
+            raise ValueError("invalid stylist")
+        cost = stylist.hourly_rate * hours
+        self.economy.withdraw(user_id, cost)
+        before = self.skills.train(user_id, skill, 0).xp
+        updated = self.skills.train_with_method(
+            user_id, skill, LearningMethod.TUTOR, hours
+        )
+        gained = updated.xp - before
+        return {"status": "ok", "skill": updated, "xp_gained": gained}
+
+
+stylist_service = StylistService()
+
+__all__ = [
+    "study_image_tutorial",
+    "Stylist",
+    "StylistService",
+    "stylist_service",
+]

--- a/tests/test_image_skills.py
+++ b/tests/test_image_skills.py
@@ -1,0 +1,119 @@
+import sqlite3
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from backend.seeds.skill_seed import SEED_SKILLS
+from backend.models.learning_method import METHOD_PROFILES, LearningMethod
+from backend.services import fan_interaction_service, fan_service
+from backend.services.image_training_service import (
+    Stylist,
+    StylistService,
+    study_image_tutorial,
+)
+from backend.services.skill_service import SkillService
+from backend.services.economy_service import EconomyService
+
+
+FASHION_SKILL = next(s for s in SEED_SKILLS if s.name == "fashion")
+IMAGE_MANAGEMENT_SKILL = next(s for s in SEED_SKILLS if s.name == "image_management")
+
+
+def _setup_fan_db(tmp_path, monkeypatch):
+    db = tmp_path / "fans.sqlite"
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE fan_interactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            band_id INTEGER,
+            fan_id INTEGER,
+            interaction_type TEXT,
+            content TEXT,
+            created_at TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE fans (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            band_id INTEGER,
+            location TEXT,
+            loyalty INTEGER,
+            source TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    # Patch DB paths
+    monkeypatch.setattr(fan_interaction_service, "DB_PATH", db)
+    monkeypatch.setattr(fan_service, "DB_PATH", db)
+    monkeypatch.setattr(
+        fan_service, "avatar_service", SimpleNamespace(get_avatar=lambda _: None)
+    )
+    return db
+
+
+def test_image_skills_increase_fans(tmp_path, monkeypatch):
+    _setup_fan_db(tmp_path, monkeypatch)
+    skills = SkillService()
+    monkeypatch.setattr(fan_interaction_service, "skill_service", skills)
+    monkeypatch.setattr(
+        "backend.services.image_training_service.skill_service", skills
+    )
+    monkeypatch.setattr(skills, "_has_item", lambda *args, **kwargs: True)
+
+    fan_interaction_service.record_interaction(1, 1, "post", "hello")
+    conn = sqlite3.connect(fan_service.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM fans")
+    assert cur.fetchone()[0] == 0
+    conn.close()
+
+    study_image_tutorial(1, FASHION_SKILL, 10)
+    study_image_tutorial(1, IMAGE_MANAGEMENT_SKILL, 10)
+
+    result = fan_interaction_service.record_interaction(
+        1, 2, "photo_op", "stylish"
+    )
+    assert result["fans_gained"] > 0
+    conn = sqlite3.connect(fan_service.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM fans")
+    fans = cur.fetchone()[0]
+    conn.close()
+    assert fans == result["fans_gained"]
+
+
+def test_stylist_training_session(tmp_path, monkeypatch):
+    economy = EconomyService(db_path=tmp_path / "econ.sqlite")
+    economy.ensure_schema()
+    skills = SkillService()
+    svc = StylistService(economy, skills)
+    stylist = svc.create_stylist(
+        Stylist(id=None, name="Aiko", specialization="fashion", hourly_rate=50)
+    )
+    monkeypatch.setattr(skills, "_has_item", lambda *args, **kwargs: True)
+
+    economy.deposit(1, 10000)
+    skills.train(1, FASHION_SKILL, 1400)
+
+    balance_before = economy.get_balance(1)
+    result = svc.schedule_session(1, FASHION_SKILL, stylist.id, 2)
+    balance_after = economy.get_balance(1)
+
+    assert balance_after == balance_before - stylist.hourly_rate * 2
+    assert (
+        result["xp_gained"]
+        == METHOD_PROFILES[LearningMethod.TUTOR].xp_per_hour * 2
+    )
+


### PR DESCRIPTION
## Summary
- Introduce new `image` skill category including `fashion` and `image_management`
- Fan interactions now boost fans based on band image skills
- Provide online tutorial and stylist NPC services for training image skills
- Add tests validating fan growth and stylist training

## Testing
- `pytest tests/test_image_skills.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'BookIn' from 'backend.routes.admin_book_routes', and other missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9eec268883259b02887912f5a6a4