### PR TITLE
Add voice stat affecting vocals and gigs

### DIFF
--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -62,6 +62,7 @@ class Avatar(Base):
     creativity = Column(Integer, default=50)
     discipline = Column(Integer, default=50)
     resilience = Column(Integer, default=50)
+    voice = Column(Integer, default=50)
     luck = Column(Integer, default=0)
     social_media = Column(Integer, default=0)
     tech_savvy = Column(Integer, default=0)

--- a/backend/schemas/avatar.py
+++ b/backend/schemas/avatar.py
@@ -31,6 +31,7 @@ class AvatarBase(BaseModel):
     creativity: int = 50
     discipline: int = 50
     resilience: int = 50
+    voice: int = 50
     luck: int = 0
     social_media: int = 0
     tech_savvy: int = 0
@@ -66,6 +67,7 @@ class AvatarUpdate(BaseModel):
     creativity: Optional[int] = None
     discipline: Optional[int] = None
     resilience: Optional[int] = None
+    voice: Optional[int] = None
     luck: Optional[int] = None
     social_media: Optional[int] = None
     tech_savvy: Optional[int] = None
@@ -78,6 +80,7 @@ class AvatarUpdate(BaseModel):
         "creativity",
         "discipline",
         "resilience",
+        "voice",
         "luck",
         "social_media",
         "tech_savvy",

--- a/backend/services/avatar_service.py
+++ b/backend/services/avatar_service.py
@@ -46,6 +46,7 @@ class AvatarService:
             payload.setdefault("tech_savvy", 0)
             payload.setdefault("networking", 0)
             payload.setdefault("resilience", 50)
+            payload.setdefault("voice", 50)
             avatar = Avatar(**payload)
             session.add(avatar)
             session.commit()
@@ -76,6 +77,7 @@ class AvatarService:
                     "creativity",
                     "discipline",
                     "resilience",
+                    "voice",
                     "luck",
                     "social_media",
                     "tech_savvy",

--- a/backend/services/gig_service.py
+++ b/backend/services/gig_service.py
@@ -8,6 +8,9 @@ from backend.services.skill_service import skill_service
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
 from seeds.skill_seed import SKILL_NAME_TO_ID
+from backend.services.avatar_service import AvatarService
+
+avatar_service = AvatarService()
 
 
 def create_gig(band_id: int, city: str, venue_size: int, date: str, ticket_price: int) -> dict:
@@ -71,10 +74,13 @@ def simulate_gig_result(gig_id: int):
     base_attendance = int(fan_stats["total_fans"] * (fan_stats["average_loyalty"] / 100))
     randomness = random.randint(-10, 10)
     attendance = max(0, min(venue_size, base_attendance + randomness))
+    avatar = avatar_service.get_avatar(band_id)
+    voice_val = avatar.voice if avatar else 50
+    attendance = min(venue_size, int(attendance * (1 + voice_val / 200)))
 
     # === Calculate earnings and fame ===
     earnings = attendance * ticket_price
