### PR TITLE
Centralise lifestyle config with admin controls

### DIFF
--- a/backend/config/lifestyle.py
+++ b/backend/config/lifestyle.py
@@ -1,0 +1,25 @@
+"""Configuration values for lifestyle decay and XP modifiers.
+
+Centralising these values makes it easy to tweak balance for the lifestyle
+system without touching the core scheduling logic.  Admin routes can mutate
+these dictionaries at runtime for live tuning.
+"""
+
+# Daily decay values applied to lifestyle attributes.
+DECAY = {
+    "mental_health": 1.0,
+    "stress": 1.5,
+    "training_discipline": 0.5,
+}
+
+# Thresholds for XP modifiers. Each entry defines either a minimum or maximum
+# threshold that triggers a multiplier when violated.
+MODIFIER_THRESHOLDS = {
+    "sleep_hours": {"min": 5, "modifier": 0.7},
+    "stress": {"max": 80, "modifier": 0.75},
+    "training_discipline": {"min": 30, "modifier": 0.85},
+    "mental_health": {"min": 60, "modifier": 0.8},
+    "nutrition": {"min": 40, "modifier": 0.9},
+    "fitness": {"min": 30, "modifier": 0.9},
+}
+

--- a/backend/routes/admin_lifestyle_routes.py
+++ b/backend/routes/admin_lifestyle_routes.py
@@ -1,0 +1,54 @@
+"""Admin endpoints for managing lifestyle configuration."""
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user_id, require_permission
+from backend.services.admin_audit_service import audit_dependency
+from backend.config import lifestyle as lifestyle_config
+
+
+router = APIRouter(
+    prefix="/lifestyle", tags=["AdminLifestyle"], dependencies=[Depends(audit_dependency)]
+)
+
+
+class LifestyleConfigIn(BaseModel):
+    decay: dict[str, float] | None = None
+    modifier_thresholds: dict[str, dict[str, float]] | None = None
+
+
+@router.get("/config")
+async def get_config(req: Request) -> dict:
+    """Return current lifestyle configuration."""
+
+    admin_id = await get_current_user_id(req)
+    await require_permission(["admin"], admin_id)
+    return {
+        "decay": lifestyle_config.DECAY,
+        "modifier_thresholds": lifestyle_config.MODIFIER_THRESHOLDS,
+    }
+
+
+@router.put("/config")
+async def update_config(payload: LifestyleConfigIn, req: Request) -> dict:
+    """Update lifestyle configuration values."""
+
+    admin_id = await get_current_user_id(req)
+    await require_permission(["admin"], admin_id)
+
+    if payload.decay:
+        lifestyle_config.DECAY.update(payload.decay)
+
+    if payload.modifier_thresholds:
+        for key, values in payload.modifier_thresholds.items():
+            if key in lifestyle_config.MODIFIER_THRESHOLDS:
+                lifestyle_config.MODIFIER_THRESHOLDS[key].update(values)
+            else:
+                lifestyle_config.MODIFIER_THRESHOLDS[key] = values
+
+    return {
+        "decay": lifestyle_config.DECAY,
+        "modifier_thresholds": lifestyle_config.MODIFIER_THRESHOLDS,
+    }
+

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -36,6 +36,7 @@ from .admin_venue_routes import router as venue_router
 from .admin_workshop_routes import router as workshop_router
 from .admin_xp_event_routes import router as xp_event_router
 from .admin_xp_routes import router as xp_router
+from .admin_lifestyle_routes import router as lifestyle_router
 
 router = APIRouter(prefix="/admin", tags=["Admin"])
 
@@ -74,6 +75,7 @@ router.include_router(schema_router)
 router.include_router(song_popularity_router)
 router.include_router(item_router)
 router.include_router(drug_router)
+router.include_router(lifestyle_router)
 
 router.include_router(course_router)
 router.include_router(book_router)

--- a/tests/test_lifestyle_config.py
+++ b/tests/test_lifestyle_config.py
@@ -1,0 +1,47 @@
+from backend.config import lifestyle as cfg
+from backend.services.lifestyle_scheduler import lifestyle_xp_modifier
+
+
+def test_default_lifestyle_config_values() -> None:
+    assert cfg.DECAY == {
+        "mental_health": 1.0,
+        "stress": 1.5,
+        "training_discipline": 0.5,
+    }
+    assert cfg.MODIFIER_THRESHOLDS == {
+        "sleep_hours": {"min": 5, "modifier": 0.7},
+        "stress": {"max": 80, "modifier": 0.75},
+        "training_discipline": {"min": 30, "modifier": 0.85},
+        "mental_health": {"min": 60, "modifier": 0.8},
+        "nutrition": {"min": 40, "modifier": 0.9},
+        "fitness": {"min": 30, "modifier": 0.9},
+    }
+
+
+def test_modifier_respects_config() -> None:
+    thresholds = cfg.MODIFIER_THRESHOLDS
+    assert (
+        lifestyle_xp_modifier(4, 20, 100, 100, 100, 100, thresholds)
+        == thresholds["sleep_hours"]["modifier"]
+    )
+    assert (
+        lifestyle_xp_modifier(8, 90, 100, 100, 100, 100, thresholds)
+        == thresholds["stress"]["modifier"]
+    )
+    assert (
+        lifestyle_xp_modifier(8, 20, 20, 100, 100, 100, thresholds)
+        == thresholds["training_discipline"]["modifier"]
+    )
+    assert (
+        lifestyle_xp_modifier(8, 20, 100, 50, 100, 100, thresholds)
+        == thresholds["mental_health"]["modifier"]
+    )
+    assert (
+        lifestyle_xp_modifier(8, 20, 100, 100, 30, 100, thresholds)
+        == thresholds["nutrition"]["modifier"]
+    )
+    assert (
+        lifestyle_xp_modifier(8, 20, 100, 100, 100, 20, thresholds)
+        == thresholds["fitness"]["modifier"]
+    )
+


### PR DESCRIPTION
## Summary
- move lifestyle decay and XP thresholds into a dedicated config module
- inject lifestyle config into scheduler and expose admin CRUD endpoints
- add tests to ensure default config matches previous behaviour

## Testing
- `PYTHONPATH=$PWD pytest tests/test_lifestyle_config.py`
- `pytest` *(fails: 91 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68be9ab0b4a8832599783b7b4fd4060c