### PR TITLE
Add luck stat to avatars and adjust random rewards

### DIFF
--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -61,6 +61,7 @@ class Avatar(Base):
     intelligence = Column(Integer, default=50)
     creativity = Column(Integer, default=50)
     discipline = Column(Integer, default=50)
+    luck = Column(Integer, default=0)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -30,6 +30,7 @@ class AvatarBase(BaseModel):
     intelligence: int = 50
     creativity: int = 50
     discipline: int = 50
+    luck: int = 0
 
 
 class AvatarCreate(AvatarBase):
@@ -60,8 +61,16 @@ class AvatarUpdate(BaseModel):
     intelligence: Optional[int] = None
     creativity: Optional[int] = None
     discipline: Optional[int] = None
+    luck: Optional[int] = None
 
-    @field_validator("stamina", "charisma", "intelligence", "creativity", "discipline")
+    @field_validator(
+        "stamina",
+        "charisma",
+        "intelligence",
+        "creativity",
+        "discipline",
+        "luck",
+    )
     @classmethod
     def _validate_stats(cls, v: int | None) -> int | None:
         if v is not None and not 0 <= v <= 100:

--- a/backend/services/avatar_service.py
+++ b/backend/services/avatar_service.py
@@ -40,7 +40,9 @@ class AvatarService:
     # ------------------------------------------------------------------
     def create_avatar(self, data: AvatarCreate) -> Avatar:
         with self.session_factory() as session:
-            avatar = Avatar(**data.model_dump())
+            payload = data.model_dump()
+            payload.setdefault("luck", 0)
+            avatar = Avatar(**payload)
             session.add(avatar)
             session.commit()
             session.refresh(avatar)
@@ -69,6 +71,7 @@ class AvatarService:
                     "intelligence",
                     "creativity",
                     "discipline",
+                    "luck",
                 } and value is not None:
                     setattr(avatar, field, max(0, min(100, value)))
                 else:

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -42,15 +42,20 @@ def _ensure_schema() -> None:
         conn.commit()
 
 
-def roll_for_daily_event(user_id, lifestyle_data, active_skills):
-    """Determine if a daily event triggers for the user."""
+def roll_for_daily_event(user_id, lifestyle_data, active_skills, *, luck: int = 0):
+    """Determine if a daily event triggers for the user.
+
+    ``luck`` scales the probability of negative outcomes. A higher value
+    reduces the chance of detrimental events.
+    """
 
     vocals_id = SKILL_NAME_TO_ID["vocals"]
     guitar_id = SKILL_NAME_TO_ID["guitar"]
 
     # Sample logic: if drinking high and vocals practiced 5 days in a row
+    luck_factor = max(0.0, 1 - luck / 100)
     if lifestyle_data.get("drinking") == "high" and vocals_id in active_skills:
-        if random.random() < 0.15:
+        if random.random() < 0.15 * luck_factor:
             return {
                 "event": "vocal fatigue",
                 "effect": "freeze_progress",
@@ -58,7 +63,7 @@ def roll_for_daily_event(user_id, lifestyle_data, active_skills):
                 "duration": 3,
             }
 
-    if random.random() < 0.01:
+    if random.random() < 0.01 * luck_factor:
         return {
             "event": "sprained wrist",
             "effect": "block_skill",

--- a/backend/tests/test_luck_bonus.py
+++ b/backend/tests/test_luck_bonus.py
@@ -1,0 +1,24 @@
+import random
+
+from backend.services.random_event_service import RandomEventService
+
+
+def run_trials(service, luck: int, iterations: int = 1000) -> int:
+    options = [
+        {"type": "good", "description": "", "impact": {"fame": 5}},
+        {"type": "bad", "description": "", "impact": {"fame": -5}},
+    ]
+    good = 0
+    for _ in range(iterations):
+        event = service._trigger(None, 1, None, options, luck=luck)
+        if event["type"] == "good":
+            good += 1
+    return good
+
+
+def test_high_luck_increases_positive_events():
+    random.seed(0)
+    service = RandomEventService(db=None)
+    low = run_trials(service, luck=0)
+    high = run_trials(service, luck=80)
+    assert high > low


### PR DESCRIPTION
## Summary
- introduce `luck` stat for avatars with schema and model support
- use luck to influence random event probabilities and daily event rolls
- clamp and seed luck in avatar service and test luck-based outcomes

## Testing
- `ruff check backend/models/avatar.py backend/schemas/avatar.py backend/services/event_service.py backend/services/random_event_service.py backend/services/avatar_service.py backend/tests/test_luck_bonus.py`
- `python -m pytest backend/tests/test_luck_bonus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb15b9154832599b0ff016f2827c9