### PR TITLE
feat: add leadership attribute and band training effects

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from routes import (
     admin_routes,
     apprenticeship_routes,
     avatar,
+    band_routes,
     character,
     chemistry_routes,
     crafting_routes,
@@ -170,6 +171,7 @@ app.include_router(user_settings_routes.router, prefix="/api", tags=["UserSettin
 app.include_router(live_album_routes.router, prefix="/api", tags=["LiveAlbums"])
 app.include_router(avatar.router, prefix="/api", tags=["Avatars"])
 app.include_router(character.router, prefix="/api", tags=["Characters"])
+app.include_router(band_routes.router, prefix="/api", tags=["Bands"])
 app.include_router(playlist_routes.router, prefix="/api", tags=["Playlists"])
 app.include_router(chemistry_routes.router)
 app.include_router(crafting_routes.router, prefix="/api", tags=["Crafting"])

--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -66,6 +66,7 @@ class Avatar(Base):
     social_media = Column(Integer, default=0)
     tech_savvy = Column(Integer, default=0)
     networking = Column(Integer, default=0)
+    leadership = Column(Integer, default=0)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/routes/band_routes.py
+++ b/backend/routes/band_routes.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from services import band_service
+from services.avatar_service import AvatarService
+from schemas.avatar import AvatarUpdate
+
+router = APIRouter(prefix="/bands", tags=["Bands"])
+
+_avatar_service = AvatarService()
+
+
+class LeadershipUpdate(BaseModel):
+    leadership: int
+
+
+@router.get("/{band_id}/leadership")
+def get_band_leadership(band_id: int):
+    info = band_service.get_band_info(band_id)
+    if not info:
+        raise HTTPException(status_code=404, detail="Band not found")
+    data = []
+    for member in info["members"]:
+        avatar = _avatar_service.get_avatar_by_character_id(member["user_id"])
+        data.append(
+            {
+                "user_id": member["user_id"],
+                "leadership": avatar.leadership if avatar else None,
+            }
+        )
+    return data
+
+
+@router.put("/{band_id}/leadership/{user_id}")
+def update_leadership(band_id: int, user_id: int, payload: LeadershipUpdate):
+    info = band_service.get_band_info(band_id)
+    if not info or user_id not in [m["user_id"] for m in info["members"]]:
+        raise HTTPException(status_code=404, detail="Member not found")
+    avatar = _avatar_service.get_avatar_by_character_id(user_id)
+    if not avatar:
+        raise HTTPException(status_code=404, detail="Avatar not found")
+    _avatar_service.update_avatar(avatar.id, AvatarUpdate(leadership=payload.leadership))
+    updated = _avatar_service.get_avatar(avatar.id)
+    return {"user_id": user_id, "leadership": updated.leadership}

--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -35,6 +35,7 @@ class AvatarBase(BaseModel):
     social_media: int = 0
     tech_savvy: int = 0
     networking: int = 0
+    leadership: int = 0
 
 
 class AvatarCreate(AvatarBase):
@@ -70,6 +71,7 @@ class AvatarUpdate(BaseModel):
     social_media: Optional[int] = None
     tech_savvy: Optional[int] = None
     networking: Optional[int] = None
+    leadership: Optional[int] = None
 
     @field_validator(
         "stamina",
@@ -82,6 +84,7 @@ class AvatarUpdate(BaseModel):
         "social_media",
         "tech_savvy",
         "networking",
+        "leadership",
     )
     @classmethod
     def _validate_stats(cls, v: int | None) -> int | None:

--- a/backend/services/avatar_service.py
+++ b/backend/services/avatar_service.py
@@ -45,6 +45,7 @@ class AvatarService:
             payload.setdefault("social_media", 0)
             payload.setdefault("tech_savvy", 0)
             payload.setdefault("networking", 0)
+            payload.setdefault("leadership", 0)
             payload.setdefault("resilience", 50)
             avatar = Avatar(**payload)
             session.add(avatar)
@@ -80,6 +81,7 @@ class AvatarService:
                     "social_media",
                     "tech_savvy",
                     "networking",
+                    "leadership",
                 } and value is not None:
                     setattr(avatar, field, max(0, min(100, value)))
                 else:

--- a/backend/tests/avatars/test_avatar_service.py
+++ b/backend/tests/avatars/test_avatar_service.py
@@ -52,6 +52,7 @@ def test_crud_lifecycle():
     assert avatar.intelligence == 50
     assert avatar.creativity == 60
     assert avatar.discipline == 70
+    assert avatar.leadership == 0
 
     fetched = svc.get_avatar(avatar.id)
     assert fetched and fetched.nickname == "Hero"
@@ -112,6 +113,10 @@ def test_update_validation_and_clamping():
         AvatarUpdate(discipline=-5)
     with pytest.raises(ValueError):
         AvatarUpdate(tech_savvy=200)
+    with pytest.raises(ValueError):
+        AvatarUpdate(leadership=150)
+    with pytest.raises(ValueError):
+        AvatarUpdate(leadership=-5)
 
     # Bypass validation to ensure service clamps the values
     update_data = AvatarUpdate.model_construct(
@@ -121,6 +126,7 @@ def test_update_validation_and_clamping():
         creativity=120,
         discipline=-5,
         tech_savvy=150,
+        leadership=150,
     )
     svc.update_avatar(avatar.id, update_data)
     updated = svc.get_avatar(avatar.id)
@@ -132,4 +138,5 @@ def test_update_validation_and_clamping():
         and updated.creativity == 100
         and updated.discipline == 0
         and updated.tech_savvy == 100
+        and updated.leadership == 100
     )

--- a/backend/tests/bands/test_band_service.py
+++ b/backend/tests/bands/test_band_service.py
@@ -5,8 +5,16 @@ from pathlib import Path
 # Ensure the default database path used by service exists during import
 Path(__file__).resolve().parents[2].joinpath("database").mkdir(parents=True, exist_ok=True)
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.avatar import Base as AvatarBase
+from models.character import Base as CharacterBase, Character
+from schemas.avatar import AvatarCreate
+from services.avatar_service import AvatarService
 from services.band_service import Base, BandMember, BandService
 from services.band_relationship_service import BandRelationshipService
+from services.skill_service import SkillService, SONGWRITING_SKILL
 
 
 def get_service():
@@ -67,4 +75,72 @@ def test_relationship_modifier_affects_split():
     expected_total = int(100 * expected_modifier)
     assert result["band_1_share"] + result["band_2_share"] == expected_total
     assert result["modifier"] == expected_modifier
+
+
+def test_leadership_effects_on_training_and_decay():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    CharacterBase.metadata.create_all(bind=engine)
+    AvatarBase.metadata.create_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    avatar_svc = AvatarService(SessionLocal)
+    skill_svc = SkillService(avatar_service=avatar_svc)
+    band_svc = BandService(SessionLocal, avatar_service=avatar_svc, skill_service=skill_svc)
+
+    with SessionLocal() as session:
+        chars = [
+            Character(name=f"C{i}", genre="rock", trait="brave", birthplace="Earth")
+            for i in range(4)
+        ]
+        session.add_all(chars)
+        session.commit()
+        ids = [c.id for c in chars]
+
+    def make_avatar(cid, leadership):
+        avatar_svc.create_avatar(
+            AvatarCreate(
+                character_id=cid,
+                nickname=f"N{cid}",
+                body_type="slim",
+                skin_tone="pale",
+                face_shape="oval",
+                hair_style="short",
+                hair_color="black",
+                top_clothing="tshirt",
+                bottom_clothing="jeans",
+                shoes="boots",
+                leadership=leadership,
+            )
+        )
+
+    make_avatar(ids[0], 80)
+    make_avatar(ids[1], 80)
+    make_avatar(ids[2], 0)
+    make_avatar(ids[3], 0)
+
+    high_band = band_svc.create_band(user_id=ids[0], band_name="High", genre="rock")
+    band_svc.add_member(high_band.id, ids[1])
+    low_band = band_svc.create_band(user_id=ids[2], band_name="Low", genre="rock")
+    band_svc.add_member(low_band.id, ids[3])
+
+    for uid in ids:
+        skill_svc.train(uid, SONGWRITING_SKILL, 0)
+
+    band_svc.collective_training(high_band.id, SONGWRITING_SKILL, 10)
+    band_svc.collective_training(low_band.id, SONGWRITING_SKILL, 10)
+
+    xp_high = skill_svc._skills[(ids[0], SONGWRITING_SKILL.id)].xp
+    xp_low = skill_svc._skills[(ids[2], SONGWRITING_SKILL.id)].xp
+    assert xp_high > xp_low
+
+    for uid in ids:
+        skill_svc._skills[(uid, SONGWRITING_SKILL.id)].xp = 100
+
+    band_svc.decay_band_skills(high_band.id, 10)
+    band_svc.decay_band_skills(low_band.id, 10)
+
+    after_high = skill_svc._skills[(ids[0], SONGWRITING_SKILL.id)].xp
+    after_low = skill_svc._skills[(ids[2], SONGWRITING_SKILL.id)].xp
+    assert 100 - after_high < 100 - after_low
 


### PR DESCRIPTION
## Summary
- add leadership stat to avatars and expose via new band routes
- use band leadership to slow skill decay and boost collective training
- test leadership clamping and group effects on skills

## Testing
- `pytest backend/tests/avatars/test_avatar_service.py::test_crud_lifecycle backend/tests/avatars/test_avatar_service.py::test_update_validation_and_clamping backend/tests/bands/test_band_service.py::test_leadership_effects_on_training_and_decay -q`


------
https://chatgpt.com/codex/tasks/task_e_68be8fe843588325af377879d9ffcb12