### PR TITLE
Add skill category multiplier for performance and recording scaling

### DIFF
--- a/backend/docs/skills.md
+++ b/backend/docs/skills.md
@@ -1,0 +1,14 @@
+# Skills
+
+## Category multipliers
+
+The `SkillService.get_category_multiplier(user_id, category)` helper returns a
+multiplier based on the average level of a user's skills within the specified
+category.
+
+```
+multiplier = 1 + (avg_level / 200)
+```
+
+The multiplier can be used by other services to scale outcomes like gig
+attendance, fame gains or recording quality.

--- a/backend/models/recording_session.py
+++ b/backend/models/recording_session.py
@@ -19,6 +19,7 @@ class RecordingSession:
     cost_cents: int = 0
     environment_quality: float = 1.0
     chemistry_avg: float = 50.0
+    track_quality: Dict[int, float] = field(default_factory=dict)
     created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
 
     def to_dict(self) -> dict:

--- a/backend/services/gig_service.py
+++ b/backend/services/gig_service.py
@@ -68,13 +68,19 @@ def simulate_gig_result(gig_id: int):
 
     # === Estimate attendance ===
     fan_stats = fan_service.get_band_fan_stats(band_id)
-    base_attendance = int(fan_stats["total_fans"] * (fan_stats["average_loyalty"] / 100))
+    base_attendance = int(
+        fan_stats["total_fans"] * (fan_stats["average_loyalty"] / 100)
+    )
     randomness = random.randint(-10, 10)
     attendance = max(0, min(venue_size, base_attendance + randomness))
 
+    # Scale outcomes by performance-related skills
+    mult = skill_service.get_category_multiplier(band_id, "performance")
+    attendance = max(0, min(venue_size, int(attendance * mult)))
+
     # === Calculate earnings and fame ===
     earnings = attendance * ticket_price
