### PR TITLE
Fix fan loyalty calculations and clean fan service

### DIFF
--- a/backend/services/business_training_service.py
+++ b/backend/services/business_training_service.py
@@ -4,14 +4,24 @@ from typing import Dict
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import SkillService, skill_service
+from backend.services.skill_service import SkillService
+from backend.services.skill_service import skill_service as default_skill_service
 
 
 class BusinessTrainingService:
     """Provide workshops and courses for business skills."""
 
-    def __init__(self, svc: SkillService | None = None) -> None:
-        self.skill_service = svc or skill_service
+    def __init__(
+        self,
+        svc: SkillService | None = None,
+        skill_service: SkillService | None = None,
+    ) -> None:
+        """Create a training service using the provided skill service.
+
+        The ``skill_service`` keyword is kept for backward compatibility.
+        """
+
+        self.skill_service = svc or skill_service or default_skill_service
         self._workshop_xp: Dict[str, int] = {
             "marketing": 50,
             "public_relations": 50,


### PR DESCRIPTION
## Summary
- Clean up merge remnants in fan_service and simplify logic
- Compute base loyalty and charisma bonuses correctly when adding fans or boosting after gigs
- Allow BusinessTrainingService to accept legacy `skill_service` kwarg for tests

## Testing
- `python -m pytest backend/tests/social/test_fan_service_charisma.py backend/tests/business/test_business_skills.py::test_marketing_pr_boost_fans -q`
- `ruff check backend/services/fan_service.py backend/services/business_training_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68bca0d2ea4c832599fac0a1c353cd07