### PR TITLE
Add stamina cost to training and recovery mechanism

### DIFF
--- a/backend/services/avatar_service.py
+++ b/backend/services/avatar_service.py
@@ -69,6 +69,19 @@ class AvatarService:
             return avatar
 
     # ------------------------------------------------------------------
+    def recover_stamina(self, avatar_id: int, amount: int) -> Optional[Avatar]:
+        """Increase an avatar's stamina by ``amount`` up to a maximum of 100."""
+
+        with self.session_factory() as session:
+            avatar = session.get(Avatar, avatar_id)
+            if not avatar:
+                return None
+            avatar.stamina = min(100, avatar.stamina + amount)
+            session.commit()
+            session.refresh(avatar)
+            return avatar
+
+    # ------------------------------------------------------------------
     def delete_avatar(self, avatar_id: int) -> bool:
         with self.session_factory() as session:
             avatar = session.get(Avatar, avatar_id)

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -24,6 +24,7 @@ from backend.services.item_service import item_service
 from backend.services.lifestyle_scheduler import lifestyle_xp_modifier
 from backend.services.xp_event_service import XPEventService
 from backend.services.avatar_service import AvatarService
+from backend.schemas.avatar import AvatarUpdate
 
 INTERNET_DEVICE_NAME = "internet device"
 
@@ -258,7 +259,18 @@ class SkillService:
         base_xp *= burnout
         self._method_history[user_id] = (method, streak)
 
-        return self.train(user_id, skill, int(base_xp))
+        result = self.train(user_id, skill, int(base_xp))
+
+        # Training consumes stamina based on session duration.
+        avatar = self.avatar_service.get_avatar(user_id)
+        if avatar:
+            cost = duration // 2
+            new_stamina = max(0, avatar.stamina - cost)
+            self.avatar_service.update_avatar(
+                user_id, AvatarUpdate(stamina=new_stamina)
+            )
+
+        return result
 
     def reduce_burnout(self, user_id: int, amount: int = 1) -> None:
         """Reduce the stored burnout streak for a user.

--- a/backend/tests/avatars/test_avatar_service.py
+++ b/backend/tests/avatars/test_avatar_service.py
@@ -60,5 +60,11 @@ def test_crud_lifecycle():
     # get_mood should reflect persisted value
     assert svc.get_mood(avatar.id) == 55
 
+    # Stamina recovery should increase stamina but not exceed 100
+    svc.update_avatar(avatar.id, AvatarUpdate(stamina=40))
+    svc.recover_stamina(avatar.id, 15)
+    recovered = svc.get_avatar(avatar.id)
+    assert recovered and recovered.stamina == 55
+
     assert svc.delete_avatar(avatar.id)
     assert svc.get_avatar(avatar.id) is None

--- a/backend/tests/skills/test_stamina_decay.py
+++ b/backend/tests/skills/test_stamina_decay.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import sessionmaker
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from backend.models.skill import Skill
+from backend.models.learning_method import LearningMethod
 from backend.schemas.avatar import AvatarCreate
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService
@@ -68,3 +69,19 @@ def test_stamina_scales_daily_decay():
 
     assert low.xp == 84
     assert high.xp == 90
+
+
+def test_training_consumes_and_recovery_restores_stamina():
+    avatar_service = _setup_avatar_service(50, 50)
+    skills = SkillService(avatar_service=avatar_service)
+    skill = Skill(id=2, name="guitar", category="music")
+
+    skills.train_with_method(
+        1, skill, LearningMethod.PRACTICE, duration=4
+    )
+    avatar = avatar_service.get_avatar(1)
+    assert avatar and avatar.stamina == 48
+
+    avatar_service.recover_stamina(1, 5)
+    avatar = avatar_service.get_avatar(1)
+    assert avatar and avatar.stamina == 53


### PR DESCRIPTION
## Summary
- deduct stamina based on training duration
- allow avatars to recover stamina and test the feature

## Testing
- `pytest tests/skills/test_stamina_decay.py tests/avatars/test_avatar_service.py -q`
- `pytest tests/test_skill_service.py -q` *(fails: No module named 'utils')*


------
https://chatgpt.com/codex/tasks/task_e_68bca29f239c8325b254290f2f84bdb9