### PR TITLE
Add skill prerequisites and enforce training dependencies

### DIFF
--- a/backend/models/skill.py
+++ b/backend/models/skill.py
@@ -24,6 +24,7 @@ class Skill:
     modifier: float = 1.0
     specializations: Dict[str, SkillSpecialization] = field(default_factory=dict)
     specialization: Optional[str] = None
+    prerequisites: Dict[int, int] = field(default_factory=dict)
 
 
 __all__ = ["Skill", "SkillSpecialization"]

--- a/backend/models/skill_seed_store.py
+++ b/backend/models/skill_seed_store.py
@@ -15,7 +15,14 @@ def load_skills() -> List[Skill]:
     """
     if SKILL_SEED_PATH.exists():
         data = json.loads(SKILL_SEED_PATH.read_text())
-        return [Skill(**item) for item in data]
+        skills: List[Skill] = []
+        for item in data:
+            prereqs = {
+                int(k): v for k, v in item.get("prerequisites", {}).items()
+            }
+            item["prerequisites"] = prereqs
+            skills.append(Skill(**item))
+        return skills
     return []
 
 

--- a/backend/routes/admin_music_routes.py
+++ b/backend/routes/admin_music_routes.py
@@ -62,6 +62,7 @@ async def add_skill(skill: SkillSchema, req: Request) -> dict:
         name=skill.name,
         category=skill.category,
         parent_id=skill.parent_id,
+        prerequisites=skill.prerequisites,
     )
     skill_seed.SEED_SKILLS.append(new_skill)
     skill_seed.SKILL_NAME_TO_ID[new_skill.name] = new_skill.id

--- a/backend/schemas/admin_music_schema.py
+++ b/backend/schemas/admin_music_schema.py
@@ -8,6 +8,7 @@ class SkillSchema(BaseModel):
     name: str
     category: str
     parent_id: Optional[int] = None
+    prerequisites: Dict[int, int] = {}
 
 
 class GenreSchema(BaseModel):
@@ -23,6 +24,4 @@ class StageEquipmentSchema(BaseModel):
     brand: str
     rating: int
     genre_affinity: Dict[str, float] = {}
-
-
 __all__ = ["SkillSchema", "GenreSchema", "StageEquipmentSchema"]

--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -2,50 +2,64 @@
 
 from backend.models.skill import Skill
 
-_RAW_SKILLS: list[tuple[str, str, str | None]] = [
-    ("guitar", "instrument", None),
-    ("bass", "instrument", None),
-    ("vocals", "performance", None),
-    ("songwriting", "creative", None),
-    ("performance", "stage", None),
+# name, category, parent_name, prerequisites_by_name
+_RAW_SKILLS: list[tuple[str, str, str | None, dict[str, int]]] = [
+    ("guitar", "instrument", None, {}),
+    ("bass", "instrument", None, {}),
+    ("vocals", "performance", None, {}),
+    ("songwriting", "creative", None, {}),
+    ("performance", "stage", None, {}),
     # Expanded instrument skills
-    ("drums", "instrument", None),
-    ("keyboard", "instrument", None),
-    ("piano", "instrument", "keyboard"),
-    ("violin", "instrument", None),
-    ("saxophone", "instrument", None),
-    ("trumpet", "instrument", None),
-    ("dj", "instrument", None),
-    ("turntablism", "instrument", "dj"),
+    ("drums", "instrument", None, {}),
+    ("keyboard", "instrument", None, {}),
+    ("piano", "instrument", "keyboard", {"keyboard": 100}),
+    ("violin", "instrument", None, {}),
+    ("saxophone", "instrument", None, {}),
+    ("trumpet", "instrument", None, {}),
+    ("dj", "instrument", None, {}),
+    ("turntablism", "instrument", "dj", {"dj": 100}),
     # Expanded performance skills
-    ("dance", "performance", None),
-    ("stage_presence", "performance", None),
-    ("crowd_interaction", "performance", None),
-    ("pyrotechnics", "performance", None),
+    ("dance", "performance", None, {}),
+    ("stage_presence", "performance", None, {}),
+    ("crowd_interaction", "performance", None, {}),
+    ("pyrotechnics", "performance", None, {}),
     # Expanded creative skills
-    ("composition", "creative", None),
-    ("arrangement", "creative", None),
-    ("music_production", "creative", None),
-    ("mixing", "creative", "music_production"),
-    ("mastering", "creative", "music_production"),
-    ("music_theory", "creative", None),
-    ("ear_training", "creative", None),
+    ("composition", "creative", None, {}),
+    ("arrangement", "creative", None, {}),
+    ("music_production", "creative", None, {}),
+    ("mixing", "creative", "music_production", {"music_production": 100}),
+    ("mastering", "creative", "music_production", {"music_production": 100}),
+    ("music_theory", "creative", None, {}),
+    ("ear_training", "creative", None, {}),
     # Image and style skills
-    ("fashion", "image", None),
-    ("image_management", "image", None),
+    ("fashion", "image", None, {}),
+    ("image_management", "image", None, {}),
     # Business skills
-    ("marketing", "business", None),
-    ("public_relations", "business", None),
-    ("financial_management", "business", None),
+    ("marketing", "business", None, {}),
+    ("public_relations", "business", None, {}),
+    ("financial_management", "business", None, {}),
 ]
 
 
 def _build_skills() -> list[Skill]:
     skills: list[Skill] = []
     name_to_id: dict[str, int] = {}
-    for idx, (name, category, parent) in enumerate(_RAW_SKILLS, start=1):
+    for idx, (name, category, parent, prereq_names) in enumerate(
+        _RAW_SKILLS, start=1
+    ):
         parent_id = name_to_id.get(parent)
-        skill = Skill(id=idx, name=name, category=category, parent_id=parent_id)
+        prereqs = {
+            name_to_id[pname]: level
+            for pname, level in prereq_names.items()
+            if pname in name_to_id
+        }
+        skill = Skill(
+            id=idx,
+            name=name,
+            category=category,
+            parent_id=parent_id,
+            prerequisites=prereqs,
+        )
         skills.append(skill)
         name_to_id[name] = idx
     return skills

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -109,10 +109,13 @@ class SkillService:
                 category=skill.category,
                 parent_id=skill.parent_id,
                 specializations=skill.specializations,
+                prerequisites=skill.prerequisites,
             )
         else:
             if skill.specializations:
                 self._skills[key].specializations = skill.specializations
+            if skill.prerequisites:
+                self._skills[key].prerequisites = skill.prerequisites
         return self._skills[key]
 
     def _synergy_bonus(self, user_id: int, skill: Skill) -> float:
@@ -213,8 +216,13 @@ class SkillService:
 
         The method defines XP and cost rates along with level restrictions.
         """
