### PR TITLE
Scale gig outcomes by band skill levels

### DIFF
--- a/backend/tests/live_performance/test_skill_multiplier.py
+++ b/backend/tests/live_performance/test_skill_multiplier.py
@@ -1,0 +1,112 @@
+import sqlite3
+
+from backend.services import live_performance_service, live_performance_analysis
+from backend.services.city_service import city_service
+from backend.models.city import City
+from backend.services.skill_service import skill_service
+from backend.models.skill import Skill
+from seeds.skill_seed import SKILL_NAME_TO_ID
+
+
+def test_skill_multiplier_boosts_crowd_and_fame(monkeypatch, tmp_path):
+    city_service.cities.clear()
+    city_service.add_city(
+        City(
+            name="Metro",
+            population=1_000_000,
+            style_preferences={},
+            event_modifier=1.0,
+            market_index=1.0,
+        )
+    )
+
+    db_file = tmp_path / "gig.db"
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE bands (id INTEGER PRIMARY KEY, fame INTEGER, skill REAL, revenue INTEGER)"
+    )
+    cur.execute(
+        "CREATE TABLE live_performances (band_id INTEGER, city TEXT, venue TEXT, date TEXT, setlist TEXT, crowd_size INTEGER, fame_earned INTEGER, revenue_earned INTEGER, skill_gain REAL, merch_sold INTEGER)"
+    )
+    cur.execute(
+        "CREATE TABLE songs (id INTEGER PRIMARY KEY, band_id INTEGER, title TEXT, duration_sec INTEGER, genre TEXT, play_count INTEGER, original_song_id INTEGER, legacy_state TEXT, original_release_date TEXT)"
+    )
+    cur.execute(
+        "CREATE TABLE band_members (band_id INTEGER, user_id INTEGER, role TEXT)"
+    )
+    cur.execute("INSERT INTO bands (id, fame, skill, revenue) VALUES (1, 100, 0, 0)")
+    cur.execute("INSERT INTO bands (id, fame, skill, revenue) VALUES (2, 100, 0, 0)")
+    cur.execute(
+        "INSERT INTO band_members (band_id, user_id, role) VALUES (1, 1, 'guitar')"
+    )
+    cur.execute(
+        "INSERT INTO band_members (band_id, user_id, role) VALUES (1, 2, 'drums')"
+    )
+    cur.execute(
+        "INSERT INTO band_members (band_id, user_id, role) VALUES (2, 3, 'guitar')"
+    )
+    cur.execute(
+        "INSERT INTO band_members (band_id, user_id, role) VALUES (2, 4, 'drums')"
+    )
+    cur.execute(
+        "INSERT INTO songs (id, band_id, title, duration_sec, genre, play_count, original_song_id, legacy_state, original_release_date) VALUES (1, 1, 'Song', 0, '', 0, NULL, 'new', NULL)"
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(live_performance_service, "DB_PATH", db_file)
+    monkeypatch.setattr(live_performance_analysis, "store_setlist_summary", lambda s: None)
+    monkeypatch.setattr(live_performance_service.random, "randint", lambda a, b: a)
+    monkeypatch.setattr(live_performance_service.gear_service, "get_band_bonus", lambda band_id, name: 0)
+    monkeypatch.setattr(live_performance_service, "is_skill_blocked", lambda band_id, skill_id: False)
+    monkeypatch.setattr(
+        live_performance_service.chemistry_service,
+        "initialize_pair",
+        lambda a, b: type("P", (), {"score": 50})(),
+    )
+
+    setlist = [{"type": "song", "reference": "1"}]
+
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+    low = live_performance_service.simulate_gig(
+        1, "Metro", "The Spot", setlist, reaction_stream=iter([0.5])
+    )
+
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+    perf = Skill(
+        id=SKILL_NAME_TO_ID["performance"],
+        name="performance",
+        category="stage",
+        xp=900,
+        level=10,
+    )
+    guitar = Skill(
+        id=SKILL_NAME_TO_ID["guitar"],
+        name="guitar",
+        category="instrument",
+        xp=900,
+        level=10,
+    )
+    drums = Skill(
+        id=SKILL_NAME_TO_ID["drums"],
+        name="drums",
+        category="instrument",
+        xp=900,
+        level=10,
+    )
+    skill_service._skills[(3, perf.id)] = perf
+    skill_service._skills[(3, guitar.id)] = guitar
+    skill_service._skills[(4, perf.id)] = Skill(
+        id=perf.id, name="performance", category="stage", xp=900, level=10
+    )
+    skill_service._skills[(4, drums.id)] = drums
+    high = live_performance_service.simulate_gig(
+        2, "Metro", "The Spot", setlist, reaction_stream=iter([0.5])
+    )
+
+    assert high["crowd_size"] > low["crowd_size"]
+    assert high["fame_earned"] > low["fame_earned"]
+

--- a/tests/test_gig_skill_multiplier.py
+++ b/tests/test_gig_skill_multiplier.py
@@ -1,0 +1,99 @@
+import sqlite3
+from pathlib import Path
+
+from backend.services import gig_service as gs
+from backend.services.skill_service import skill_service
+from backend.models.skill import Skill
+from seeds.skill_seed import SKILL_NAME_TO_ID
+
+
+def _setup_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE bands (id INTEGER PRIMARY KEY, fame INTEGER DEFAULT 0)")
+    cur.execute(
+        """
+        CREATE TABLE gigs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            band_id INTEGER,
+            city TEXT,
+            venue_size INTEGER,
+            date TEXT,
+            ticket_price INTEGER,
+            status TEXT,
+            attendance INTEGER,
+            revenue INTEGER,
+            fame_gain INTEGER
+        )
+        """
+    )
+    cur.execute(
+        "CREATE TABLE band_members (band_id INTEGER, user_id INTEGER, role TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_skill_multiplier_boosts_gig(monkeypatch, tmp_path):
+    db = tmp_path / "gig.db"
+    _setup_db(db)
+
+    monkeypatch.setattr(gs, "DB_PATH", str(db))
+    monkeypatch.setattr(
+        gs.fan_service,
+        "get_band_fan_stats",
+        lambda _bid: {"total_fans": 400, "average_loyalty": 100},
+    )
+    monkeypatch.setattr(gs.fan_service, "boost_fans_after_gig", lambda *a, **k: None)
+    monkeypatch.setattr(gs.random, "randint", lambda a, b: 0)
+
+    conn = sqlite3.connect(db)
+    conn.execute("INSERT INTO bands (id, fame) VALUES (1, 0)")
+    conn.execute(
+        "INSERT INTO band_members (band_id, user_id, role) VALUES (1, 1, 'guitar')"
+    )
+    conn.execute(
+        "INSERT INTO band_members (band_id, user_id, role) VALUES (1, 2, 'drums')"
+    )
+    conn.commit()
+    conn.close()
+
+    gs.create_gig(1, "City", 1000, "2024-01-01", 10)
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+    low = gs.simulate_gig_result(1)
+
+    gs.create_gig(1, "City", 1000, "2024-01-02", 10)
+    skill_service._skills.clear()
+    skill_service._xp_today.clear()
+    perf = Skill(
+        id=SKILL_NAME_TO_ID["performance"],
+        name="performance",
+        category="stage",
+        xp=900,
+        level=10,
+    )
+    guitar = Skill(
+        id=SKILL_NAME_TO_ID["guitar"],
+        name="guitar",
+        category="instrument",
+        xp=900,
+        level=10,
+    )
+    drums = Skill(
+        id=SKILL_NAME_TO_ID["drums"],
+        name="drums",
+        category="instrument",
+        xp=900,
+        level=10,
+    )
+    skill_service._skills[(1, perf.id)] = perf
+    skill_service._skills[(1, guitar.id)] = guitar
+    skill_service._skills[(2, perf.id)] = Skill(
+        id=perf.id, name="performance", category="stage", xp=900, level=10
+    )
+    skill_service._skills[(2, drums.id)] = drums
+    high = gs.simulate_gig_result(2)
+
+    assert high["attendance"] > low["attendance"]
+    assert high["fame_gain"] > low["fame_gain"]


### PR DESCRIPTION
## Summary
- Scale gig attendance and fame using band members' performance and instrument skills
- Apply performance skill multiplier to live performance crowd size and rewards
- Add regression tests ensuring higher skill averages boost attendance and fame

## Testing
- `pytest` *(fails: 24 errors during collection)*
- `pytest tests/test_gig_skill_multiplier.py backend/tests/live_performance/test_skill_multiplier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be8f7e8b888325ba6e4af471fe28e0