### PR TITLE
Allow incremental skill prerequisite updates

### DIFF
--- a/backend/models/skill.py
+++ b/backend/models/skill.py
@@ -22,6 +22,8 @@ class Skill:
     xp: int = 0
     level: int = 1
     modifier: float = 1.0
+    # Mapping of skill_id -> required level
+    prerequisites: Dict[int, int] = field(default_factory=dict)
     specializations: Dict[str, SkillSpecialization] = field(default_factory=dict)
     specialization: Optional[str] = None
 

--- a/backend/models/skill_seed_store.py
+++ b/backend/models/skill_seed_store.py
@@ -15,7 +15,12 @@ def load_skills() -> List[Skill]:
     """
     if SKILL_SEED_PATH.exists():
         data = json.loads(SKILL_SEED_PATH.read_text())
-        return [Skill(**item) for item in data]
+        skills: List[Skill] = []
+        for item in data:
+            prereqs = {int(k): v for k, v in item.get("prerequisites", {}).items()}
+            item["prerequisites"] = prereqs
+            skills.append(Skill(**item))
+        return skills
     return []
 
 

--- a/backend/routes/admin_music_routes.py
+++ b/backend/routes/admin_music_routes.py
@@ -11,6 +11,7 @@ from backend.models.stage_equipment import StageEquipment
 from backend.schemas.admin_music_schema import (
     GenreSchema,
     SkillSchema,
+    SkillPrerequisitesSchema,
     StageEquipmentSchema,
 )
 from backend.services.admin_audit_service import audit_dependency
@@ -62,6 +63,7 @@ async def add_skill(skill: SkillSchema, req: Request) -> dict:
         name=skill.name,
         category=skill.category,
         parent_id=skill.parent_id,
+        prerequisites=skill.prerequisites,
     )
     skill_seed.SEED_SKILLS.append(new_skill)
     skill_seed.SKILL_NAME_TO_ID[new_skill.name] = new_skill.id
@@ -78,6 +80,19 @@ async def delete_skill(skill_id: int, req: Request) -> dict:
             skill_seed.SKILL_NAME_TO_ID = {s.name: s.id for s in skill_seed.SEED_SKILLS}
             save_skills(skill_seed.SEED_SKILLS)
             return {"status": "deleted"}
+    raise HTTPException(status_code=404, detail="Skill not found")
+
+
+@router.post("/skills/{skill_id}/prerequisites")
+async def update_skill_prerequisites(
+    skill_id: int, data: SkillPrerequisitesSchema, req: Request
+) -> dict:
+    await _ensure_admin(req)
+    for s in skill_seed.SEED_SKILLS:
+        if s.id == skill_id:
+            s.prerequisites.update(data.prerequisites)
+            save_skills(skill_seed.SEED_SKILLS)
+            return {"status": "updated", "prerequisites": s.prerequisites}
     raise HTTPException(status_code=404, detail="Skill not found")
 
 

--- a/backend/schemas/admin_music_schema.py
+++ b/backend/schemas/admin_music_schema.py
@@ -8,7 +8,11 @@ class SkillSchema(BaseModel):
     name: str
     category: str
     parent_id: Optional[int] = None
+    prerequisites: Dict[int, int] = {}
 
+
+class SkillPrerequisitesSchema(BaseModel):
+    prerequisites: Dict[int, int]
 
 class GenreSchema(BaseModel):
     id: int
@@ -24,5 +28,9 @@ class StageEquipmentSchema(BaseModel):
     rating: int
     genre_affinity: Dict[str, float] = {}
 
-
-__all__ = ["SkillSchema", "GenreSchema", "StageEquipmentSchema"]
+__all__ = [
+    "SkillSchema",
+    "SkillPrerequisitesSchema",
+    "GenreSchema",
+    "StageEquipmentSchema",
+]

--- a/tests/admin/test_admin_skill_routes.py
+++ b/tests/admin/test_admin_skill_routes.py
@@ -1,0 +1,65 @@
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+
+from fastapi import Request
+
+BASE = Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE))
+sys.path.append(str(BASE / "backend"))
+
+import backend.seeds.skill_seed as skill_seed
+from backend.models import skill_seed_store
+
+
+def test_prerequisites_persist_across_restarts(tmp_path, monkeypatch):
+    # Use temporary file for skill persistence
+    monkeypatch.setattr(
+        skill_seed_store,
+        "SKILL_SEED_PATH",
+        tmp_path / "skill_seed.json",
+        raising=False,
+    )
+
+    # Dummy modules for unrelated seeds
+    dummy_genre_seed = types.SimpleNamespace(SEED_GENRES=[], GENRE_NAME_TO_ID={})
+    dummy_equipment_seed = types.SimpleNamespace(
+        SEED_STAGE_EQUIPMENT=[], STAGE_EQUIPMENT_NAME_TO_ID={}
+    )
+    monkeypatch.setitem(sys.modules, "backend.seeds.genre_seed", dummy_genre_seed)
+    monkeypatch.setitem(
+        sys.modules, "backend.seeds.stage_equipment_seed", dummy_equipment_seed
+    )
+
+    admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")
+
+    async def fake_current_user(req):
+        return 1
+
+    async def fake_require_permission(roles, user_id):
+        return True
+
+    monkeypatch.setattr(admin_music_routes, "get_current_user_id", fake_current_user)
+    monkeypatch.setattr(admin_music_routes, "require_permission", fake_require_permission)
+
+    req = Request({"type": "http"})
+
+    skill_id = skill_seed.SEED_SKILLS[0].id
+    update = admin_music_routes.SkillPrerequisitesSchema(prerequisites={2: 3})
+    asyncio.run(admin_music_routes.update_skill_prerequisites(skill_id, update, req))
+
+    assert skill_seed_store.SKILL_SEED_PATH.exists()
+    assert any(s.prerequisites.get(2) == 3 for s in skill_seed.SEED_SKILLS)
+
+    # Simulate restart
+    importlib.reload(skill_seed)
+    del sys.modules["backend.routes.admin_music_routes"]
+    admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")
+
+    reloaded_skill = next(s for s in skill_seed.SEED_SKILLS if s.id == skill_id)
+    assert reloaded_skill.prerequisites.get(2) == 3
+
+    # Cleanup
+    importlib.reload(skill_seed)


### PR DESCRIPTION
## Summary
- Store skill prerequisite mappings and reload them from JSON
- Add admin endpoint to update prerequisites for a single skill
- Test prerequisite persistence across service reloads

## Testing
- `pytest`
- `pytest tests/admin/test_admin_skill_routes.py -q`
- `pytest tests/admin/test_admin_schema_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcafaa0524832587cec9cf091e57d7