### PR TITLE
Add attribute training service with stamina-based cost reduction

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -50,6 +50,7 @@ from routes import (
     trade_routes,
     business_training_routes,
     image_training_routes,
+    attribute_routes,
     university_routes,
     user_settings_routes,
     venue_sponsorships_routes,
@@ -155,6 +156,11 @@ app.include_router(
     image_training_routes.router,
     prefix="/api/training/image",
     tags=["ImageTraining"],
+)
+app.include_router(
+    attribute_routes.router,
+    prefix="/api",
+    tags=["Attributes"],
 )
 app.include_router(university_routes.router, prefix="/api", tags=["University"])
 app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])

--- a/backend/models/attribute.py
+++ b/backend/models/attribute.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Attribute:
+    """Represents a trainable user attribute."""
+
+    stat: str
+    xp: int = 0
+    level: int = 1
+
+
+__all__ = ["Attribute"]

--- a/backend/routes/attribute_routes.py
+++ b/backend/routes/attribute_routes.py
@@ -1,0 +1,19 @@
+"""Routes for training user attributes."""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from backend.services.attribute_service import attribute_service
+
+router = APIRouter()
+
+
+class TrainAttributeRequest(BaseModel):
+    stat: str
+    amount: int
+
+
+@router.post("/avatar/{user_id}/train_attribute")
+def train_attribute(user_id: int, req: TrainAttributeRequest) -> dict:
+    attr = attribute_service.train_attribute(user_id, req.stat, req.amount)
+    return {"stat": attr.stat, "xp": attr.xp, "level": attr.level}

--- a/backend/services/attribute_service.py
+++ b/backend/services/attribute_service.py
@@ -1,0 +1,44 @@
+"""Service for managing user attributes."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from backend.models.attribute import Attribute
+
+
+class AttributeService:
+    """Track and train attributes for users."""
+
+    def __init__(self) -> None:
+        # keyed by (user_id, stat)
+        self._attributes: Dict[Tuple[int, str], Attribute] = {}
+
+    def _get(self, user_id: int, stat: str) -> Attribute:
+        key = (user_id, stat)
+        if key not in self._attributes:
+            self._attributes[key] = Attribute(stat=stat)
+        return self._attributes[key]
+
+    def get_attribute(self, user_id: int, stat: str) -> Attribute:
+        """Return a user's attribute, creating if necessary."""
+
+        return self._get(user_id, stat)
+
+    def train_attribute(self, user_id: int, stat: str, amount: int) -> Attribute:
+        """Increment XP for a stat and update its level.
+
+        Stamina reduces the effective training cost for other stats by its
+        current level.
+        """
+
+        attr = self._get(user_id, stat)
+        stamina_level = self._get(user_id, "stamina").level
+        reduction = stamina_level if stat != "stamina" else 0
+        gained = max(1, amount - reduction)
+        attr.xp += gained
+        attr.level = attr.xp // 100 + 1
+        return attr
+
+
+attribute_service = AttributeService()

--- a/tests/test_attribute_service.py
+++ b/tests/test_attribute_service.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from backend.services.attribute_service import AttributeService  # noqa: E402
+
+
+def test_attribute_levels_up():
+    service = AttributeService()
+    attr = service.train_attribute(user_id=1, stat="stamina", amount=150)
+    assert attr.xp == 150
+    assert attr.level == 2
+
+
+def test_stamina_reduces_training_cost():
+    service = AttributeService()
+    # Train stamina to level 3 (200 xp)
+    service.train_attribute(user_id=1, stat="stamina", amount=200)
+    # Train strength with stamina bonus
+    attr = service.train_attribute(user_id=1, stat="strength", amount=50)
+    assert attr.xp == 47  # cost reduced by stamina level 3
+    assert attr.level == 1
+    attr = service.train_attribute(user_id=1, stat="strength", amount=60)
+    # Additional 57 xp -> total 104 xp -> level 2
+    assert attr.xp == 104
+    assert attr.level == 2


### PR DESCRIPTION
## Summary
- add `Attribute` model for tracking xp and levels per stat
- implement `AttributeService` with stamina-based training cost reductions
- expose `/avatar/{user_id}/train_attribute` route and wire router into app
- cover attribute leveling and stamina effect with unit tests

## Testing
- `ruff check backend/models/attribute.py backend/services/attribute_service.py backend/routes/attribute_routes.py tests/test_attribute_service.py`
- `pytest tests/test_attribute_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb040d7708325b12495db23153b40