-
         profile = METHOD_PROFILES[method]
+
+        # Ensure prerequisite skills are met before training
+        for prereq_id, required in skill.prerequisites.items():
+            prereq = self._skills.get((user_id, prereq_id))
+            if not prereq or prereq.level < required:
+                raise ValueError("missing prerequisite skills")
 
         inst = self._get_skill(user_id, skill)
 

--- a/backend/tests/admin/test_music_routes.py
+++ b/backend/tests/admin/test_music_routes.py
@@ -36,12 +36,18 @@ def test_add_and_delete_skill(monkeypatch):
         start_len = len(skill_seed.SEED_SKILLS)
         start_max = max(s.id for s in skill_seed.SEED_SKILLS)
 
-        new_schema = admin_music_routes.SkillSchema(name="test_skill", category="instrument")
+        prereq_id = skill_seed.SEED_SKILLS[0].id
+        new_schema = admin_music_routes.SkillSchema(
+            name="test_skill",
+            category="instrument",
+            prerequisites={prereq_id: 100},
+        )
         asyncio.run(admin_music_routes.add_skill(new_schema, req))
         assert len(skill_seed.SEED_SKILLS) == start_len + 1
         added = skill_seed.SEED_SKILLS[-1]
         assert added.name == "test_skill"
         assert added.id == start_max + 1
+        assert added.prerequisites == {prereq_id: 100}
         assert skill_seed.SKILL_NAME_TO_ID["test_skill"] == added.id
 
         other_schema = admin_music_routes.SkillSchema(name="other_skill", category="instrument")

--- a/backend/tests/admin/test_skill_persistence.py
+++ b/backend/tests/admin/test_skill_persistence.py
@@ -41,8 +41,11 @@ def test_skills_persist_across_restarts(tmp_path, monkeypatch):
 
     req = Request({"type": "http"})
 
+    prereq_id = skill_seed.SEED_SKILLS[0].id
     new_schema = admin_music_routes.SkillSchema(
-        name="persisted_skill", category="instrument"
+        name="persisted_skill",
+        category="instrument",
+        prerequisites={prereq_id: 100},
     )
     asyncio.run(admin_music_routes.add_skill(new_schema, req))
 
@@ -53,7 +56,10 @@ def test_skills_persist_across_restarts(tmp_path, monkeypatch):
     del sys.modules["backend.routes.admin_music_routes"]
     admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")
 
-    assert any(s.name == "persisted_skill" for s in skill_seed.SEED_SKILLS)
+    assert any(
+        s.name == "persisted_skill" and s.prerequisites == {prereq_id: 100}
+        for s in skill_seed.SEED_SKILLS
+    )
 
     # Cleanup
     importlib.reload(skill_seed)


### PR DESCRIPTION
## Summary
- allow skills to specify prerequisite skill levels
- support prerequisites in admin music schemas, routes, and seed data
- prevent training until prerequisites are met and add tests

## Testing
- `pytest tests/test_skill_service.py backend/tests/admin/test_music_routes.py backend/tests/admin/test_skill_persistence.py`
- `pytest tests/test_skill_seed.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcae47ea688325b99ee40df17b2b72