### PR TITLE
Apply XP item multipliers during training

### DIFF
--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -24,6 +24,7 @@ from backend.services.item_service import item_service
 from backend.services.lifestyle_scheduler import lifestyle_xp_modifier
 from backend.services.xp_event_service import XPEventService
 from backend.services.avatar_service import AvatarService
+from backend.services.xp_item_service import xp_item_service
 
 INTERNET_DEVICE_NAME = "internet device"
 
@@ -166,6 +167,8 @@ class SkillService:
 
         modifier = self._lifestyle_modifier(user_id)
         modifier *= self.xp_events.get_active_multiplier(skill.name)
+        item_mult = xp_item_service.get_active_multiplier(user_id)
+        modifier *= item_mult
 
         buff_mult = 1.0
         key = (user_id, skill.id)

--- a/backend/tests/services/test_skill_service_xp_items.py
+++ b/backend/tests/services/test_skill_service_xp_items.py
@@ -1,0 +1,32 @@
+import pytest
+from backend.models.skill import Skill
+from backend.models.xp_item import XPItem
+from backend.services.skill_service import SkillService
+from backend.services.xp_item_service import XPItemService
+
+
+class DummyXPEvents:
+    def get_active_multiplier(self, skill: str | None = None) -> float:  # pragma: no cover - simple
+        return 1.0
+
+
+def test_xp_items_increase_awarded_xp(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    item_db = tmp_path / "items.sqlite"
+    item_svc = XPItemService(db_path=item_db)
+    monkeypatch.setattr("backend.services.skill_service.xp_item_service", item_svc)
+
+    svc = SkillService(xp_events=DummyXPEvents())
+    skill = Skill(id=1, name="guitar", category="instrument")
+
+    first = svc.train(1, skill, 10)
+    baseline = first.xp
+    assert baseline == 10
+
+    item = item_svc.create_item(
+        XPItem(id=None, name="double", effect_type="boost", amount=2.0, duration=60)
+    )
+    item_svc.assign_to_user(1, item.id)
+    item_svc.apply_item(1, item.id)
+
+    boosted = svc.train(1, skill, 10)
+    assert boosted.xp - baseline == 20


### PR DESCRIPTION
## Summary
- apply active XP item multipliers during skill training
- add test ensuring XP items boost training XP

## Testing
- `pytest backend/tests/services/test_skill_service_xp_items.py -q`
- `PYTHONPATH=. pytest tests/test_skill_service.py::test_skill_gain_with_modifiers -q` *(fails: ModuleNotFoundError: No module named 'utils')*


------
https://chatgpt.com/codex/tasks/task_e_68bca1c719548325a6911307f9bf35b3