### PR TITLE
feat: add fatigue tracking and rest recovery

### DIFF
--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -57,6 +57,7 @@ class Avatar(Base):
     # influenced by lifestyle scores and random events.
     mood = Column(Integer, default=50)
     stamina = Column(Integer, default=50)
+    fatigue = Column(Integer, default=0)
     charisma = Column(Integer, default=50)
     intelligence = Column(Integer, default=50)
     creativity = Column(Integer, default=50)

--- a/backend/routes/avatar_routes.py
+++ b/backend/routes/avatar_routes.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, HTTPException
+from schemas.avatar import AvatarResponse
+from services.avatar_service import AvatarService
+
+try:  # pragma: no cover - fallback when auth module absent
+    from auth.dependencies import require_permission
+except Exception:  # pragma: no cover
+    def require_permission(roles):
+        async def _noop():
+            return True
+        return _noop
+
+router = APIRouter(prefix="/avatars", tags=["Avatars"])
+svc = AvatarService()
+
+
+@router.post(
+    "/{avatar_id}/rest",
+    response_model=AvatarResponse,
+    dependencies=[Depends(require_permission(["band_member", "admin", "moderator"]))],
+)
+def rest_avatar(avatar_id: int):
+    avatar = svc.rest(avatar_id)
+    if not avatar:
+        raise HTTPException(status_code=404, detail="Avatar not found")
+    return avatar

--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -26,6 +26,7 @@ class AvatarBase(BaseModel):
     health: int = 100
     mood: int = 50
     stamina: int = 50
+    fatigue: int = 0
     charisma: int = 50
     intelligence: int = 50
     creativity: int = 50
@@ -61,6 +62,7 @@ class AvatarUpdate(BaseModel):
     health: Optional[int] = None
     mood: Optional[int] = None
     stamina: Optional[int] = None
+    fatigue: Optional[int] = None
     charisma: Optional[int] = None
     intelligence: Optional[int] = None
     creativity: Optional[int] = None
@@ -73,6 +75,7 @@ class AvatarUpdate(BaseModel):
 
     @field_validator(
         "stamina",
+        "fatigue",
         "charisma",
         "intelligence",
         "creativity",

--- a/backend/services/avatar_service.py
+++ b/backend/services/avatar_service.py
@@ -46,6 +46,7 @@ class AvatarService:
             payload.setdefault("tech_savvy", 0)
             payload.setdefault("networking", 0)
             payload.setdefault("resilience", 50)
+            payload.setdefault("fatigue", 0)
             avatar = Avatar(**payload)
             session.add(avatar)
             session.commit()
@@ -71,6 +72,7 @@ class AvatarService:
             for field, value in data.model_dump(exclude_unset=True).items():
                 if field in {
                     "stamina",
+                    "fatigue",
                     "charisma",
                     "intelligence",
                     "creativity",
@@ -84,6 +86,20 @@ class AvatarService:
                     setattr(avatar, field, max(0, min(100, value)))
                 else:
                     setattr(avatar, field, value)
+            session.commit()
+            session.refresh(avatar)
+            return avatar
+
+    # ------------------------------------------------------------------
+    def rest(self, avatar_id: int) -> Optional[Avatar]:
+        """Fully restore stamina and clear fatigue."""
+
+        with self.session_factory() as session:
+            avatar = session.get(Avatar, avatar_id)
+            if not avatar:
+                return None
+            avatar.stamina = 100
+            avatar.fatigue = 0
             session.commit()
             session.refresh(avatar)
             return avatar

--- a/backend/tests/skills/test_fatigue_system.py
+++ b/backend/tests/skills/test_fatigue_system.py
@@ -1,0 +1,73 @@
+import pytest
+from models.avatar import Base as AvatarBase
+from models.character import Base as CharacterBase
+from models.character import Character
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.models.learning_method import LearningMethod
+from backend.models.skill import Skill
+from backend.schemas.avatar import AvatarCreate, AvatarUpdate
+from backend.services.avatar_service import AvatarService
+from backend.services.skill_service import SkillService
+
+
+def _setup_services() -> tuple[AvatarService, SkillService]:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    CharacterBase.metadata.create_all(bind=engine)
+    AvatarBase.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    avatar_service = AvatarService(SessionLocal)
+    with SessionLocal() as session:
+        c = Character(name="A", genre="rock", trait="brave", birthplace="Earth")
+        session.add(c)
+        session.commit()
+        cid = c.id
+    avatar_service.create_avatar(
+        AvatarCreate(
+            character_id=cid,
+            nickname="A",
+            body_type="slim",
+            skin_tone="pale",
+            face_shape="oval",
+            hair_style="short",
+            hair_color="black",
+            top_clothing="t",
+            bottom_clothing="j",
+            shoes="b",
+            stamina=50,
+        )
+    )
+    skill_service = SkillService(avatar_service=avatar_service)
+    return avatar_service, skill_service
+
+
+def test_fatigue_affects_training_and_blocks():
+    avatar_service, skills = _setup_services()
+    skill = Skill(id=1, name="guitar", category="music")
+
+    inst = skills.train(1, skill, 100, duration=10)
+    avatar = avatar_service.get_avatar(1)
+    assert avatar and avatar.fatigue == 10
+    assert inst.xp == 100
+
+    avatar_service.update_avatar(1, AvatarUpdate(fatigue=50))
+    inst = skills.train(1, skill, 100)
+    assert inst.xp == 150
+
+    avatar_service.update_avatar(1, AvatarUpdate(fatigue=85))
+    with pytest.raises(ValueError):
+        skills.train(1, skill, 100)
+
+
+def test_rest_recovers_fatigue_and_stamina():
+    avatar_service, skills = _setup_services()
+    skill = Skill(id=2, name="guitar", category="music")
+
+    skills.train_with_method(1, skill, LearningMethod.PRACTICE, duration=4)
+    avatar = avatar_service.get_avatar(1)
+    assert avatar and avatar.fatigue == 4 and avatar.stamina < 50
+
+    avatar_service.rest(1)
+    avatar = avatar_service.get_avatar(1)
+    assert avatar and avatar.fatigue == 0 and avatar.stamina == 100


### PR DESCRIPTION
## Summary
- track avatar fatigue and reduce XP as fatigue rises
- block training above fatigue threshold and add rest endpoint to recover stamina
- test fatigue accumulation, training limits, and rest recovery

## Testing
- `ruff check backend/models/avatar.py backend/schemas/avatar.py backend/services/avatar_service.py backend/services/skill_service.py backend/routes/avatar_routes.py backend/tests/skills/test_fatigue_system.py`
- `pytest backend/tests/skills`


------
https://chatgpt.com/codex/tasks/task_e_68be8fe94c208325acfa4fc0609542ef