### PR TITLE
Implement perk system with unlock evaluation and routing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -51,6 +51,7 @@ from routes import (
     business_training_routes,
     image_training_routes,
     attribute_routes,
+    perk_routes,
     university_routes,
     user_settings_routes,
     venue_sponsorships_routes,
@@ -162,6 +163,7 @@ app.include_router(
     prefix="/api",
     tags=["Attributes"],
 )
+app.include_router(perk_routes.router, prefix="/api", tags=["Perks"])
 app.include_router(university_routes.router, prefix="/api", tags=["University"])
 app.include_router(daily_loop_routes.router, prefix="/api", tags=["DailyLoop"])
 app.include_router(user_settings_routes.router, prefix="/api", tags=["UserSettings"])

--- a/backend/models/perk.py
+++ b/backend/models/perk.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class Perk:
+    """Represents a gameplay perk unlocked via requirements."""
+
+    id: int
+    name: str
+    description: str
+    requirements: Dict[str, int] = field(default_factory=dict)
+
+
+__all__ = ["Perk"]

--- a/backend/routes/perk_routes.py
+++ b/backend/routes/perk_routes.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+
+from backend.services.perk_service import perk_service
+
+router = APIRouter()
+
+
+@router.get("/avatar/{user_id}/perks")
+def list_perks(user_id: int) -> list[dict]:
+    """Return perks unlocked for the given user."""
+
+    perks = perk_service.get_perks(user_id)
+    return [
+        {"id": p.id, "name": p.name, "description": p.description}
+        for p in perks
+    ]

--- a/backend/services/attribute_service.py
+++ b/backend/services/attribute_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Dict, Tuple
 
 from backend.models.attribute import Attribute
+from backend.services.perk_service import perk_service
 
 
 class AttributeService:
@@ -38,6 +39,8 @@ class AttributeService:
         gained = max(1, amount - reduction)
         attr.xp += gained
         attr.level = attr.xp // 100 + 1
+        # Evaluate perk requirements after level change
+        perk_service.update_attribute(user_id, stat, attr.level)
         return attr
 
 

--- a/backend/services/perk_service.py
+++ b/backend/services/perk_service.py
@@ -1,0 +1,73 @@
+"""Service for managing perk unlocks based on attributes and skills."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Set
+
+from backend.models.perk import Perk
+
+
+class PerkService:
+    """Track perks unlocked by users and evaluate requirements."""
+
+    def __init__(self) -> None:
+        # Registered perk definitions
+        self._perks: Dict[int, Perk] = {}
+        # Map of user -> set of perk ids granted
+        self._granted: Dict[int, Set[int]] = {}
+        # Track user attribute levels
+        self._attributes: Dict[int, Dict[str, int]] = {}
+        # Track user skill levels
+        self._skills: Dict[int, Dict[str, int]] = {}
+
+    # ------------------------------------------------------------------
+    # Registration and queries
+    def register_perk(self, perk: Perk) -> None:
+        self._perks[perk.id] = perk
+
+    def get_perks(self, user_id: int) -> List[Perk]:
+        ids = self._granted.get(user_id, set())
+        return [self._perks[i] for i in ids]
+
+    # ------------------------------------------------------------------
+    # State updates
+    def update_attribute(self, user_id: int, stat: str, level: int) -> None:
+        self._attributes.setdefault(user_id, {})[stat] = level
+        self._evaluate(user_id)
+
+    def update_skill(self, user_id: int, skill: str, level: int) -> None:
+        self._skills.setdefault(user_id, {})[skill] = level
+        self._evaluate(user_id)
+
+    # ------------------------------------------------------------------
+    def _evaluate(self, user_id: int) -> None:
+        granted = self._granted.setdefault(user_id, set())
+        attrs = self._attributes.get(user_id, {})
+        skills = self._skills.get(user_id, {})
+        for perk in self._perks.values():
+            if perk.id in granted:
+                continue
+            meets = True
+            for name, lvl in perk.requirements.items():
+                level = attrs.get(name)
+                if level is None:
+                    level = skills.get(name)
+                if level is None or level < lvl:
+                    meets = False
+                    break
+            if meets:
+                granted.add(perk.id)
+
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        """Clear all stored state (useful for tests)."""
+
+        self._perks.clear()
+        self._granted.clear()
+        self._attributes.clear()
+        self._skills.clear()
+
+
+perk_service = PerkService()
+
+__all__ = ["PerkService", "perk_service"]

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -24,6 +24,7 @@ from backend.services.item_service import item_service
 from backend.services.lifestyle_scheduler import lifestyle_xp_modifier
 from backend.services.xp_event_service import XPEventService
 from backend.services.avatar_service import AvatarService
+from backend.services.perk_service import perk_service
 from backend.schemas.avatar import AvatarUpdate
 from backend.services.xp_item_service import xp_item_service
 
@@ -201,6 +202,8 @@ class SkillService:
 
         inst.xp += gain
         self._check_level(inst)
+        # Evaluate perk requirements after level change
+        perk_service.update_skill(user_id, inst.name, inst.level)
         return inst
 
     def train_with_method(
@@ -285,6 +288,8 @@ class SkillService:
                 user_id, AvatarUpdate(stamina=new_stamina)
             )
 
+        # Perk evaluation occurs within ``train``; ensure latest level stored
+        perk_service.update_skill(user_id, result.name, result.level)
         return result
 
     def reduce_burnout(self, user_id: int, amount: int = 1) -> None:
@@ -320,6 +325,7 @@ class SkillService:
             return None
         inst.xp = max(0, inst.xp - amount)
         self._check_level(inst)
+        perk_service.update_skill(user_id, inst.name, inst.level)
         return inst
 
     def apply_daily_decay(self, user_id: int, amount: int = 1) -> None:

--- a/tests/test_perk_service.py
+++ b/tests/test_perk_service.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from backend.models.perk import Perk
+from backend.models.skill import Skill
+from backend.services.attribute_service import AttributeService
+from backend.services.perk_service import perk_service
+from backend.services.skill_service import SkillService
+
+
+def setup_function() -> None:
+    perk_service.reset()
+
+
+def test_perk_unlocks_from_attribute() -> None:
+    perk_service.register_perk(
+        Perk(id=1, name="Muscle", description="Be strong", requirements={"strength": 2})
+    )
+    attrs = AttributeService()
+    attrs.train_attribute(1, "strength", 101)
+    perks = perk_service.get_perks(1)
+    assert len(perks) == 1 and perks[0].name == "Muscle"
+    # Further training of other stats should not remove the perk
+    attrs.train_attribute(1, "stamina", 50)
+    perks = perk_service.get_perks(1)
+    assert len(perks) == 1
+
+
+def test_perk_unlocks_from_skill() -> None:
+    perk_service.register_perk(
+        Perk(id=2, name="Guitar Hero", description="Skill perk", requirements={"guitar": 2})
+    )
+    svc = SkillService()
+    skill = Skill(id=99, name="guitar", category="instrument")
+    svc.train(1, skill, 100)
+    perks = perk_service.get_perks(1)
+    assert len(perks) == 1 and perks[0].name == "Guitar Hero"
+    # Training other skills should keep the perk unlocked
+    other = Skill(id=100, name="drums", category="instrument")
+    svc.train(1, other, 50)
+    perks = perk_service.get_perks(1)
+    assert any(p.name == "Guitar Hero" for p in perks)


### PR DESCRIPTION
## Summary
- add `Perk` dataclass model
- track perk unlocks through new `PerkService`
- update attribute and skill services to evaluate perks on level changes
- expose `/avatar/{user_id}/perks` endpoint
- cover perk unlocking and persistence with tests

## Testing
- `pytest tests/test_perk_service.py tests/test_attribute_service.py tests/test_skill_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb2a20a6083258122c4c3334c4275