### PR TITLE
Add music production subskills and training

### DIFF
--- a/backend/seeds/skill_seed.py
+++ b/backend/seeds/skill_seed.py
@@ -32,7 +32,67 @@ _RAW_SKILLS: list[tuple[str, str, str | None, dict[str, int]]] = [
     ("mastering", "creative", "music_production", {"music_production": 100}),
     ("music_theory", "creative", None, {}),
     ("ear_training", "creative", None, {}),
-    ("sound_design", "creative", None, {}),
+    # Music production sub-skills
+    (
+        "audio_engineering",
+        "creative",
+        "music_production",
+        {"music_production": 100},
+    ),
+    (
+        "multitrack_recording",
+        "creative",
+        "music_production",
+        {"music_production": 100},
+    ),
+    (
+        "microphone_technique",
+        "creative",
+        "music_production",
+        {"music_production": 100},
+    ),
+    (
+        "audio_editing",
+        "creative",
+        "music_production",
+        {"music_production": 100},
+    ),
+    (
+        "sound_design",
+        "creative",
+        "music_production",
+        {"music_production": 100},
+    ),
+    (
+        "beat_programming",
+        "creative",
+        "music_production",
+        {"music_production": 100},
+    ),
+    (
+        "midi_programming",
+        "creative",
+        "music_production",
+        {"music_production": 100},
+    ),
+    (
+        "vocal_tuning",
+        "creative",
+        "music_production",
+        {"music_production": 100},
+    ),
+    (
+        "sample_management",
+        "creative",
+        "music_production",
+        {"music_production": 100},
+    ),
+    (
+        "studio_acoustics",
+        "creative",
+        "music_production",
+        {"music_production": 100},
+    ),
     # Image and style skills
     ("fashion", "image", None, {}),
     ("image_management", "image", None, {}),

--- a/backend/services/recording_service.py
+++ b/backend/services/recording_service.py
@@ -104,6 +104,32 @@ class RecordingService:
         for uid in session.personnel:
             skill_service.train_with_method(uid, skill, LearningMethod.PRACTICE, difficulty)
 
+    # ------------------------------------------------------------------
+    def practice_skill(
+        self,
+        user_id: int,
+        skill_name: str,
+        amount: int,
+        method: LearningMethod = LearningMethod.PRACTICE,
+        environment_quality: float = 1.0,
+    ) -> Skill:
+        """Award XP toward a specific music production skill."""
+        if skill_name not in SKILL_NAME_TO_ID:
+            raise KeyError("skill_not_found")
+        skill = Skill(
+            id=SKILL_NAME_TO_ID[skill_name],
+            name=skill_name,
+            category="creative",
+            parent_id=SKILL_NAME_TO_ID.get("music_production"),
+        )
+        return skill_service.train_with_method(
+            user_id,
+            skill,
+            method,
+            amount,
+            environment_quality=environment_quality,
+        )
+
     def get_session(self, session_id: int) -> Optional[RecordingSession]:
         return self.sessions.get(session_id)
 

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -9,6 +9,8 @@ from backend.models.skill import Skill, SkillSpecialization
 from backend.models.xp_config import XPConfig, get_config, set_config
 from backend.services.item_service import item_service
 from backend.services.skill_service import SkillService
+from backend.services.recording_service import RecordingService
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 class DummyXPEvents:
@@ -261,4 +263,37 @@ def test_prerequisite_requirements() -> None:
     svc.train(1, keyboard, 9900)
     updated = svc.train_with_method(1, piano, LearningMethod.PRACTICE, 1)
     assert updated.xp > 0
+
+
+@pytest.mark.parametrize(
+    "skill_name",
+    [
+        "audio_engineering",
+        "multitrack_recording",
+        "microphone_technique",
+        "audio_editing",
+        "sound_design",
+        "beat_programming",
+        "midi_programming",
+        "vocal_tuning",
+        "sample_management",
+        "studio_acoustics",
+    ],
+)
+def test_music_production_subskills_persist(
+    skill_name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "backend.services.skill_service.random.random", lambda: 0.99
+    )
+    svc = RecordingService()
+    user_id = 100 + SKILL_NAME_TO_ID[skill_name]
+
+    updated = svc.practice_skill(user_id, skill_name, 10)
+    assert updated.xp == 100
+    assert updated.level == 2
+
+    refreshed = svc.practice_skill(user_id, skill_name, 0)
+    assert refreshed.xp == 100
+    assert refreshed.level == 2
 

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,15 @@
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+@contextmanager
+def get_conn(db_path: str | None = None):
+    conn = sqlite3.connect(db_path or DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- seed audio_engineering, multitrack_recording, microphone_technique, audio_editing, sound_design, beat_programming, midi_programming, vocal_tuning, sample_management, and studio_acoustics
- add recording service helper to train any production sub-skill
- test XP gain and persistence for new production skills

## Testing
- `PYTHONPATH=.:'backend' pytest tests/test_skill_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68be8ff2db7c8325b671293bcbcb160a