### PR TITLE
Add tech savvy avatar attribute influencing digital production and streaming

### DIFF
--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -63,6 +63,7 @@ class Avatar(Base):
     discipline = Column(Integer, default=50)
     luck = Column(Integer, default=0)
     social_media = Column(Integer, default=0)
+    tech_savvy = Column(Integer, default=0)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -32,6 +32,7 @@ class AvatarBase(BaseModel):
     discipline: int = 50
     luck: int = 0
     social_media: int = 0
+    tech_savvy: int = 0
 
 
 class AvatarCreate(AvatarBase):
@@ -64,6 +65,7 @@ class AvatarUpdate(BaseModel):
     discipline: Optional[int] = None
     luck: Optional[int] = None
     social_media: Optional[int] = None
+    tech_savvy: Optional[int] = None
 
     @field_validator(
         "stamina",
@@ -73,6 +75,7 @@ class AvatarUpdate(BaseModel):
         "discipline",
         "luck",
         "social_media",
+        "tech_savvy",
     )
     @classmethod
     def _validate_stats(cls, v: int | None) -> int | None:

--- a/backend/services/avatar_service.py
+++ b/backend/services/avatar_service.py
@@ -43,6 +43,7 @@ class AvatarService:
             payload = data.model_dump()
             payload.setdefault("luck", 0)
             payload.setdefault("social_media", 0)
+            payload.setdefault("tech_savvy", 0)
             avatar = Avatar(**payload)
             session.add(avatar)
             session.commit()
@@ -74,6 +75,7 @@ class AvatarService:
                     "discipline",
                     "luck",
                     "social_media",
+                    "tech_savvy",
                 } and value is not None:
                     setattr(avatar, field, max(0, min(100, value)))
                 else:

--- a/backend/services/music_production_service.py
+++ b/backend/services/music_production_service.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Music production utilities influenced by avatar tech savvy."""
+
+from backend.services.avatar_service import AvatarService
+
+
+class MusicProductionService:
+    """Simplified production calculations that factor in an avatar's tech skills."""
+
+    def __init__(self, avatar_service: AvatarService | None = None):
+        self.avatar_service = avatar_service or AvatarService()
+
+    def produce_track(
+        self,
+        band_id: int,
+        base_minutes: int,
+        base_stamina_cost: int = 10,
+        base_xp: int = 5,
+    ) -> dict[str, int]:
+        """Return production metrics adjusted by tech_savvy.
+
+        ``tech_savvy`` between 0-100 reduces time and stamina cost while
+        increasing the XP gain from the session.  Values are clamped so the
+        production still requires at least one minute and non-negative stamina.
+        """
+
+        avatar = self.avatar_service.get_avatar(band_id)
+        tech = getattr(avatar, "tech_savvy", 0) if avatar else 0
+        time_minutes = max(1, int(base_minutes * (100 - tech) / 100))
+        stamina_cost = max(0, int(base_stamina_cost * (100 - tech) / 100))
+        xp_gain = int(base_xp * (1 + tech / 100))
+        return {
+            "time_minutes": time_minutes,
+            "stamina_cost": stamina_cost,
+            "xp_gain": xp_gain,
+        }

--- a/backend/services/stream_service.py
+++ b/backend/services/stream_service.py
@@ -27,7 +27,10 @@ class StreamService:
         for band_id, percent in song['royalties_split'].items():
             avatar = self.avatar_service.get_avatar(band_id)
             social_media = getattr(avatar, "social_media", 0) if avatar else 0
-            revenue = total_amount * (percent / 100) * (1 + social_media / 100)
+            tech = getattr(avatar, "tech_savvy", 0) if avatar else 0
+            revenue = total_amount * (percent / 100) * (1 + social_media / 100) * (
+                1 + tech / 100
+            )
             self.db.add_revenue_entry(band_id, stream.song_id, revenue, stream.timestamp)
 
     def get_band_revenue(self, band_id):

--- a/backend/tests/avatars/test_avatar_service.py
+++ b/backend/tests/avatars/test_avatar_service.py
@@ -110,6 +110,8 @@ def test_update_validation_and_clamping():
         AvatarUpdate(creativity=120)
     with pytest.raises(ValueError):
         AvatarUpdate(discipline=-5)
