### PR TITLE
Add stage presence stat affecting gig rewards

### DIFF
--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -66,6 +66,7 @@ class Avatar(Base):
     social_media = Column(Integer, default=0)
     tech_savvy = Column(Integer, default=0)
     networking = Column(Integer, default=0)
+    stage_presence = Column(Integer, default=50)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -35,6 +35,7 @@ class AvatarBase(BaseModel):
     social_media: int = 0
     tech_savvy: int = 0
     networking: int = 0
+    stage_presence: int = 50
 
 
 class AvatarCreate(AvatarBase):
@@ -70,6 +71,7 @@ class AvatarUpdate(BaseModel):
     social_media: Optional[int] = None
     tech_savvy: Optional[int] = None
     networking: Optional[int] = None
+    stage_presence: Optional[int] = None
 
     @field_validator(
         "stamina",
@@ -82,6 +84,7 @@ class AvatarUpdate(BaseModel):
         "social_media",
         "tech_savvy",
         "networking",
+        "stage_presence",
     )
     @classmethod
     def _validate_stats(cls, v: int | None) -> int | None:

--- a/backend/services/avatar_service.py
+++ b/backend/services/avatar_service.py
@@ -45,6 +45,7 @@ class AvatarService:
             payload.setdefault("social_media", 0)
             payload.setdefault("tech_savvy", 0)
             payload.setdefault("networking", 0)
+            payload.setdefault("stage_presence", 50)
             payload.setdefault("resilience", 50)
             avatar = Avatar(**payload)
             session.add(avatar)
@@ -80,6 +81,7 @@ class AvatarService:
                     "social_media",
                     "tech_savvy",
                     "networking",
+                    "stage_presence",
                 } and value is not None:
                     setattr(avatar, field, max(0, min(100, value)))
                 else:

--- a/backend/services/gig_service.py
+++ b/backend/services/gig_service.py
@@ -7,7 +7,11 @@ from backend.services import fan_service
 from backend.services.skill_service import skill_service
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
+from backend.services.avatar_service import AvatarService
 from seeds.skill_seed import SKILL_NAME_TO_ID
+
+
+avatar_service = AvatarService()
 
 
 def create_gig(band_id: int, city: str, venue_size: int, date: str, ticket_price: int) -> dict:
@@ -70,7 +74,11 @@ def simulate_gig_result(gig_id: int):
     fan_stats = fan_service.get_band_fan_stats(band_id)
     base_attendance = int(fan_stats["total_fans"] * (fan_stats["average_loyalty"] / 100))
     randomness = random.randint(-10, 10)
-    attendance = max(0, min(venue_size, base_attendance + randomness))
+    avatar = avatar_service.get_avatar(band_id)
+    stage_presence = getattr(avatar, "stage_presence", 50)
+    adjusted = max(0, base_attendance + randomness)
+    adjusted = int(adjusted * (1 + stage_presence / 500))
+    attendance = min(venue_size, adjusted)
 
     # === Calculate earnings and fame ===
     earnings = attendance * ticket_price
@@ -103,5 +111,5 @@ def simulate_gig_result(gig_id: int):
         "earnings": earnings,
         "fame_gain": fame_gain,
         "city": city,
-        "status": "completed"
+        "status": "completed",
     }

--- a/backend/tests/avatars/test_avatar_service.py
+++ b/backend/tests/avatars/test_avatar_service.py
@@ -52,6 +52,7 @@ def test_crud_lifecycle():
     assert avatar.intelligence == 50
     assert avatar.creativity == 60
     assert avatar.discipline == 70
+    assert avatar.stage_presence == 50
 
     fetched = svc.get_avatar(avatar.id)
     assert fetched and fetched.nickname == "Hero"
@@ -112,6 +113,10 @@ def test_update_validation_and_clamping():
         AvatarUpdate(discipline=-5)
     with pytest.raises(ValueError):
         AvatarUpdate(tech_savvy=200)
