### PR TITLE
Add image skill training and integrate with fan bonuses

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -49,6 +49,7 @@ from routes import (
     tour_planner_routes,
     trade_routes,
     business_training_routes,
+    image_training_routes,
     university_routes,
     user_settings_routes,
     venue_sponsorships_routes,
@@ -149,6 +150,11 @@ app.include_router(
     business_training_routes.router,
     prefix="/api/training/business",
     tags=["BusinessTraining"],
+)
+app.include_router(
+    image_training_routes.router,
+    prefix="/api/training/image",
+    tags=["ImageTraining"],
 )
 app.include_router(university_routes.router, prefix="/api", tags=["University"])
 app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])

--- a/backend/routes/image_training_routes.py
+++ b/backend/routes/image_training_routes.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.models.skill import Skill
+from backend.services.image_training_service import image_training_service
+
+router = APIRouter(prefix="/training/image", tags=["ImageTraining"])
+
+
+class TrainingPayload(BaseModel):
+    user_id: int
+
+
+@router.post("/workshop/{skill_name}", response_model=Skill)
+def attend_image_workshop(skill_name: str, payload: TrainingPayload) -> Skill:
+    """Attend an image workshop and gain XP."""
+
+    try:
+        return image_training_service.attend_workshop(payload.user_id, skill_name)
+    except ValueError as exc:  # pragma: no cover - simple passthrough
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.post("/course/{skill_name}", response_model=Skill)
+def attend_image_course(skill_name: str, payload: TrainingPayload) -> Skill:
+    """Attend an image course and gain XP."""
+
+    try:
+        return image_training_service.attend_course(payload.user_id, skill_name)
+    except ValueError as exc:  # pragma: no cover - simple passthrough
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+__all__ = [
+    "router",
+    "attend_image_workshop",
+    "attend_image_course",
+    "TrainingPayload",
+]
+

--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -34,9 +34,9 @@ SEED_SKILLS = [
     Skill(id=25, name="fashion", category="image"),
     Skill(id=26, name="image_management", category="image"),
     # Business skills
-    Skill(id=25, name="marketing", category="business"),
-    Skill(id=26, name="public_relations", category="business"),
-    Skill(id=27, name="financial_management", category="business"),
+    Skill(id=27, name="marketing", category="business"),
+    Skill(id=28, name="public_relations", category="business"),
+    Skill(id=29, name="financial_management", category="business"),
 ]
 
 SKILL_NAME_TO_ID = {skill.name: skill.id for skill in SEED_SKILLS}

--- a/backend/services/fan_service.py
+++ b/backend/services/fan_service.py
@@ -109,7 +109,7 @@ def boost_fans_after_gig(band_id: int, location: str, attendance: int):
         (5 + charisma_bonus, band_id, location),
     )
 
-    # Add new fans based on attendance and marketing/PR skill levels
+    # Add new fans based on attendance and marketing/PR/image skill levels
     base_new = attendance // 10
     marketing = Skill(
         id=SKILL_NAME_TO_ID.get("marketing", 0),
@@ -121,10 +121,26 @@ def boost_fans_after_gig(band_id: int, location: str, attendance: int):
         name="public_relations",
         category="business",
     )
+    fashion = Skill(
+        id=SKILL_NAME_TO_ID.get("fashion", 0),
+        name="fashion",
+        category="image",
+    )
+    image_mgmt = Skill(
+        id=SKILL_NAME_TO_ID.get("image_management", 0),
+        name="image_management",
+        category="image",
+    )
     marketing_level = skill_service.train(band_id, marketing, 0).level
     pr_level = skill_service.train(band_id, pr_skill, 0).level
-    skill_multiplier = 1 + 0.05 * max(marketing_level - 1, 0) + 0.05 * max(
-        pr_level - 1, 0
+    fashion_level = skill_service.train(band_id, fashion, 0).level
+    image_level = skill_service.train(band_id, image_mgmt, 0).level
+    skill_multiplier = (
+        1
+        + 0.05 * max(marketing_level - 1, 0)
+        + 0.05 * max(pr_level - 1, 0)
+        + 0.05 * max(fashion_level - 1, 0)
+        + 0.05 * max(image_level - 1, 0)
     )
     new_fans = int(base_new * skill_multiplier)
     for _ in range(new_fans):

--- a/backend/tests/image/__init__.py
+++ b/backend/tests/image/__init__.py
@@ -1,0 +1,2 @@
+# Empty file to mark package for image-related tests
+

--- a/backend/tests/image/test_image_skills.py
+++ b/backend/tests/image/test_image_skills.py
@@ -1,0 +1,47 @@
+import sqlite3
+
+from backend.services import fan_service
+from backend.services.image_training_service import ImageTrainingService
+from backend.services.skill_service import skill_service
+
+
+def test_image_training_awards_xp(tmp_path):
+    skill_service.db_path = tmp_path / "skills.db"
+    skill_service._skills.clear()
+    svc = ImageTrainingService(skill_service=skill_service)
+
+    fashion = svc.attend_workshop(1, "fashion")
+    assert fashion.xp == 40
+    assert fashion.level == 1
+
+    image_mgmt = svc.attend_course(1, "image_management")
+    assert image_mgmt.xp == 100
+    assert image_mgmt.level == 2
+
+
+def test_image_skills_boost_fans(tmp_path, monkeypatch):
+    db = tmp_path / "fans.db"
+    monkeypatch.setattr(fan_service, "DB_PATH", db)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE fans (user_id INTEGER, band_id INTEGER, location TEXT, loyalty INTEGER, source TEXT)"
+        )
+        conn.commit()
+
+    skill_service.db_path = tmp_path / "skills.db"
+    skill_service._skills.clear()
+    training = ImageTrainingService(skill_service=skill_service)
+
+    # baseline
+    result = fan_service.boost_fans_after_gig(1, "NY", 100)
+    assert result["fans_boosted"] == 10
+
+    # train skills to level 3 (200 XP)
+    for _ in range(5):
+        training.attend_workshop(1, "fashion")
+    for _ in range(2):
+        training.attend_course(1, "image_management")
+
+    result = fan_service.boost_fans_after_gig(1, "NY", 100)
+    assert result["fans_boosted"] == 12
+


### PR DESCRIPTION
## Summary
- seed new image skills (fashion, image_management) and fix business skill IDs
- add image training service and routes similar to business training
- apply fashion and image management bonuses when boosting fans
- test image skill training and fan boosts

## Testing
- `pytest backend/tests/image/test_image_skills.py backend/tests/business/test_business_skills.py`

------
https://chatgpt.com/codex/tasks/task_e_68bca64d08588325bc805b2d33a97996