### PR TITLE
Add networking stat and gate high-profile collaborations

### DIFF
--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -63,6 +63,7 @@ class Avatar(Base):
     discipline = Column(Integer, default=50)
     luck = Column(Integer, default=0)
     social_media = Column(Integer, default=0)
+    networking = Column(Integer, default=0)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/routes/character.py
+++ b/backend/routes/character.py
@@ -2,9 +2,14 @@
 
 from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 from schemas.character import CharacterCreate, CharacterResponse
+from schemas.avatar import AvatarUpdate
+from services.avatar_service import AvatarService
 from services.character_service import character_service
 from utils.i18n import _
+
+avatar_service = AvatarService()
 
 router = APIRouter(prefix="/characters", tags=["Characters"])
 
@@ -75,4 +80,40 @@ def delete_character(
     if not deleted:
         raise HTTPException(status_code=404, detail=_("Character not found"))
     return {"ok": True}
+
+
+class NetworkingUpdate(BaseModel):
+    networking: int
+
+
+@router.get(
+    "/{character_id}/networking",
+    dependencies=[Depends(require_permission(["admin", "player"]))],
+)
+def get_networking(
+    character_id: int, user_id: int = Depends(get_current_user_id)
+) -> dict[str, int]:
+    avatar = avatar_service.get_avatar_by_character_id(character_id)
+    if not avatar:
+        raise HTTPException(status_code=404, detail=_("Character not found"))
+    return {"networking": avatar.networking}
+
+
+@router.put(
+    "/{character_id}/networking",
+    dependencies=[Depends(require_permission(["admin", "player"]))],
+)
+def set_networking(
+    character_id: int,
+    payload: NetworkingUpdate,
+    user_id: int = Depends(get_current_user_id),
+) -> dict[str, int]:
+    avatar = avatar_service.get_avatar_by_character_id(character_id)
+    if not avatar:
+        raise HTTPException(status_code=404, detail=_("Character not found"))
+    updated = avatar_service.update_avatar(
+        avatar.id, AvatarUpdate(networking=payload.networking)
+    )
+    assert updated  # for type checkers
+    return {"networking": updated.networking}
 

--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -32,6 +32,7 @@ class AvatarBase(BaseModel):
     discipline: int = 50
     luck: int = 0
     social_media: int = 0
+    networking: int = 0
 
 
 class AvatarCreate(AvatarBase):
@@ -64,6 +65,7 @@ class AvatarUpdate(BaseModel):
     discipline: Optional[int] = None
     luck: Optional[int] = None
     social_media: Optional[int] = None
+    networking: Optional[int] = None
 
     @field_validator(
         "stamina",
@@ -73,6 +75,7 @@ class AvatarUpdate(BaseModel):
         "discipline",
         "luck",
         "social_media",
+        "networking",
     )
     @classmethod
     def _validate_stats(cls, v: int | None) -> int | None:

--- a/backend/services/avatar_service.py
+++ b/backend/services/avatar_service.py
@@ -43,6 +43,7 @@ class AvatarService:
             payload = data.model_dump()
             payload.setdefault("luck", 0)
             payload.setdefault("social_media", 0)
+            payload.setdefault("networking", 0)
             avatar = Avatar(**payload)
             session.add(avatar)
             session.commit()
@@ -74,6 +75,7 @@ class AvatarService:
                     "discipline",
                     "luck",
                     "social_media",
+                    "networking",
                 } and value is not None:
                     setattr(avatar, field, max(0, min(100, value)))
                 else:
@@ -81,6 +83,15 @@ class AvatarService:
             session.commit()
             session.refresh(avatar)
             return avatar
+
+    # ------------------------------------------------------------------
+    def get_avatar_by_character_id(self, character_id: int) -> Optional[Avatar]:
+        with self.session_factory() as session:
+            return (
+                session.query(Avatar)
+                .filter(Avatar.character_id == character_id)
+                .first()
+            )
 
     # ------------------------------------------------------------------
     def recover_stamina(self, avatar_id: int, amount: int) -> Optional[Avatar]:

--- a/backend/services/band_relationship_service.py
+++ b/backend/services/band_relationship_service.py
@@ -62,7 +62,11 @@ class BandRelationshipService:
         relationship_type: str,
         affinity: Optional[int] = None,
         compatibility: Optional[int] = None,
+        high_profile: bool = False,
+        networking: int = 0,
     ) -> dict:
+        if high_profile and networking < 60:
+            raise ValueError("Networking too low for high-profile collaboration")
         rel = BandRelationship(
             id=None,
             band_a_id=band_a_id,

--- a/backend/tests/routes/test_character_networking.py
+++ b/backend/tests/routes/test_character_networking.py
@@ -1,0 +1,75 @@
+import types
+import sys
+
+
+def load_character_module(monkeypatch):
+    class DummyRouter:
+        def __init__(self, *args, **kwargs):
+            pass
+        def get(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+            return decorator
+
+        def put(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+            return decorator
+
+        def post(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+            return decorator
+
+        def delete(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+            return decorator
+
+    monkeypatch.setattr("fastapi.APIRouter", DummyRouter)
+
+    from auth import dependencies as deps
+
+    def fake_require_permission(_roles):
+        def _dep():
+            return True
+
+        return _dep
+
+    deps.require_permission = fake_require_permission
+    deps.get_current_user_id = lambda: 1
+
+    sys.modules.pop("routes.character", None)
+    import routes.character as character_routes
+
+    return character_routes
+
+
+class DummyAvatar:
+    def __init__(self, networking=20):
+        self.id = 1
+        self.networking = networking
+
+
+class DummyAvatarService:
+    def __init__(self):
+        self.avatar = DummyAvatar()
+
+    def get_avatar_by_character_id(self, character_id: int):
+        return self.avatar
+
+    def update_avatar(self, avatar_id: int, data):
+        if getattr(data, "networking", None) is not None:
+            self.avatar.networking = data.networking
+        return self.avatar
+
+
+def test_networking_routes(monkeypatch):
+    character_routes = load_character_module(monkeypatch)
+    svc = DummyAvatarService()
+    monkeypatch.setattr(character_routes, "avatar_service", svc)
+    result = character_routes.get_networking(1, user_id=1)
+    assert result == {"networking": 20}
+    character_routes.set_networking(1, character_routes.NetworkingUpdate(networking=90), user_id=1)
+    result = character_routes.get_networking(1, user_id=1)
+    assert result == {"networking": 90}

--- a/backend/tests/services/test_band_relationship_networking.py
+++ b/backend/tests/services/test_band_relationship_networking.py
@@ -1,0 +1,12 @@
+import pytest
+from services.band_relationship_service import BandRelationshipService
+
+
+def test_high_profile_collab_requires_networking():
+    svc = BandRelationshipService()
+    # low networking should block
+    with pytest.raises(ValueError):
+        svc.create_relationship(1, 2, "collab", high_profile=True, networking=30)
+    # high networking should allow
+    rel = svc.create_relationship(1, 2, "collab", high_profile=True, networking=80)
+    assert rel["band_a_id"] == 1 and rel["band_b_id"] == 2


### PR DESCRIPTION
## Summary
- add networking stat to avatars and expose via API
- gate high-profile band collaborations on networking
- basic tests for networking routes and band relationship gating

## Testing
- `pytest backend/tests/services/test_band_relationship_networking.py backend/tests/routes/test_character_networking.py backend/tests/avatars/test_avatar_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcb79122c483258318689d1a2c1eee