### PR TITLE
Add content creation skill and XP-aware video engagement

### DIFF
--- a/backend/routes/video_routes.py
+++ b/backend/routes/video_routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from backend.auth.dependencies import get_current_user_id, require_permission
 from backend.services.economy_service import EconomyService
 from backend.services.video_service import VideoService
+from backend.services.skill_service import SkillService
 
 
 router = APIRouter(prefix="/videos")
@@ -9,7 +10,7 @@ router = APIRouter(prefix="/videos")
 # Create service instances for the simple demo implementation
 _economy = EconomyService()
 _economy.ensure_schema()
-_video_service = VideoService(_economy)
+_video_service = VideoService(_economy, SkillService())
 
 
 async def _current_user(user_id: int = Depends(get_current_user_id)) -> int:

--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -34,6 +34,7 @@ _RAW_SKILLS: list[tuple[str, str, str | None, dict[str, int]]] = [
     # Image and style skills
     ("fashion", "image", None, {}),
     ("image_management", "image", None, {}),
+    ("content_creation", "image", None, {}),
     # Business skills
     ("marketing", "business", None, {}),
     ("public_relations", "business", None, {}),

--- a/backend/tests/services/test_media_moderation_service.py
+++ b/backend/tests/services/test_media_moderation_service.py
@@ -4,6 +4,7 @@ import pytest
 
 from services.economy_service import EconomyService
 from services.media_moderation_service import media_moderation_service
+from services.skill_service import SkillService
 from services.video_service import VideoService
 
 
@@ -12,7 +13,8 @@ def _setup_video_service():
     tmp.close()
     economy = EconomyService(db_path=tmp.name)
     economy.ensure_schema()
-    return VideoService(economy)
+    skills = SkillService()
+    return VideoService(economy, skills)
 
 
 def test_scan_bytes_detects_banned_word():

--- a/backend/tests/video/test_video_routes.py
+++ b/backend/tests/video/test_video_routes.py
@@ -1,9 +1,11 @@
 import tempfile
+import tempfile
 
 from fastapi import HTTPException
-
+import tempfile
 from routes import video_routes
 from services.economy_service import EconomyService
+from services.skill_service import SkillService
 from services.video_service import VideoService
 
 
@@ -19,7 +21,7 @@ def setup_services():
     economy = EconomyService(tmp.name)
     economy.ensure_schema()
     video_routes._economy = economy
-    video_routes._video_service = VideoService(economy)
+    video_routes._video_service = VideoService(economy, SkillService())
     return economy
 
 

--- a/backend/tests/video/test_video_service.py
+++ b/backend/tests/video/test_video_service.py
@@ -1,22 +1,26 @@
 import tempfile
 
 from services.economy_service import EconomyService
-from services.video_service import SERVICE_LATENCY_MS, VideoService
+from services.skill_service import SkillService
+from services.video_service import SERVICE_LATENCY_MS, VideoService, XP_PER_VIEW
+from seeds.skill_seed import SEED_SKILLS
+CONTENT_CREATION_SKILL = next(s for s in SEED_SKILLS if s.name == "content_creation")
 
 from backend.utils.metrics import generate_latest
 
 
-def setup_service():
+def setup_service(ad_rate_cents: int = 1):
     tmp = tempfile.NamedTemporaryFile(delete=False)
     tmp.close()
     economy = EconomyService(db_path=tmp.name)
     economy.ensure_schema()
-    service = VideoService(economy)
-    return service, economy
+    skills = SkillService()
+    service = VideoService(economy, skills, ad_rate_cents=ad_rate_cents)
+    return service, economy, skills
 
 
 def test_upload_and_transcode():
-    svc, _ = setup_service()
+    svc, _, _ = setup_service()
     video = svc.upload_video(owner_id=1, title="Intro", filename="intro.mp4")
     assert video.status == "processing"
     svc.mark_transcoded(video.id)
@@ -24,17 +28,19 @@ def test_upload_and_transcode():
 
 
 def test_view_tracking_and_revenue_distribution():
-    svc, economy = setup_service()
+    svc, economy, skills = setup_service()
     video = svc.upload_video(owner_id=1, title="Demo", filename="demo.mp4")
     svc.mark_transcoded(video.id)
     for _ in range(3):
         svc.record_view(video.id)
     assert svc.get_video(video.id).view_count == 3
     assert economy.get_balance(1) == 3
+    skill = skills.train(1, CONTENT_CREATION_SKILL, 0)
+    assert skill.xp == XP_PER_VIEW * 3
 
 
 def test_record_view_latency_metric():
-    svc, _ = setup_service()
+    svc, _, _ = setup_service()
     video = svc.upload_video(owner_id=1, title="Demo", filename="demo.mp4")
     svc.mark_transcoded(video.id)
     before = SERVICE_LATENCY_MS._values.get(("video_service", "record_view"), {"count": 0})["count"]
@@ -43,3 +49,15 @@ def test_record_view_latency_metric():
     assert after == before + 1
     output = generate_latest().decode()
     assert 'service_latency_ms_count{service="video_service",operation="record_view"}' in output
+
+
+def test_high_skill_increases_revenue():
+    svc, economy, skills = setup_service(ad_rate_cents=100)
+    video = svc.upload_video(owner_id=1, title="Demo", filename="demo.mp4")
+    svc.mark_transcoded(video.id)
+    svc.record_view(video.id)  # baseline view at level 1
+    base = economy.get_balance(1)
+    skills.train(1, CONTENT_CREATION_SKILL, 500)
+    svc.record_view(video.id)
+    after = economy.get_balance(1)
+    assert after - base == 106


### PR DESCRIPTION
## Summary
- introduce `content_creation` skill in default seed data
- scale video revenue by creator's content-creation level and grant XP per view
- cover video routes and services with tests including revenue boost from high skill

## Testing
- `pytest tests/test_skill_seed.py backend/tests/video/test_video_service.py backend/tests/video/test_video_routes.py backend/tests/services/test_media_moderation_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcbea7a16c8325835e71af4419d695