### PR TITLE
Add sound design skill and integrate into production metrics

### DIFF
--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -31,6 +31,7 @@ _RAW_SKILLS: list[tuple[str, str, str | None, dict[str, int]]] = [
     ("mastering", "creative", "music_production", {"music_production": 100}),
     ("music_theory", "creative", None, {}),
     ("ear_training", "creative", None, {}),
+    ("sound_design", "creative", None, {}),
     # Image and style skills
     ("fashion", "image", None, {}),
     ("image_management", "image", None, {}),

--- a/backend/services/audio_mixing_service.py
+++ b/backend/services/audio_mixing_service.py
@@ -2,15 +2,30 @@ from __future__ import annotations
 
 from typing import List
 
+from backend.models.skill import Skill
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from backend.services.skill_service import skill_service
 
-def mix_tracks(performance_ids: List[int]) -> List[int]:
-    """Return identifiers for mixed audio tracks.
+
+def mix_tracks(performance_ids: List[int], user_id: int | None = None) -> List[int]:
+    """Return identifiers for mixed audio tracks and award sound design XP.
 
     In the real application this function would take raw performance
     recordings and produce mixed tracks stored in an audio service.  For test
     purposes we simply return deterministic identifiers derived from the
     provided ``performance_ids``.
+
+    If ``user_id`` is provided, sound-design XP is granted based on the
+    number of performances mixed.
     """
+
+    if user_id is not None:
+        skill = Skill(
+            id=SKILL_NAME_TO_ID["sound_design"],
+            name="sound_design",
+            category="creative",
+        )
+        skill_service.train(user_id, skill, 10 * len(performance_ids))
 
     # A simple deterministic transformation that is easy to assert in tests.
     return [pid + 1000 for pid in performance_ids]

--- a/backend/tests/production/test_sound_design_production.py
+++ b/backend/tests/production/test_sound_design_production.py
@@ -1,0 +1,34 @@
+from backend.services.music_production_service import MusicProductionService
+from backend.services.skill_service import skill_service
+from backend.models.skill import Skill
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+
+
+class DummyAvatar:
+    def __init__(self, tech_savvy: int):
+        self.tech_savvy = tech_savvy
+
+
+class DummyAvatarService:
+    def __init__(self, tech_savvy: int):
+        self.avatar = DummyAvatar(tech_savvy)
+
+    def get_avatar(self, _band_id):
+        return self.avatar
+
+
+def test_sound_design_reduces_time_and_boosts_quality():
+    svc = MusicProductionService(avatar_service=DummyAvatarService(0))
+    user_id = 1
+    skill_service._skills.clear()
+
+    base = svc.produce_track(1, base_minutes=120, user_id=user_id)
+    skill_service.train(
+        user_id,
+        Skill(id=SKILL_NAME_TO_ID["sound_design"], name="sound_design", category="creative"),
+        500,
+    )
+    advanced = svc.produce_track(1, base_minutes=120, user_id=user_id)
+
+    assert advanced["time_minutes"] < base["time_minutes"]
+    assert advanced["quality"] > base["quality"]

--- a/tests/live_album/test_audio_mixing.py
+++ b/tests/live_album/test_audio_mixing.py
@@ -3,8 +3,11 @@ import sqlite3
 
 import pytest
 
+from backend.models.skill import Skill
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services import audio_mixing_service
 from backend.services.live_album_service import LiveAlbumService
+from backend.services.skill_service import skill_service
 
 
 def _insert_performance(cur, band_id, setlist, skill_gain, city="", venue=""):
@@ -146,3 +149,15 @@ def test_missing_recording_raises_error(tmp_path):
         service.compile_live_album([1, 2, 3, 4, 5], "Live")
     assert "5" in str(exc.value)
     assert "2" in str(exc.value)
+
+
+def test_mixing_awards_sound_design_xp():
+    skill_service._skills.clear()
+    user_id = 1
+    audio_mixing_service.mix_tracks([1, 2, 3], user_id=user_id)
+    skill = skill_service.train(
+        user_id,
+        Skill(id=SKILL_NAME_TO_ID["sound_design"], name="sound_design", category="creative"),
+        0,
+    )
+    assert skill.xp > 0


### PR DESCRIPTION
## Summary
- Add `sound_design` to default skills
- Grant sound-design XP when mixing tracks
- Factor `sound_design` skill level into production time and quality
- Test XP gain from mixing and production improvements

## Testing
- `pytest` *(fails: collection errors in unrelated tests)*
- `pytest tests/live_album/test_audio_mixing.py backend/tests/production/test_sound_design_production.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcc11e6538832587d36459bf0dcece