### PR TITLE
Add social media management skill and training

### DIFF
--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -38,6 +38,7 @@ _RAW_SKILLS: list[tuple[str, str, str | None, dict[str, int]]] = [
     ("marketing", "business", None, {}),
     ("public_relations", "business", None, {}),
     ("financial_management", "business", None, {}),
+    ("social_media_management", "business", None, {}),
 ]
 
 

--- a/backend/services/fan_service.py
+++ b/backend/services/fan_service.py
@@ -133,16 +133,23 @@ def boost_fans_after_gig(band_id: int, location: str, attendance: int):
         name="image_management",
         category="image",
     )
+    social_media_skill = Skill(
+        id=SKILL_NAME_TO_ID.get("social_media_management", 0),
+        name="social_media_management",
+        category="business",
+    )
     marketing_level = skill_service.train(band_id, marketing, 0).level
     pr_level = skill_service.train(band_id, pr_skill, 0).level
     fashion_level = skill_service.train(band_id, fashion, 0).level
     image_level = skill_service.train(band_id, image_mgmt, 0).level
+    social_level = skill_service.train(band_id, social_media_skill, 0).level
     skill_multiplier = (
         1
         + 0.05 * max(marketing_level - 1, 0)
         + 0.05 * max(pr_level - 1, 0)
         + 0.05 * max(fashion_level - 1, 0)
         + 0.05 * max(image_level - 1, 0)
+        + 0.05 * max(social_level - 1, 0)
     )
     social_multiplier = 1 + social_media / 100
     new_fans = int(base_new * skill_multiplier * social_multiplier)

--- a/backend/services/social_media_training_service.py
+++ b/backend/services/social_media_training_service.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from backend.models.skill import Skill
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from backend.services.skill_service import SkillService
+from backend.services.skill_service import skill_service as default_skill_service
+
+
+class SocialMediaTrainingService:
+    """Provide workshops for social media management skills."""
+
+    def __init__(self, skill_service: SkillService | None = None) -> None:
+        self.skill_service = skill_service or default_skill_service
+        self._workshop_xp = {"social_media_management": 50}
+
+    def attend_workshop(self, user_id: int, skill_name: str = "social_media_management") -> Skill:
+        """Attend a workshop to gain XP in social media management."""
+        if skill_name not in self._workshop_xp:
+            raise ValueError("unknown_workshop")
+        skill_id = SKILL_NAME_TO_ID[skill_name]
+        skill = Skill(id=skill_id, name=skill_name, category="business")
+        return self.skill_service.train(
+            user_id, skill, self._workshop_xp[skill_name]
+        )
+
+
+# Default shared instance
+social_media_training_service = SocialMediaTrainingService()
+
+__all__ = ["SocialMediaTrainingService", "social_media_training_service"]
+

--- a/backend/tests/business/test_business_skills.py
+++ b/backend/tests/business/test_business_skills.py
@@ -4,6 +4,7 @@ from backend.services import fan_service
 from backend.services.business_service import BusinessService
 from backend.services.business_training_service import BusinessTrainingService
 from backend.services.skill_service import skill_service
+from backend.services.social_media_training_service import SocialMediaTrainingService
 
 
 def test_business_training_awards_xp(tmp_path):
@@ -44,6 +45,29 @@ def test_marketing_pr_boost_fans(tmp_path, monkeypatch):
 
     result = fan_service.boost_fans_after_gig(1, "NY", 100)
     assert result["fans_boosted"] == 12
+
+
+def test_social_media_management_boosts_fans(tmp_path, monkeypatch):
+    db = tmp_path / "fans.db"
+    monkeypatch.setattr(fan_service, "DB_PATH", db)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE fans (user_id INTEGER, band_id INTEGER, location TEXT, loyalty INTEGER, source TEXT)"
+        )
+        conn.commit()
+
+    skill_service.db_path = tmp_path / "skills.db"
+    skill_service._skills.clear()
+    training = SocialMediaTrainingService(skill_service=skill_service)
+
+    baseline = fan_service.boost_fans_after_gig(1, "NY", 100)
+    assert baseline["fans_boosted"] == 10
+
+    for _ in range(4):
+        training.attend_workshop(1)
+
+    result = fan_service.boost_fans_after_gig(1, "NY", 100)
+    assert result["fans_boosted"] == 11
 
 
 def test_financial_management_boosts_revenue(tmp_path):


### PR DESCRIPTION
## Summary
- add `social_media_management` to seed skills and mapping
- introduce SocialMediaTrainingService and fan growth bonus from the skill
- test that social media training boosts fan gains

## Testing
- `ruff check backend/seeds/skill_seed.py backend/services/fan_service.py backend/services/social_media_training_service.py backend/tests/business/test_business_skills.py`
- `pytest tests/test_skill_seed.py backend/tests/business/test_business_skills.py backend/tests/social/test_social_media_boosts.py backend/tests/image/test_image_skills.py backend/tests/admin/test_music_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bcbdbd99988325865d49c4b02abd9a