### PR TITLE
Add avatar resilience and rest recovery mechanics

### DIFF
--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -61,6 +61,7 @@ class Avatar(Base):
     intelligence = Column(Integer, default=50)
     creativity = Column(Integer, default=50)
     discipline = Column(Integer, default=50)
+    resilience = Column(Integer, default=50)
     luck = Column(Integer, default=0)
     social_media = Column(Integer, default=0)
     tech_savvy = Column(Integer, default=0)

--- a/backend/routes/lifestyle_routes.py
+++ b/backend/routes/lifestyle_routes.py
@@ -6,8 +6,10 @@ from services.lifestyle_service import (
     evaluate_lifestyle_risks,
     apply_recovery_action,
 )
+from services.avatar_service import AvatarService
 
 router = APIRouter()
+avatar_service = AvatarService()
 
 fake_lifestyle_data = {
     "user_id": 1,
@@ -33,8 +35,32 @@ def get_lifestyle():
 
 @router.post("/lifestyle/recover/{action}")
 def recover(action: str):
-    apply_recovery_action(fake_lifestyle_data["user_id"], fake_lifestyle_data, action)
+    apply_recovery_action(
+        fake_lifestyle_data["user_id"],
+        fake_lifestyle_data,
+        action,
+        avatar_service=avatar_service,
+    )
     score = calculate_lifestyle_score(fake_lifestyle_data)
     events = evaluate_lifestyle_risks(fake_lifestyle_data)
     fake_lifestyle_data["lifestyle_score"] = score
     return {"lifestyle": fake_lifestyle_data, "risk_events": events}
+
+
+@router.post("/lifestyle/rest")
+def rest():
+    apply_recovery_action(
+        fake_lifestyle_data["user_id"],
+        fake_lifestyle_data,
+        "rest",
+        avatar_service=avatar_service,
+    )
+    score = calculate_lifestyle_score(fake_lifestyle_data)
+    events = evaluate_lifestyle_risks(fake_lifestyle_data)
+    fake_lifestyle_data["lifestyle_score"] = score
+    avatar = avatar_service.get_avatar(fake_lifestyle_data["user_id"])
+    return {
+        "lifestyle": fake_lifestyle_data,
+        "risk_events": events,
+        "avatar": avatar,
+    }

--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -30,6 +30,7 @@ class AvatarBase(BaseModel):
     intelligence: int = 50
     creativity: int = 50
     discipline: int = 50
+    resilience: int = 50
     luck: int = 0
     social_media: int = 0
     tech_savvy: int = 0
@@ -64,6 +65,7 @@ class AvatarUpdate(BaseModel):
     intelligence: Optional[int] = None
     creativity: Optional[int] = None
     discipline: Optional[int] = None
+    resilience: Optional[int] = None
     luck: Optional[int] = None
     social_media: Optional[int] = None
     tech_savvy: Optional[int] = None
@@ -75,6 +77,7 @@ class AvatarUpdate(BaseModel):
         "intelligence",
         "creativity",
         "discipline",
+        "resilience",
         "luck",
         "social_media",
         "tech_savvy",

--- a/backend/services/avatar_service.py
+++ b/backend/services/avatar_service.py
@@ -45,6 +45,7 @@ class AvatarService:
             payload.setdefault("social_media", 0)
             payload.setdefault("tech_savvy", 0)
             payload.setdefault("networking", 0)
+            payload.setdefault("resilience", 50)
             avatar = Avatar(**payload)
             session.add(avatar)
             session.commit()
@@ -74,6 +75,7 @@ class AvatarService:
                     "intelligence",
                     "creativity",
                     "discipline",
+                    "resilience",
                     "luck",
                     "social_media",
                     "tech_savvy",

--- a/backend/tests/lifestyle/test_resilience_effects.py
+++ b/backend/tests/lifestyle/test_resilience_effects.py
@@ -1,0 +1,121 @@
+import random
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.avatar import Base as AvatarBase
+from models.character import Base as CharacterBase, Character
+from schemas.avatar import AvatarCreate
+from services.avatar_service import AvatarService
+from services import lifestyle_service
+
+
+class DummySkillService:
+    def reduce_burnout(self, user_id, amount=1):
+        pass
+
+
+def setup_services(res_low: int, res_high: int):
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    CharacterBase.metadata.create_all(bind=engine)
+    AvatarBase.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    avatar_svc = AvatarService(SessionLocal)
+
+    with SessionLocal() as session:
+        c1 = Character(name="L", genre="rock", trait="x", birthplace="Earth")
+        c2 = Character(name="H", genre="rock", trait="x", birthplace="Earth")
+        session.add_all([c1, c2])
+        session.commit()
+        id1, id2 = c1.id, c2.id
+
+    av1 = avatar_svc.create_avatar(
+        AvatarCreate(
+            character_id=id1,
+            nickname="low",
+            body_type="slim",
+            skin_tone="pale",
+            face_shape="oval",
+            hair_style="short",
+            hair_color="black",
+            top_clothing="t",
+            bottom_clothing="j",
+            shoes="b",
+            resilience=res_low,
+            stamina=50,
+        )
+    )
+    av2 = avatar_svc.create_avatar(
+        AvatarCreate(
+            character_id=id2,
+            nickname="high",
+            body_type="slim",
+            skin_tone="pale",
+            face_shape="oval",
+            hair_style="short",
+            hair_color="black",
+            top_clothing="t",
+            bottom_clothing="j",
+            shoes="b",
+            resilience=res_high,
+            stamina=50,
+        )
+    )
+    return avatar_svc, av1.id, av2.id
+
+
+def test_high_resilience_delays_burnout(monkeypatch):
+    avatar_svc, low_id, high_id = setup_services(10, 90)
+    monkeypatch.setattr(lifestyle_service, "skill_service", DummySkillService())
+    lifestyle_low = {
+        "user_id": low_id,
+        "stress": 80,
+        "drinking": "light",
+        "sleep_hours": 8,
+        "nutrition": 50,
+        "fitness": 50,
+    }
+    lifestyle_high = {
+        "user_id": high_id,
+        "stress": 80,
+        "drinking": "light",
+        "sleep_hours": 8,
+        "nutrition": 50,
+        "fitness": 50,
+    }
+    lifestyle_service._RECOVERY_ACTIONS["overwork"] = {"stress": 10}
+    lifestyle_service.apply_recovery_action(low_id, lifestyle_low, "overwork", avatar_service=avatar_svc)
+    lifestyle_service.apply_recovery_action(high_id, lifestyle_high, "overwork", avatar_service=avatar_svc)
+    assert lifestyle_low["stress"] > lifestyle_high["stress"]
+    monkeypatch.setattr(random, "random", lambda: 0)
+    events_low = lifestyle_service.evaluate_lifestyle_risks(lifestyle_low)
+    events_high = lifestyle_service.evaluate_lifestyle_risks(lifestyle_high)
+    assert "burnout" in events_low
+    assert "burnout" not in events_high
+
+
+def test_high_resilience_accelerates_recovery(monkeypatch):
+    avatar_svc, low_id, high_id = setup_services(10, 90)
+    monkeypatch.setattr(lifestyle_service, "skill_service", DummySkillService())
+    lifestyle_low = {
+        "user_id": low_id,
+        "stress": 90,
+        "drinking": "light",
+        "sleep_hours": 8,
+        "nutrition": 50,
+        "fitness": 50,
+    }
+    lifestyle_high = {
+        "user_id": high_id,
+        "stress": 90,
+        "drinking": "light",
+        "sleep_hours": 8,
+        "nutrition": 50,
+        "fitness": 50,
+    }
+    lifestyle_service.apply_recovery_action(low_id, lifestyle_low, "rest", avatar_service=avatar_svc)
+    lifestyle_service.apply_recovery_action(high_id, lifestyle_high, "rest", avatar_service=avatar_svc)
+    assert lifestyle_high["stress"] < lifestyle_low["stress"]
+    low_avatar = avatar_svc.get_avatar(low_id)
+    high_avatar = avatar_svc.get_avatar(high_id)
+    assert high_avatar.stamina > low_avatar.stamina


### PR DESCRIPTION
## Summary
- introduce resilience stat to avatars and validate in schemas and service
- factor resilience into lifestyle recovery to temper stress and boost stamina
- expose lifestyle rest endpoint and tests for resilience effects

## Testing
- `python -m pytest backend/tests/avatars/test_avatar_service.py backend/tests/lifestyle/test_resilience_effects.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcbcb31324832596107359da542fb6