### PR TITLE
Add reputation tracking and elite event gating

### DIFF
--- a/backend/models/reputation.py
+++ b/backend/models/reputation.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
+
+
+@dataclass
+class ReputationEvent:
+    """Represents a single change to a user's reputation."""
+
+    user_id: int
+    change: int
+    reason: str
+    source: str
+    timestamp: str | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple timestamp default
+        if self.timestamp is None:
+            self.timestamp = datetime.utcnow().isoformat()
+
+
+@dataclass
+class Reputation:
+    """Simple in-memory representation of a user's reputation state."""
+
+    user_id: int
+    score: int = 0
+    history: List[ReputationEvent] = field(default_factory=list)
+
+    def add_event(self, event: ReputationEvent) -> None:
+        self.score += event.change
+        self.history.append(event)

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -17,8 +17,10 @@ from .city_service import city_service
 from .npc_ai_service import npc_ai_service
 from .skill_service import skill_service
 from .weather_service import weather_service
+from .reputation_service import reputation_service
 
 logger = logging.getLogger(__name__)
+ELITE_REPUTATION_THRESHOLD = 100
 
 
 def _conn() -> sqlite3.Connection:
@@ -375,3 +377,14 @@ def purchase_workshop_ticket(user_id: int, event_id: int) -> Event:
     skill = Skill(id=skill_id, name=workshop.skill_target, category="event")
     skill_service.train(user_id, skill, workshop.xp_reward)
     return workshop
+
+# ---------------------------------------------------------------------------
+# Elite events
+# ---------------------------------------------------------------------------
+
+def schedule_elite_event(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
+    """Register an elite event if the user meets the reputation threshold."""
+
+    if reputation_service.get_reputation(user_id) < ELITE_REPUTATION_THRESHOLD:
+        raise PermissionError("Insufficient reputation for elite events")
+    return event

--- a/backend/services/reputation_service.py
+++ b/backend/services/reputation_service.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from backend.database import DB_PATH
+from backend.models.reputation import ReputationEvent
+
+
+class ReputationService:
+    """Persist and mutate reputation scores and events."""
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS reputation_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    change INTEGER NOT NULL,
+                    reason TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    timestamp TEXT NOT NULL
+                )
+                """,
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS user_reputation (
+                    user_id INTEGER PRIMARY KEY,
+                    total INTEGER NOT NULL DEFAULT 0
+                )
+                """,
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def _record(self, user_id: int, amount: int, reason: str, source: str) -> None:
+        event = ReputationEvent(
+            user_id=user_id,
+            change=amount,
+            reason=reason,
+            source=source,
+            timestamp=datetime.utcnow().isoformat(),
+        )
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO reputation_events (user_id, change, reason, source, timestamp)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (event.user_id, event.change, event.reason, event.source, event.timestamp),
+            )
+            cur.execute(
+                """
+                INSERT INTO user_reputation (user_id, total)
+                VALUES (?, ?)
+                ON CONFLICT(user_id) DO UPDATE SET total = total + excluded.total
+                """,
+                (user_id, amount),
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def record_gig(self, user_id: int, points: int = 10) -> None:
+        """Award reputation for completing a gig."""
+
+        self._record(user_id, points, "gig", "gig")
+
+    def record_release(self, user_id: int, points: int = 20) -> None:
+        """Award reputation for releasing music."""
+
+        self._record(user_id, points, "release", "release")
+
+    def record_achievement(self, user_id: int, points: int = 30) -> None:
+        """Award reputation for unlocking an achievement."""
+
+        self._record(user_id, points, "achievement", "achievement")
+
+    # ------------------------------------------------------------------
+    def get_reputation(self, user_id: int) -> int:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT total FROM user_reputation WHERE user_id = ?", (user_id,))
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
+
+    def get_history(self, user_id: int) -> List[Dict[str, Any]]:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT id, user_id, change, reason, source, timestamp
+                  FROM reputation_events
+                 WHERE user_id = ?
+                 ORDER BY id
+                """,
+                (user_id,),
+            )
+            rows = cur.fetchall()
+            return [
+                {
+                    "id": r[0],
+                    "user_id": r[1],
+                    "change": r[2],
+                    "reason": r[3],
+                    "source": r[4],
+                    "timestamp": r[5],
+                }
+                for r in rows
+            ]
+
+
+reputation_service = ReputationService()
+
+__all__ = ["ReputationService", "reputation_service"]

--- a/tests/test_reputation_service.py
+++ b/tests/test_reputation_service.py
@@ -1,0 +1,37 @@
+import sys, pathlib
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+import pytest
+
+from backend.services.reputation_service import ReputationService
+from backend.services import event_service
+
+
+def test_reputation_accumulation_and_elite_unlock(tmp_path):
+    db = tmp_path / "rep.sqlite"
+    svc = ReputationService(db_path=db)
+    # Make event_service use this test instance
+    event_service.reputation_service = svc
+
+    user_id = 1
+
+    # Initially not enough reputation
+    with pytest.raises(PermissionError):
+        event_service.schedule_elite_event(user_id, {"name": "vip gig"})
+
+    # Award reputation via different activities
+    svc.record_gig(user_id)
+    svc.record_release(user_id)
+    svc.record_achievement(user_id)
+
+    assert svc.get_reputation(user_id) == 60
+    assert len(svc.get_history(user_id)) == 3
+
+    # Accumulate additional gigs until threshold met
+    while svc.get_reputation(user_id) < event_service.ELITE_REPUTATION_THRESHOLD:
+        svc.record_gig(user_id)
+
+    evt = event_service.schedule_elite_event(user_id, {"name": "vip gig"})
+    assert evt["name"] == "vip gig"


### PR DESCRIPTION
## Summary
- add reputation model tracking score and event history
- implement service to award reputation for gigs, releases, and achievements
- gate elite events behind a reputation threshold
- test reputation accumulation and elite unlocks

## Testing
- `pytest tests/test_reputation_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be8fe8955083259a5e0bee44a38567