### PR TITLE
feat: add tour planner component

### DIFF
--- a/frontend/src/tour/Planner.tsx
+++ b/frontend/src/tour/Planner.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+// Internal state setter to allow updateSlot to modify component state
+let setEntriesRef: React.Dispatch<React.SetStateAction<Record<string, any>>> | null = null;
+
+export async function fetchSchedule(): Promise<Record<string, any>> {
+  const res = await fetch('/api/tour-collab/schedule');
+  if (!res.ok) {
+    throw new Error('Failed to fetch schedule');
+  }
+  return res.json();
+}
+
+export async function saveSlot(time: string, value: any, durationDays = 1) {
+  const res = await fetch(`/api/tour-collab/schedule/${encodeURIComponent(time)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ value, durationDays })
+  });
+  if (!res.ok) {
+    throw new Error('Failed to save slot');
+  }
+  return res.json();
+}
+
+export async function deleteSlot(time: string) {
+  const res = await fetch(`/api/tour-collab/schedule/${encodeURIComponent(time)}`, {
+    method: 'DELETE'
+  });
+  if (!res.ok) {
+    throw new Error('Failed to delete slot');
+  }
+  return res.json();
+}
+
+export async function updateSlot(time: string, value: any, durationDays = 1) {
+  if (setEntriesRef) {
+    setEntriesRef((prev) => ({ ...prev, [time]: value }));
+  }
+  const res = await saveSlot(time, value, durationDays);
+  return res;
+}
+
+interface ScheduleItem {
+  date: string;
+  venue: string;
+}
+
+interface ExpenseItem {
+  description: string;
+  amount: number;
+}
+
+export const Planner: React.FC = () => {
+  const [entries, setEntries] = useState<Record<string, any>>({});
+  const [schedule, setSchedule] = useState<ScheduleItem[]>([]);
+  const [expenses, setExpenses] = useState<ExpenseItem[]>([]);
+  const gridRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setEntriesRef = setEntries;
+    fetchSchedule().then(setEntries).catch(() => {});
+    return () => {
+      setEntriesRef = null;
+    };
+  }, []);
+
+  const handleAddDate = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const date = (form.elements.namedItem('date') as HTMLInputElement).value;
+    const venue = (form.elements.namedItem('venue') as HTMLInputElement).value;
+    const item = { date, venue };
+    await fetch('/api/tour-collab/schedule', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(item)
+    });
+    setSchedule((prev) => [...prev, item]);
+    form.reset();
+  };
+
+  const handleDeleteDate = async (idx: number) => {
+    const item = schedule[idx];
+    await fetch('/api/tour-collab/schedule', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(item)
+    });
+    setSchedule((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const handleAddExpense = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const description = (form.elements.namedItem('description') as HTMLInputElement).value;
+    const amount = parseFloat((form.elements.namedItem('amount') as HTMLInputElement).value);
+    const item = { description, amount };
+    await fetch('/api/tour-collab/expenses', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(item)
+    });
+    setExpenses((prev) => [...prev, item]);
+    form.reset();
+  };
+
+  const handleDeleteExpense = async (idx: number) => {
+    const item = expenses[idx];
+    await fetch('/api/tour-collab/expenses', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(item)
+    });
+    setExpenses((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const slots = [] as JSX.Element[];
+  for (let h = 0; h < 24; h++) {
+    for (let q = 0; q < 4; q++) {
+      const minutes = q * 15;
+      const time = `${String(h).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+      const d = new Date();
+      d.setHours(h, minutes, 0, 0);
+      const label = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const content = entries[time]
+        ? typeof entries[time] === 'object'
+          ? entries[time].label || entries[time].value || ''
+          : entries[time]
+        : label;
+      slots.push(
+        <div
+          key={time}
+          className="slot"
+          data-time={time}
+          draggable
+          onDragStart={(e) => e.dataTransfer.setData('text/plain', time)}
+          onDrop={(e) => {
+            e.preventDefault();
+            const src = e.dataTransfer.getData('text/plain');
+            if (src && entries[src]) {
+              updateSlot(time, entries[src]);
+            }
+          }}
+          onDragOver={(e) => e.preventDefault()}
+          style={{ border: '1px solid #ccc', padding: '2px', minHeight: '20px' }}
+        >
+          {content}
+        </div>
+      );
+    }
+  }
+
+  return (
+    <div>
+      <div
+        id="plannerGrid"
+        ref={gridRef}
+        style={{ display: 'grid', gridTemplateColumns: 'repeat(8, 1fr)', gap: '2px' }}
+      >
+        {slots}
+      </div>
+
+      <h3>Tour Dates</h3>
+      <form onSubmit={handleAddDate}>
+        <input name="date" placeholder="Date" required />
+        <input name="venue" placeholder="Venue" required />
+        <button type="submit">Add Date</button>
+      </form>
+      <ul>
+        {schedule.map((s, i) => (
+          <li key={`${s.date}-${i}`}>{`${s.date} @ ${s.venue}`}
+            <button onClick={() => handleDeleteDate(i)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+
+      <h3>Expenses</h3>
+      <form onSubmit={handleAddExpense}>
+        <input name="description" placeholder="Description" required />
+        <input name="amount" type="number" step="0.01" placeholder="Amount" required />
+        <button type="submit">Add Expense</button>
+      </form>
+      <ul>
+        {expenses.map((e, i) => (
+          <li key={`${e.description}-${i}`}>{`${e.description}: $${e.amount}`}
+            <button onClick={() => handleDeleteExpense(i)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Planner;

--- a/frontend/tests/tour/planner.test.tsx
+++ b/frontend/tests/tour/planner.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { Planner, updateSlot } from '../../src/tour/Planner';
 import sched from '../schedule/fixtures/schedule.json';
 import { vi } from 'vitest';
@@ -21,22 +21,20 @@ describe('tour planner', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     render(<Planner />);
-    await new Promise((r) => setTimeout(r, 0));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
 
     const slots = document.querySelectorAll('#plannerGrid .slot');
     expect(slots.length).toBe(96);
-    const slot0000 = document.querySelector('[data-time="00:00"]');
-    expect(slot0000!.textContent).toContain('Sleep');
+    expect(await screen.findByText('Sleep')).toBeInTheDocument();
 
     await updateSlot('00:15', 'Practice');
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/tour-collab/schedule/00:15',
       expect.objectContaining({ method: 'PUT' })
     );
-    await new Promise((r) => setTimeout(r, 0));
-    const slot0015 = document.querySelector('[data-time="00:15"]');
-    expect(slot0015!.textContent).toContain('Practice');
+    await waitFor(() => expect(screen.getByText('Practice')).toBeInTheDocument());
 
-    (global as any).fetch = originalFetch;
+    (globalThis as any).fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 });


### PR DESCRIPTION
## Summary
- add React tour planner component with draggable grid
- swap prompt inputs for schedule and expenses to forms
- test planner scheduling interactions with vitest

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be9beafa2083259b9731a085209f1f