### PR TITLE
Ensure sequential skill IDs and test mapping uniqueness

### DIFF
--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -2,43 +2,56 @@
 
 from backend.models.skill import Skill
 
-SEED_SKILLS = [
-    Skill(id=1, name="guitar", category="instrument"),
-    Skill(id=2, name="bass", category="instrument"),
-    Skill(id=3, name="vocals", category="performance"),
-    Skill(id=4, name="songwriting", category="creative"),
-    Skill(id=5, name="performance", category="stage"),
+_RAW_SKILLS: list[tuple[str, str, str | None]] = [
+    ("guitar", "instrument", None),
+    ("bass", "instrument", None),
+    ("vocals", "performance", None),
+    ("songwriting", "creative", None),
+    ("performance", "stage", None),
     # Expanded instrument skills
-    Skill(id=6, name="drums", category="instrument"),
-    Skill(id=7, name="keyboard", category="instrument"),
-    Skill(id=8, name="piano", category="instrument", parent_id=7),
-    Skill(id=9, name="violin", category="instrument"),
-    Skill(id=10, name="saxophone", category="instrument"),
-    Skill(id=11, name="trumpet", category="instrument"),
-    Skill(id=12, name="dj", category="instrument"),
-    Skill(id=13, name="turntablism", category="instrument", parent_id=12),
+    ("drums", "instrument", None),
+    ("keyboard", "instrument", None),
+    ("piano", "instrument", "keyboard"),
+    ("violin", "instrument", None),
+    ("saxophone", "instrument", None),
+    ("trumpet", "instrument", None),
+    ("dj", "instrument", None),
+    ("turntablism", "instrument", "dj"),
     # Expanded performance skills
-    Skill(id=14, name="dance", category="performance"),
-    Skill(id=15, name="stage_presence", category="performance"),
-    Skill(id=16, name="crowd_interaction", category="performance"),
-    Skill(id=17, name="pyrotechnics", category="performance"),
+    ("dance", "performance", None),
+    ("stage_presence", "performance", None),
+    ("crowd_interaction", "performance", None),
+    ("pyrotechnics", "performance", None),
     # Expanded creative skills
-    Skill(id=18, name="composition", category="creative"),
-    Skill(id=19, name="arrangement", category="creative"),
-    Skill(id=20, name="music_production", category="creative"),
-    Skill(id=21, name="mixing", category="creative", parent_id=20),
-    Skill(id=22, name="mastering", category="creative", parent_id=20),
-    Skill(id=23, name="music_theory", category="creative"),
-    Skill(id=24, name="ear_training", category="creative"),
+    ("composition", "creative", None),
+    ("arrangement", "creative", None),
+    ("music_production", "creative", None),
+    ("mixing", "creative", "music_production"),
+    ("mastering", "creative", "music_production"),
+    ("music_theory", "creative", None),
+    ("ear_training", "creative", None),
     # Image and style skills
-    Skill(id=25, name="fashion", category="image"),
-    Skill(id=26, name="image_management", category="image"),
+    ("fashion", "image", None),
+    ("image_management", "image", None),
     # Business skills
-    Skill(id=27, name="marketing", category="business"),
-    Skill(id=28, name="public_relations", category="business"),
-    Skill(id=29, name="financial_management", category="business"),
+    ("marketing", "business", None),
+    ("public_relations", "business", None),
+    ("financial_management", "business", None),
 ]
 
+
+def _build_skills() -> list[Skill]:
+    skills: list[Skill] = []
+    name_to_id: dict[str, int] = {}
+    for idx, (name, category, parent) in enumerate(_RAW_SKILLS, start=1):
+        parent_id = name_to_id.get(parent)
+        skill = Skill(id=idx, name=name, category=category, parent_id=parent_id)
+        skills.append(skill)
+        name_to_id[name] = idx
+    return skills
+
+
+SEED_SKILLS = _build_skills()
 SKILL_NAME_TO_ID = {skill.name: skill.id for skill in SEED_SKILLS}
 
 

--- a/tests/admin/test_apprenticeship_routes.py
+++ b/tests/admin/test_apprenticeship_routes.py
@@ -17,6 +17,7 @@ from backend.routes.admin_apprenticeship_routes import (  # type: ignore  # noqa
     update_apprenticeship,
     svc,
 )
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID  # noqa: E402
 
 
 def test_apprenticeship_routes_require_admin():
@@ -25,7 +26,7 @@ def test_apprenticeship_routes_require_admin():
         student_id=1,
         mentor_id=2,
         mentor_type="player",
-        skill_id=3,
+        skill_id=SKILL_NAME_TO_ID["vocals"],
         duration_days=7,
         level_requirement=0,
     )
@@ -62,7 +63,7 @@ def test_apprenticeship_routes_crud(monkeypatch, tmp_path):
         student_id=1,
         mentor_id=2,
         mentor_type="player",
-        skill_id=3,
+        skill_id=SKILL_NAME_TO_ID["vocals"],
         duration_days=7,
         level_requirement=0,
     )
@@ -76,7 +77,7 @@ def test_apprenticeship_routes_crud(monkeypatch, tmp_path):
         student_id=1,
         mentor_id=3,
         mentor_type="npc",
-        skill_id=4,
+        skill_id=SKILL_NAME_TO_ID["songwriting"],
         duration_days=10,
         level_requirement=5,
         status="active",

--- a/tests/test_skill_seed.py
+++ b/tests/test_skill_seed.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parents[1]
+sys.path.append(str(BASE))
+sys.path.append(str(BASE / "backend"))
+
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID  # noqa: E402
+
+
+def test_skill_name_to_id_unique_values():
+    values = list(SKILL_NAME_TO_ID.values())
+    assert len(values) == len(set(values))


### PR DESCRIPTION
## Summary
- Rebuild skill seeds using sequentially assigned IDs and rebuild SKILL_NAME_TO_ID
- Update apprenticeship route tests to reference SKILL_NAME_TO_ID instead of hard-coded IDs
- Add unit test asserting SKILL_NAME_TO_ID has no duplicate values

## Testing
- `pytest` *(fails: OperationalError and missing dependencies during collection)*
- `pytest tests/test_skill_seed.py`
- `pytest tests/admin/test_apprenticeship_routes.py`
- `ruff check .` *(fails: 989 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bcab06c1c88325a17fe5730a3ddfbc