-    fame_gain = attendance // 20
+    fame_gain = int(attendance // 20 * (1 + voice_val / 200))
 
     # === Update gig record ===
     cur.execute("""

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -27,6 +27,7 @@ from backend.services.avatar_service import AvatarService
 from backend.services.perk_service import perk_service
 from backend.schemas.avatar import AvatarUpdate
 from backend.services.xp_item_service import xp_item_service
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 INTERNET_DEVICE_NAME = "internet device"
 
@@ -199,6 +200,8 @@ class SkillService:
             attr_val = attr_map.get(inst.category)
             if attr_val is not None:
                 gain = int(gain * (1 + attr_val / 200))
+            if inst.id == SKILL_NAME_TO_ID.get("vocals") or inst.parent_id == SKILL_NAME_TO_ID.get("vocals"):
+                gain = int(gain * (1 + avatar.voice / 200))
             discipline = avatar.discipline
         else:
             discipline = 50

--- a/backend/tests/avatars/test_avatar_service.py
+++ b/backend/tests/avatars/test_avatar_service.py
@@ -52,13 +52,14 @@ def test_crud_lifecycle():
     assert avatar.intelligence == 50
     assert avatar.creativity == 60
     assert avatar.discipline == 70
+    assert avatar.voice == 50
 
     fetched = svc.get_avatar(avatar.id)
     assert fetched and fetched.nickname == "Hero"
 
-    svc.update_avatar(avatar.id, AvatarUpdate(nickname="Legend"))
+    svc.update_avatar(avatar.id, AvatarUpdate(nickname="Legend", voice=80))
     updated = svc.get_avatar(avatar.id)
-    assert updated and updated.nickname == "Legend"
+    assert updated and updated.nickname == "Legend" and updated.voice == 80
 
     # Adjust mood based on lifestyle and events
     updated = svc.adjust_mood(avatar.id, lifestyle_score=80, events=["burnout"])
@@ -112,6 +113,8 @@ def test_update_validation_and_clamping():
         AvatarUpdate(discipline=-5)
     with pytest.raises(ValueError):
         AvatarUpdate(tech_savvy=200)
+    with pytest.raises(ValueError):
+        AvatarUpdate(voice=150)
 
     # Bypass validation to ensure service clamps the values
     update_data = AvatarUpdate.model_construct(
@@ -121,6 +124,7 @@ def test_update_validation_and_clamping():
         creativity=120,
         discipline=-5,
         tech_savvy=150,
+        voice=150,
     )
     svc.update_avatar(avatar.id, update_data)
     updated = svc.get_avatar(avatar.id)
@@ -132,4 +136,5 @@ def test_update_validation_and_clamping():
         and updated.creativity == 100
         and updated.discipline == 0
         and updated.tech_savvy == 100
+        and updated.voice == 100
     )

--- a/tests/test_practice_xp.py
+++ b/tests/test_practice_xp.py
@@ -79,3 +79,45 @@ def test_recording_session_grants_skill():
     prod_skill = Skill(id=SKILL_NAME_TO_ID["music_production"], name="music_production", category="creative")
     inst = skill_service.train(42, prod_skill, 0)
     assert inst.xp == 20
+
+
+def test_gig_voice_influence(monkeypatch, tmp_path):
+    from backend.services import gig_service as gs
+
+    db = tmp_path / "gig.db"
+    _setup_gig_db(db)
+    monkeypatch.setattr(gs, "DB_PATH", str(db))
+    monkeypatch.setattr(
+        gs.fan_service,
+        "get_band_fan_stats",
+        lambda _bid: {"total_fans": 100, "average_loyalty": 100},
+    )
+    monkeypatch.setattr(gs.fan_service, "boost_fans_after_gig", lambda *a, **k: None)
+    monkeypatch.setattr(gs.skill_service, "train_with_method", lambda *a, **k: None)
+
+    conn = sqlite3.connect(db)
+    conn.execute("INSERT INTO bands (id, fame) VALUES (1, 0)")
+    conn.commit()
+    conn.close()
+
+    class DummyAvatar:
+        def __init__(self, voice: int):
+            self.voice = voice
+
+    class DummyAvatarService:
+        def __init__(self, voice: int):
+            self.avatar = DummyAvatar(voice)
+
+        def get_avatar(self, _user_id: int):
+            return self.avatar
+
+    gs.avatar_service = DummyAvatarService(0)
+    gs.create_gig(1, "Test City", 200, "2024-01-01", 10)
+    low = gs.simulate_gig_result(1)
+
+    gs.avatar_service = DummyAvatarService(100)
+    gs.create_gig(1, "Test City", 200, "2024-01-02", 10)
+    high = gs.simulate_gig_result(2)
+
+    assert high["attendance"] > low["attendance"]
+    assert high["fame_gain"] > low["fame_gain"]

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -9,6 +9,7 @@ from backend.models.skill import Skill, SkillSpecialization
 from backend.models.xp_config import XPConfig, get_config, set_config
 from backend.services.item_service import item_service
 from backend.services.skill_service import SkillService
+from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 class DummyXPEvents:
@@ -196,6 +197,28 @@ def test_environment_quality(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
         1, skill, LearningMethod.PRACTICE, 1, environment_quality=1.5
     )
     assert updated.xp == 15
+
+
+def test_voice_boosts_vocal_xp() -> None:
+    class DummyAvatar:
+        def __init__(self, voice: int):
+            self.voice = voice
+            self.discipline = 50
+            self.creativity = 50
+            self.charisma = 0
+            self.intelligence = 50
+
+    class DummyAvatarService:
+        def __init__(self, avatar: DummyAvatar):
+            self.avatar = avatar
+
+        def get_avatar(self, user_id: int) -> DummyAvatar:
+            return self.avatar
+
+    svc = SkillService(avatar_service=DummyAvatarService(DummyAvatar(80)))
+    skill = Skill(id=SKILL_NAME_TO_ID["vocals"], name="vocals", category="performance")
+    updated = svc.train(1, skill, 100)
+    assert updated.xp == 140
 
 
 def test_lifestyle_modifier(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `voice` stat to avatars and API schemas
- clamp `voice` updates to 0-100 and leverage it for vocal XP
- factor avatar voice into gig attendance and fan response
- cover voice persistence, XP boost, and gig influence with tests

## Testing
- `pytest backend/tests/avatars/test_avatar_service.py tests/test_skill_service.py tests/test_practice_xp.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'BookIn' and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68be8ff6c5dc832582d03ef7c1071f08