+    with pytest.raises(ValueError):
+        AvatarUpdate(tech_savvy=200)
 
     # Bypass validation to ensure service clamps the values
     update_data = AvatarUpdate.model_construct(
@@ -118,6 +120,7 @@ def test_update_validation_and_clamping():
         intelligence=101,
         creativity=120,
         discipline=-5,
+        tech_savvy=150,
     )
     svc.update_avatar(avatar.id, update_data)
     updated = svc.get_avatar(avatar.id)
@@ -128,4 +131,5 @@ def test_update_validation_and_clamping():
         and updated.intelligence == 100
         and updated.creativity == 100
         and updated.discipline == 0
+        and updated.tech_savvy == 100
     )

--- a/backend/tests/production/test_tech_savvy_production.py
+++ b/backend/tests/production/test_tech_savvy_production.py
@@ -1,0 +1,24 @@
+from backend.services.music_production_service import MusicProductionService
+
+
+class DummyAvatar:
+    def __init__(self, tech_savvy: int):
+        self.tech_savvy = tech_savvy
+
+
+class DummyAvatarService:
+    def __init__(self, tech_savvy: int):
+        self.avatar = DummyAvatar(tech_savvy)
+
+    def get_avatar(self, _band_id):
+        return self.avatar
+
+
+def test_tech_savvy_reduces_production_time_and_stamina():
+    svc_low = MusicProductionService(avatar_service=DummyAvatarService(0))
+    svc_high = MusicProductionService(avatar_service=DummyAvatarService(80))
+    result_low = svc_low.produce_track(1, base_minutes=120, base_stamina_cost=20)
+    result_high = svc_high.produce_track(1, base_minutes=120, base_stamina_cost=20)
+    assert result_high["time_minutes"] < result_low["time_minutes"]
+    assert result_high["stamina_cost"] < result_low["stamina_cost"]
+    assert result_high["xp_gain"] > result_low["xp_gain"]

--- a/backend/tests/social/test_social_media_boosts.py
+++ b/backend/tests/social/test_social_media_boosts.py
@@ -26,14 +26,15 @@ class DummyDB:
 
 
 class DummyAvatar:
-    def __init__(self, charisma: int = 50, social_media: int = 0):
+    def __init__(self, charisma: int = 50, social_media: int = 0, tech_savvy: int = 0):
         self.charisma = charisma
         self.social_media = social_media
+        self.tech_savvy = tech_savvy
 
 
 class DummyAvatarService:
-    def __init__(self, social_media: int):
-        self.avatar = DummyAvatar(social_media=social_media)
+    def __init__(self, social_media: int, tech_savvy: int = 0):
+        self.avatar = DummyAvatar(social_media=social_media, tech_savvy=tech_savvy)
 
     def get_avatar(self, _band_id):
         return self.avatar
@@ -50,6 +51,17 @@ def test_social_media_boosts_streaming_revenue():
     db_high = DummyDB()
     svc_low = StreamService(db_low, avatar_service=DummyAvatarService(0))
     svc_high = StreamService(db_high, avatar_service=DummyAvatarService(80))
+    data = {"id": 1, "song_id": 1, "user_id": 1, "platform": "Spotify"}
+    svc_low.record_stream(data)
+    svc_high.record_stream(data)
+    assert db_high.revenues[0] > db_low.revenues[0]
+
+
+def test_tech_savvy_boosts_streaming_revenue():
+    db_low = DummyDB()
+    db_high = DummyDB()
+    svc_low = StreamService(db_low, avatar_service=DummyAvatarService(0, tech_savvy=0))
+    svc_high = StreamService(db_high, avatar_service=DummyAvatarService(0, tech_savvy=80))
     data = {"id": 1, "song_id": 1, "user_id": 1, "platform": "Spotify"}
     svc_low.record_stream(data)
     svc_high.record_stream(data)


### PR DESCRIPTION
## Summary
- extend avatar model and schema with `tech_savvy` and clamp it through the avatar service
- scale stream payouts and production metrics based on `tech_savvy`
- add music production helper service plus tests for production and streaming boosts

## Testing
- `pytest backend/tests/avatars/test_avatar_service.py backend/tests/social/test_social_media_boosts.py backend/tests/production/test_tech_savvy_production.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'BookIn' from 'backend.routes.admin_book_routes')*

------
https://chatgpt.com/codex/tasks/task_e_68bcb8a31d5c83259885d42aacf0203a