-    fame_gain = attendance // 20
+    fame_gain = int((attendance // 20) * mult)
 
     # === Update gig record ===
     cur.execute("""

--- a/backend/services/recording_service.py
+++ b/backend/services/recording_service.py
@@ -104,6 +104,17 @@ class RecordingService:
         for uid in session.personnel:
             skill_service.train_with_method(uid, skill, LearningMethod.PRACTICE, difficulty)
 
+        # Scale track quality by creative skill levels
+        if session.personnel:
+            mults = [
+                skill_service.get_category_multiplier(uid, "creative")
+                for uid in session.personnel
+            ]
+            quality_mult = sum(mults) / len(mults)
+        else:
+            quality_mult = 1.0
+        session.track_quality[track_id] = session.environment_quality * quality_mult
+
     def get_session(self, session_id: int) -> Optional[RecordingSession]:
         return self.sessions.get(session_id)
 

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -165,6 +165,19 @@ class SkillService:
 
     # ------------------------------------------------------------------
     # Public API
+    def get_category_multiplier(self, user_id: int, category: str) -> float:
+        """Return ``1 + (avg_level / 200)`` for a skill category."""
+
+        levels = [
+            s.level
+            for (uid, _sid), s in self._skills.items()
+            if uid == user_id and s.category == category
+        ]
+        if not levels:
+            return 1.0
+        avg_level = sum(levels) / len(levels)
+        return 1 + (avg_level / 200)
+
     def train(self, user_id: int, skill: Skill, base_xp: int) -> Skill:
         """Apply training XP to a skill respecting modifiers and caps."""
 

--- a/tests/test_skill_category_multiplier.py
+++ b/tests/test_skill_category_multiplier.py
@@ -1,0 +1,117 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from backend.models.skill import Skill
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from backend.services import gig_service as gs
+from backend.services.skill_service import SkillService, skill_service
+from backend.services.recording_service import RecordingService
+
+
+class DummyEconomy:
+    def ensure_schema(self) -> None:
+        pass
+
+    def withdraw(self, *args, **kwargs) -> None:
+        pass
+
+
+def _setup_gig_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE bands (id INTEGER PRIMARY KEY, fame INTEGER DEFAULT 0)")
+    cur.execute(
+        """
+        CREATE TABLE gigs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            band_id INTEGER,
+            city TEXT,
+            venue_size INTEGER,
+            date TEXT,
+            ticket_price INTEGER,
+            status TEXT,
+            attendance INTEGER,
+            revenue INTEGER,
+            fame_gain INTEGER
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_get_category_multiplier() -> None:
+    svc = SkillService()
+    guitar = Skill(id=1, name="guitar", category="instrument")
+    drums = Skill(id=2, name="drums", category="instrument")
+    svc.train(1, guitar, 1000)
+    svc.train(1, drums, 300)
+    mult = svc.get_category_multiplier(1, "instrument")
+    assert mult == pytest.approx(1 + ((11 + 4) / 2) / 200)
+
+
+def test_gig_scaled_by_performance_skills(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db = tmp_path / "gig.db"
+    _setup_gig_db(db)
+    monkeypatch.setattr(gs, "DB_PATH", str(db))
+    monkeypatch.setattr(
+        gs.fan_service,
+        "get_band_fan_stats",
+        lambda _bid: {"total_fans": 100, "average_loyalty": 100},
+    )
+    monkeypatch.setattr(gs.fan_service, "boost_fans_after_gig", lambda *a, **k: None)
+    monkeypatch.setattr(gs.random, "randint", lambda a, b: 0)
+
+    conn = sqlite3.connect(db)
+    conn.execute("INSERT INTO bands (id, fame) VALUES (1, 0)")
+    conn.commit()
+    conn.close()
+
+    gs.create_gig(1, "City", 200, "2024-01-01", 10)
+    gs.create_gig(1, "City", 200, "2024-02-01", 10)
+
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+    base = gs.simulate_gig_result(1)
+
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+    dance = Skill(id=SKILL_NAME_TO_ID["dance"], name="dance", category="performance")
+    stage = Skill(
+        id=SKILL_NAME_TO_ID["stage_presence"],
+        name="stage_presence",
+        category="performance",
+    )
+    skill_service.train(1, dance, 9900)
+    skill_service.train(1, stage, 9900)
+    skilled = gs.simulate_gig_result(2)
+
+    assert skilled["attendance"] > base["attendance"]
+    assert skilled["fame_gain"] > base["fame_gain"]
+
+
+def test_recording_quality_scales_with_creative_skills() -> None:
+    svc = RecordingService(economy=DummyEconomy())
+    session = svc.schedule_session(1, "Studio", "2024-01-01", "2024-01-02", [1], 0)
+    svc.assign_personnel(session.id, 1)
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+    svc.update_track_status(session.id, 1, "recorded")
+    base_quality = session.track_quality[1]
+
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+    prod = Skill(
+        id=SKILL_NAME_TO_ID["music_production"],
+        name="music_production",
+        category="creative",
+    )
+    skill_service.train(1, prod, 9900)
+    session2 = svc.schedule_session(1, "Studio", "2024-03-01", "2024-03-02", [2], 0)
+    svc.assign_personnel(session2.id, 1)
+    svc.update_track_status(session2.id, 2, "recorded")
+    skilled_quality = session2.track_quality[2]
+
+    assert skilled_quality > base_quality


### PR DESCRIPTION
## Summary
- add `SkillService.get_category_multiplier` to compute average skill level boosts
- scale gig attendance and fame by performance skill multipliers
- scale recording track quality by creative skill multipliers
- document skill category multiplier usage and add tests

## Testing
- `PYTHONPATH=backend:. pytest tests/test_skill_category_multiplier.py -q`
- `PYTHONPATH=backend:. pytest tests/test_practice_xp.py -q`
- `PYTHONPATH=backend:. pytest backend/tests/test_recording_service.py -q`
- `PYTHONPATH=backend:. pytest -q` *(fails: ImportError: cannot import name 'BookIn' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68be8f7bbe4483259a4653d67c43275a