### PR TITLE
Add avatar skin marketplace and 3D avatar designer

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -58,6 +58,7 @@ from routes import (
     venue_sponsorships_routes,
     video_routes,
     world_pulse_routes,
+    skin_marketplace,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -187,6 +188,7 @@ app.include_router(
     tags=["Notifications"],
     dependencies=[Depends(get_current_user_id)],
 )
+app.include_router(skin_marketplace.router, prefix="/api", tags=["Skins"])
 
 
 

--- a/backend/models/avatar.py
+++ b/backend/models/avatar.py
@@ -77,4 +77,7 @@ class Avatar(Base):
     # trying to manage the other side which may be defined elsewhere with a
     # different registry.
     character = relationship(Character, lazy="joined", viewonly=True)
+    skins = relationship(
+        "AvatarSkin", back_populates="avatar", cascade="all, delete-orphan"
+    )
 

--- a/backend/models/avatar_skin.py
+++ b/backend/models/avatar_skin.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Boolean, Column, ForeignKey, Integer
+from sqlalchemy.orm import relationship
+
+from models.avatar import Base
+
+
+class AvatarSkin(Base):
+    """Association between an :class:`Avatar` and owned skins."""
+
+    __tablename__ = "avatar_skins"
+
+    id = Column(Integer, primary_key=True, index=True)
+    avatar_id = Column(
+        Integer,
+        ForeignKey("avatars.id", use_alter=True, link_to_name=True),
+        nullable=False,
+    )
+    skin_id = Column(Integer, nullable=False)
+    is_applied = Column(Boolean, default=False)
+
+    avatar = relationship("Avatar", back_populates="skins")

--- a/backend/routes/skin_marketplace.py
+++ b/backend/routes/skin_marketplace.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, HTTPException
+
+from schemas.skin import SkinResponse
+from schemas.skin_marketplace import SkinApplyRequest, SkinPurchaseRequest
+from services.skin_service import SkinService
+
+router = APIRouter(prefix="/skins", tags=["Skins"])
+svc = SkinService()
+
+
+@router.get("/", response_model=list[SkinResponse])
+def list_skins():
+    return svc.list_skins()
+
+
+@router.post("/{skin_id}/purchase")
+def purchase_skin(skin_id: int, payload: SkinPurchaseRequest):
+    svc.purchase_skin(payload.avatar_id, skin_id)
+    return {"status": "purchased"}
+
+
+@router.post("/{skin_id}/apply")
+def apply_skin(skin_id: int, payload: SkinApplyRequest):
+    avatar = svc.apply_skin(payload.avatar_id, skin_id)
+    if not avatar:
+        raise HTTPException(status_code=400, detail="Skin not owned")
+    return {"status": "applied", "avatar_id": avatar.id}

--- a/backend/schemas/skin_marketplace.py
+++ b/backend/schemas/skin_marketplace.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class SkinPurchaseRequest(BaseModel):
+    avatar_id: int
+
+
+class SkinApplyRequest(BaseModel):
+    avatar_id: int

--- a/backend/services/skin_service.py
+++ b/backend/services/skin_service.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.avatar import Avatar, Base as AvatarBase
+from models.skin import Skin
+from models.avatar_skin import AvatarSkin
+
+# Reuse the same SQLite database as AvatarService
+from services.avatar_service import DB_PATH
+
+DATABASE_URL = f"sqlite:///{DB_PATH}"
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+# Ensure tables exist
+Skin.__table__.create(bind=engine, checkfirst=True)
+AvatarBase.metadata.create_all(bind=engine)
+
+
+class SkinService:
+    """Marketplace operations for avatar skins."""
+
+    def __init__(self, session_factory: Callable[[], Session] | sessionmaker = SessionLocal):
+        self.session_factory = session_factory
+
+    # ------------------------------------------------------------------
+    def list_skins(self) -> list[Skin]:
+        with self.session_factory() as session:
+            return session.query(Skin).all()
+
+    # ------------------------------------------------------------------
+    def purchase_skin(self, avatar_id: int, skin_id: int) -> AvatarSkin:
+        with self.session_factory() as session:
+            owned = (
+                session.query(AvatarSkin)
+                .filter_by(avatar_id=avatar_id, skin_id=skin_id)
+                .first()
+            )
+            if owned:
+                return owned
+            avatar_skin = AvatarSkin(avatar_id=avatar_id, skin_id=skin_id)
+            session.add(avatar_skin)
+            session.commit()
+            session.refresh(avatar_skin)
+            return avatar_skin
+
+    # ------------------------------------------------------------------
+    def apply_skin(self, avatar_id: int, skin_id: int) -> Optional[Avatar]:
+        with self.session_factory() as session:
+            avatar_skin = (
+                session.query(AvatarSkin)
+                .filter_by(avatar_id=avatar_id, skin_id=skin_id)
+                .first()
+            )
+            if not avatar_skin:
+                return None
+            skin = session.get(Skin, skin_id)
+            avatar = session.get(Avatar, avatar_id)
+            if not skin or not avatar:
+                return None
+            # Reset other skins for this avatar
+            session.query(AvatarSkin).filter_by(avatar_id=avatar_id).update({"is_applied": False})
+            avatar_skin.is_applied = True
+            # Apply appearance based on category
+            try:
+                setattr(avatar, skin.category, skin.name)
+            except Exception:
+                pass
+            session.commit()
+            session.refresh(avatar)
+            return avatar

--- a/backend/tests/avatar/test_skin_marketplace.py
+++ b/backend/tests/avatar/test_skin_marketplace.py
@@ -1,0 +1,73 @@
+from services.avatar_service import AvatarService
+from services.skin_service import SkinService, engine
+from models.avatar import Avatar
+from models.skin import Skin
+from models.avatar_skin import AvatarSkin
+from schemas.avatar import AvatarCreate
+from models.avatar import Base as AvatarBase
+
+# ensure a clean database for each test run
+AvatarBase.metadata.drop_all(bind=engine)
+Skin.__table__.drop(bind=engine, checkfirst=True)
+Skin.__table__.create(bind=engine, checkfirst=True)
+AvatarBase.metadata.create_all(bind=engine)
+
+avatar_service = AvatarService()
+skin_service = SkinService()
+
+
+def _create_avatar() -> Avatar:
+    avatar = avatar_service.create_avatar(
+        AvatarCreate(
+            character_id=1,
+            nickname="Hero",
+            body_type="slim",
+            skin_tone="light",
+            face_shape="oval",
+            hair_style="short",
+            hair_color="#000000",
+            top_clothing="t-shirt",
+            bottom_clothing="jeans",
+            shoes="sneakers",
+        )
+    )
+    return avatar
+
+
+def _create_skin() -> Skin:
+    with skin_service.session_factory() as session:
+        skin = Skin(
+            name="Cool Shirt",
+            category="top_clothing",
+            mesh_url="/mesh",
+            texture_url="/tex",
+            rarity="common",
+            author="sys",
+            price=100,
+        )
+        session.add(skin)
+        session.commit()
+        session.refresh(skin)
+        return skin
+
+
+def test_list_and_purchase_and_apply_skin():
+    avatar = _create_avatar()
+    skin = _create_skin()
+
+    skins = skin_service.list_skins()
+    assert any(s.id == skin.id for s in skins)
+
+    skin_service.purchase_skin(avatar.id, skin.id)
+    with skin_service.session_factory() as session:
+        owned = session.query(AvatarSkin).filter_by(avatar_id=avatar.id, skin_id=skin.id).first()
+        assert owned is not None
+        assert owned.is_applied is False
+
+    skin_service.apply_skin(avatar.id, skin.id)
+    with skin_service.session_factory() as session:
+        avatar_db = session.get(Avatar, avatar.id)
+        owned = session.query(AvatarSkin).filter_by(avatar_id=avatar.id, skin_id=skin.id).first()
+        assert avatar_db.top_clothing == "Cool Shirt"
+        assert owned.is_applied is True
+

--- a/frontend/src/avatar/Designer.tsx
+++ b/frontend/src/avatar/Designer.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+
+interface AvatarData {
+  hair_color: string;
+  top_clothing: string;
+}
+
+interface Props {
+  avatar: AvatarData;
+  onChange: (field: keyof AvatarData, value: string) => void;
+}
+
+const Designer: React.FC<Props> = ({ avatar, onChange }) => {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(300, 300);
+    mount.appendChild(renderer.domElement);
+
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshBasicMaterial({ color: avatar.hair_color });
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+    camera.position.z = 5;
+
+    const animate = () => {
+      cube.rotation.x += 0.01;
+      cube.rotation.y += 0.01;
+      renderer.render(scene, camera);
+      requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      mount.removeChild(renderer.domElement);
+      renderer.dispose();
+    };
+  }, [avatar.hair_color]);
+
+  return (
+    <div>
+      <div ref={mountRef} />
+      <div className="mt-2 space-y-2">
+        <label className="block">
+          Hair Color
+          <input
+            type="color"
+            value={avatar.hair_color}
+            onChange={(e) => onChange('hair_color', e.target.value)}
+            className="ml-2"
+          />
+        </label>
+        <label className="block">
+          Top Clothing
+          <input
+            type="text"
+            value={avatar.top_clothing}
+            onChange={(e) => onChange('top_clothing', e.target.value)}
+            className="ml-2 border"
+          />
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default Designer;


### PR DESCRIPTION
## Summary
- Add Three.js-based avatar designer component to edit hair color and clothing
- Implement skin marketplace backend with list, purchase and apply endpoints
- Persist avatar-owned skins and cover marketplace flow with unit tests

## Testing
- `pytest backend/tests/avatar/test_skin_marketplace.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bea1e03e488325931e7a7e7a54f36e