### PR TITLE
Add data analytics skill and forecast training

### DIFF
--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -40,6 +40,7 @@ _RAW_SKILLS: list[tuple[str, str, str | None, dict[str, int]]] = [
     ("public_relations", "business", None, {}),
     ("financial_management", "business", None, {}),
     ("social_media_management", "business", None, {}),
+    ("data_analytics", "business", None, {}),
 ]
 
 

--- a/tests/test_analytics_skill.py
+++ b/tests/test_analytics_skill.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from backend.services.analytics_service import AnalyticsService
+
+
+def test_data_analytics_skill_improves_forecast_accuracy():
+    svc = AnalyticsService()
+    history = [100, 120, 80, 110]
+    actual_next = 115
+
+    low = svc.sales_forecast(1, history)
+    low_error = abs(low["forecast"] - actual_next)
+
+    for _ in range(5):
+        svc.sales_forecast(2, history)
+    high = svc.sales_forecast(2, history)
+    high_error = abs(high["forecast"] - actual_next)
+
+    assert high_error < low_error
+    assert "confidence" in high
+    assert "confidence" not in low


### PR DESCRIPTION
## Summary
- seed new `data_analytics` skill under business skills
- enable analytics service to train and use data analytics skill for more accurate sales forecasts with confidence metric
- add tests verifying higher analytics skill reduces forecast error

## Testing
- `pytest tests/test_analytics_skill.py -q`
- `pytest tests/test_skill_seed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcc11f22448325b5c34b2c5a195486