### PR TITLE
feat: add social media stat to avatars

### DIFF
--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -62,6 +62,7 @@ class Avatar(Base):
     creativity = Column(Integer, default=50)
     discipline = Column(Integer, default=50)
     luck = Column(Integer, default=0)
+    social_media = Column(Integer, default=0)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -31,6 +31,7 @@ class AvatarBase(BaseModel):
     creativity: int = 50
     discipline: int = 50
     luck: int = 0
+    social_media: int = 0
 
 
 class AvatarCreate(AvatarBase):
@@ -62,6 +63,7 @@ class AvatarUpdate(BaseModel):
     creativity: Optional[int] = None
     discipline: Optional[int] = None
     luck: Optional[int] = None
+    social_media: Optional[int] = None
 
     @field_validator(
         "stamina",
@@ -70,6 +72,7 @@ class AvatarUpdate(BaseModel):
         "creativity",
         "discipline",
         "luck",
+        "social_media",
     )
     @classmethod
     def _validate_stats(cls, v: int | None) -> int | None:

--- a/backend/services/avatar_service.py
+++ b/backend/services/avatar_service.py
@@ -42,6 +42,7 @@ class AvatarService:
         with self.session_factory() as session:
             payload = data.model_dump()
             payload.setdefault("luck", 0)
+            payload.setdefault("social_media", 0)
             avatar = Avatar(**payload)
             session.add(avatar)
             session.commit()
@@ -72,6 +73,7 @@ class AvatarService:
                     "creativity",
                     "discipline",
                     "luck",
+                    "social_media",
                 } and value is not None:
                     setattr(avatar, field, max(0, min(100, value)))
                 else:

--- a/backend/services/fan_service.py
+++ b/backend/services/fan_service.py
@@ -15,7 +15,8 @@ def add_fan(user_id: int, band_id: int, location: str, source: str = "organic") 
 
     avatar = avatar_service.get_avatar(band_id)
     charisma = avatar.charisma if avatar else 50
-    loyalty_gain = 10 + charisma // 20
+    social_media = getattr(avatar, "social_media", 0) if avatar else 0
+    loyalty_gain = 10 + charisma // 20 + social_media // 25
 
     # Check if fan already exists in that location
     cur.execute(
@@ -36,7 +37,7 @@ def add_fan(user_id: int, band_id: int, location: str, source: str = "organic") 
         )
     else:
         # Create new fan record
-        base_loyalty = 25 + charisma // 10
+        base_loyalty = 25 + charisma // 10 + social_media // 10
         cur.execute(
             """
             INSERT INTO fans (user_id, band_id, location, loyalty, source)
@@ -97,7 +98,8 @@ def boost_fans_after_gig(band_id: int, location: str, attendance: int):
 
     avatar = avatar_service.get_avatar(band_id)
     charisma = avatar.charisma if avatar else 50
-    charisma_bonus = max(1, charisma // 50)
+    social_media = getattr(avatar, "social_media", 0) if avatar else 0
+    charisma_bonus = max(1, (charisma + social_media) // 50)
 
     # Boost existing fans in that location
     cur.execute(
@@ -142,7 +144,8 @@ def boost_fans_after_gig(band_id: int, location: str, attendance: int):
         + 0.05 * max(fashion_level - 1, 0)
         + 0.05 * max(image_level - 1, 0)
     )
-    new_fans = int(base_new * skill_multiplier)
+    social_multiplier = 1 + social_media / 100
+    new_fans = int(base_new * skill_multiplier * social_multiplier)
     for _ in range(new_fans):
         cur.execute(
             """

--- a/backend/tests/social/test_social_media_boosts.py
+++ b/backend/tests/social/test_social_media_boosts.py
@@ -1,0 +1,87 @@
+import sqlite3
+
+from backend.services.stream_service import StreamService
+from backend.services import fan_service
+
+
+class DummyDB:
+    def __init__(self):
+        self.revenues = []
+        self.song = {"royalties_split": {1: 100}}
+
+    def insert_stream(self, stream):
+        pass
+
+    def get_song_by_id(self, song_id):
+        return self.song
+
+    def add_revenue_entry(self, band_id, song_id, revenue, timestamp):
+        self.revenues.append(revenue)
+
+    def get_revenue_by_band(self, band_id):  # pragma: no cover - not used
+        return self.revenues
+
+    def get_streams_by_song(self, song_id):  # pragma: no cover - not used
+        return []
+
+
+class DummyAvatar:
+    def __init__(self, charisma: int = 50, social_media: int = 0):
+        self.charisma = charisma
+        self.social_media = social_media
+
+
+class DummyAvatarService:
+    def __init__(self, social_media: int):
+        self.avatar = DummyAvatar(social_media=social_media)
+
+    def get_avatar(self, _band_id):
+        return self.avatar
+
+
+class DummySkillService:
+    def train(self, band_id, skill, amount):
+        skill.level = 1
+        return skill
+
+
+def test_social_media_boosts_streaming_revenue():
+    db_low = DummyDB()
+    db_high = DummyDB()
+    svc_low = StreamService(db_low, avatar_service=DummyAvatarService(0))
+    svc_high = StreamService(db_high, avatar_service=DummyAvatarService(80))
+    data = {"id": 1, "song_id": 1, "user_id": 1, "platform": "Spotify"}
+    svc_low.record_stream(data)
+    svc_high.record_stream(data)
+    assert db_high.revenues[0] > db_low.revenues[0]
+
+
+def test_social_media_increases_fan_conversions(tmp_path, monkeypatch):
+    db_file = tmp_path / "fans.db"
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE fans (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            band_id INTEGER,
+            location TEXT,
+            loyalty INTEGER,
+            source TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(fan_service, "DB_PATH", db_file)
+    monkeypatch.setattr(fan_service, "skill_service", DummySkillService())
+
+    monkeypatch.setattr(fan_service, "avatar_service", DummyAvatarService(0))
+    low = fan_service.boost_fans_after_gig(1, "NY", 100)
+
+    monkeypatch.setattr(fan_service, "avatar_service", DummyAvatarService(80))
+    high = fan_service.boost_fans_after_gig(1, "NY", 100)
+
+    assert high["fans_boosted"] > low["fans_boosted"]


### PR DESCRIPTION
## Summary
- add social_media integer stat to Avatar model and schema
- clamp social_media to 0-100 when updating
- boost stream revenue and fan growth based on social media score
- add tests for revenue and fan conversion boosts

## Testing
- `pytest backend/tests/social/test_social_media_boosts.py backend/tests/social/test_fan_service_charisma.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb65f2c7083259d77e1e78be3bd62