+    with pytest.raises(ValueError):
+        AvatarUpdate(stage_presence=150)
+    with pytest.raises(ValueError):
+        AvatarUpdate(stage_presence=-10)
 
     # Bypass validation to ensure service clamps the values
     update_data = AvatarUpdate.model_construct(
@@ -121,6 +126,7 @@ def test_update_validation_and_clamping():
         creativity=120,
         discipline=-5,
         tech_savvy=150,
+        stage_presence=150,
     )
     svc.update_avatar(avatar.id, update_data)
     updated = svc.get_avatar(avatar.id)
@@ -132,4 +138,5 @@ def test_update_validation_and_clamping():
         and updated.creativity == 100
         and updated.discipline == 0
         and updated.tech_savvy == 100
+        and updated.stage_presence == 100
     )

--- a/tests/test_practice_xp.py
+++ b/tests/test_practice_xp.py
@@ -50,6 +50,9 @@ def test_gig_performance_grants_skill(monkeypatch, tmp_path):
 
     skill_service._skills.clear()
     skill_service._xp_today.clear()
+    skill_service._method_history.clear()
+    monkeypatch.setattr(skill_service, "_lifestyle_modifier", lambda _uid: 1.0)
+    monkeypatch.setattr(skill_service.xp_events, "get_active_multiplier", lambda _n: 1.0)
     gs.simulate_gig_result(1)
 
     perf_skill = Skill(id=SKILL_NAME_TO_ID["performance"], name="performance", category="stage")

--- a/tests/test_stage_presence_gig_rewards.py
+++ b/tests/test_stage_presence_gig_rewards.py
@@ -1,0 +1,68 @@
+import sqlite3
+
+from backend.services import gig_service as gs
+
+
+def _setup_gig_db(db_path):
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE gigs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            band_id INTEGER,
+            city TEXT,
+            venue_size INTEGER,
+            date TEXT,
+            ticket_price INTEGER,
+            status TEXT,
+            attendance INTEGER,
+            revenue INTEGER,
+            fame_gain INTEGER
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_stage_presence_boosts_gig_rewards(monkeypatch, tmp_path):
+    db = tmp_path / "gig.db"
+    _setup_gig_db(db)
+    monkeypatch.setattr(gs, "DB_PATH", str(db))
+    monkeypatch.setattr(
+        gs.fan_service,
+        "get_band_fan_stats",
+        lambda _bid: {"total_fans": 200, "average_loyalty": 50},
+    )
+    fans = []
+
+    def fake_boost(_bid, _city, attendance):
+        fans.append(attendance // 10)
+
+    monkeypatch.setattr(gs.fan_service, "boost_fans_after_gig", fake_boost)
+    monkeypatch.setattr(gs.random, "randint", lambda a, b: 0)
+
+    class DummyAvatar:
+        def __init__(self, sp):
+            self.stage_presence = sp
+
+    class DummyAvatarService:
+        def __init__(self, sp):
+            self.sp = sp
+
+        def get_avatar(self, _band_id):
+            return DummyAvatar(self.sp)
+
+    monkeypatch.setattr(gs, "avatar_service", DummyAvatarService(10))
+    gs.create_gig(1, "Test City", 500, "2024-01-01", 10)
+    res_low = gs.simulate_gig_result(1)
+    fans_low = fans.pop()
+
+    monkeypatch.setattr(gs, "avatar_service", DummyAvatarService(90))
+    gs.create_gig(1, "Test City", 500, "2024-01-02", 10)
+    res_high = gs.simulate_gig_result(2)
+    fans_high = fans.pop()
+
+    assert res_high["earnings"] > res_low["earnings"]
+    assert fans_high > fans_low


### PR DESCRIPTION
## Summary
- Add `stage_presence` stat to avatars and expose it through schemas
- Clamp `stage_presence` to 0-100 and persist default in avatar service
- Factor stage presence into gig simulations to boost attendance-driven rewards
- Test that higher stage presence increases gig earnings and fan growth

## Testing
- `pytest tests/test_stage_presence_gig_rewards.py backend/tests/avatars/test_avatar_service.py tests/test_practice_xp.py::test_gig_performance_grants_skill -q`

------
https://chatgpt.com/codex/tasks/task_e_68be8fe72a4883258959d4194191f39d