### PR TITLE
Add country-specific charts and API

### DIFF
--- a/backend/migrations/sql/165_chart_country_code.sql
+++ b/backend/migrations/sql/165_chart_country_code.sql
@@ -1,0 +1,3 @@
+-- Add country_code column to chart_snapshots to support country-specific charts
+ALTER TABLE chart_snapshots ADD COLUMN country_code TEXT;
+CREATE INDEX IF NOT EXISTS ix_charts_country ON chart_snapshots(country_code);

--- a/backend/migrations/versions/0026_165_chart_country_code.py
+++ b/backend/migrations/versions/0026_165_chart_country_code.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from alembic import op
+
+revision = '0026'
+down_revision = '0025'
+branch_labels = None
+depends_on = None
+
+SQL_FILE = Path(__file__).resolve().parent.parent / 'sql' / '165_chart_country_code.sql'
+
+def upgrade() -> None:
+    op.execute(SQL_FILE.read_text())
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_charts_country;")
+    # SQLite does not support dropping columns

--- a/backend/routes/chart_routes.py
+++ b/backend/routes/chart_routes.py
@@ -1,9 +1,51 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
+import sqlite3
 
 from backend.auth.dependencies import get_current_user_id
 from backend.services.chart_service import calculate_weekly_chart, get_chart
+from backend.database import DB_PATH
 
 router = APIRouter(prefix="/charts", tags=["Charts"])
+
+
+@router.get("/{country}")
+def get_country_charts(country: str, chart_type: str = "streams_song", period: str = "daily"):
+    """Return latest chart snapshot for a given ``country``."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT MAX(period_start)
+            FROM chart_snapshots
+            WHERE chart_type = ? AND period = ? AND country_code = ?
+            """,
+            (chart_type, period, country.upper()),
+        )
+        row = cur.fetchone()
+        if not row or row[0] is None:
+            return []
+        latest = row[0]
+        cur.execute(
+            """
+            SELECT rank, work_type, work_id, band_id, title, metric_value
+            FROM chart_snapshots
+            WHERE chart_type = ? AND period = ? AND country_code = ? AND period_start = ?
+            ORDER BY rank ASC
+            """,
+            (chart_type, period, country.upper(), latest),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "rank": rank,
+            "work_type": work_type,
+            "work_id": work_id,
+            "band_id": band_id,
+            "title": title,
+            "metric": metric,
+        }
+        for rank, work_type, work_id, band_id, title, metric in rows
+    ]
 
 
 @router.get("/{region}/{week_start}")

--- a/backend/services/jobs_charts.py
+++ b/backend/services/jobs_charts.py
@@ -17,6 +17,7 @@ You can tune these weights later or make them config-driven.
 """
 
 import sqlite3
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -51,6 +52,8 @@ class ChartsJobsService:
               period TEXT NOT NULL,
               period_start TEXT NOT NULL,
               period_end TEXT NOT NULL,
+              country_code TEXT,
+              region TEXT DEFAULT 'global',
               rank INTEGER NOT NULL,
               work_type TEXT NOT NULL,
               work_id INTEGER NOT NULL,
@@ -59,11 +62,13 @@ class ChartsJobsService:
               metric_value REAL NOT NULL,
               source_notes TEXT,
               created_at TEXT DEFAULT (datetime('now')),
-              UNIQUE(chart_type, period, period_start, rank)
+              UNIQUE(chart_type, period, period_start, country_code, rank)
             )
             """)
             cur.execute("CREATE INDEX IF NOT EXISTS ix_charts_period ON chart_snapshots(period, period_start)")
             cur.execute("CREATE INDEX IF NOT EXISTS ix_charts_work ON chart_snapshots(work_type, work_id)")
+            cur.execute("CREATE INDEX IF NOT EXISTS ix_charts_region ON chart_snapshots(region)")
+            cur.execute("CREATE INDEX IF NOT EXISTS ix_charts_country ON chart_snapshots(country_code)")
             conn.commit()
 
     # -------- utilities --------
@@ -85,107 +90,303 @@ class ChartsJobsService:
         return (None, None)
 
     def _clear_period(self, cur, chart_type: str, period: str, window: Window) -> None:
-        cur.execute("""
+        cur.execute(
+            """
             DELETE FROM chart_snapshots
             WHERE chart_type = ? AND period = ? AND period_start = ?
-        """, (chart_type, period, window.start))
+            """,
+            (chart_type, period, window.start),
+        )
 
-    def _insert_rows(self, cur, chart_type: str, period: str, window: Window, rows: List[Tuple[str,int,float,str]]):
+    def _insert_rows(
+        self,
+        cur,
+        chart_type: str,
+        period: str,
+        window: Window,
+        rows: List[Tuple[Optional[str], str, int, float, str]],
+    ):
         """
-        rows: list of (work_type, work_id, metric_value, source_notes)
+        rows: list of (country_code, work_type, work_id, metric_value, source_notes)
         """
-        rank = 1
-        for work_type, work_id, metric_value, notes in rows:
+        ranks: Dict[Optional[str], int] = defaultdict(lambda: 1)
+        for country_code, work_type, work_id, metric_value, notes in rows:
             band_id, title = self._owner_band_and_title(cur, work_type, work_id)
-            cur.execute("""
-                INSERT INTO chart_snapshots (chart_type, period, period_start, period_end, rank, work_type, work_id, band_id, title, metric_value, source_notes)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (chart_type, period, window.start, window.end, rank, work_type, work_id, band_id, title, float(metric_value), notes))
-            rank += 1
+            rank = ranks[country_code]
+            cur.execute(
+                """
+                INSERT INTO chart_snapshots (
+                    chart_type, period, period_start, period_end,
+                    country_code, rank, work_type, work_id, band_id,
+                    title, metric_value, source_notes
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    chart_type,
+                    period,
+                    window.start,
+                    window.end,
+                    country_code,
+                    rank,
+                    work_type,
+                    work_id,
+                    band_id,
+                    title,
+                    float(metric_value),
+                    notes,
+                ),
+            )
+            ranks[country_code] += 1
 
     # -------- channel aggregations --------
-    def _aggregate_streams_song(self, cur, window: Window) -> List[Tuple[str,int,float,str]]:
+    def _has_column(self, cur, table: str, column: str) -> bool:
+        cur.execute(f"PRAGMA table_info({table})")
+        return any(row[1].lower() == column.lower() for row in cur.fetchall())
+
+    def _aggregate_streams_song(
+        self, cur, window: Window
+    ) -> List[Tuple[Optional[str], str, int, float, str]]:
         if not self._table_exists(cur, "streams"):
             return []
-        cur.execute(f"""
-            WITH capped AS (
-              SELECT song_id, date(created_at) AS d, user_id, MIN(COUNT(*), {DAILY_STREAM_CAP_PER_USER_PER_SONG}) AS capped_plays
-              FROM streams
-              WHERE datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
-              GROUP BY song_id, d, user_id
-            ), tot AS (
-              SELECT song_id, SUM(capped_plays) AS plays FROM capped GROUP BY song_id
+
+        country_col = None
+        if self._has_column(cur, "streams", "country_code"):
+            country_col = "country_code"
+        elif self._has_column(cur, "streams", "country"):
+            country_col = "country"
+
+        if country_col:
+            cur.execute(
+                f"""
+                WITH capped AS (
+                  SELECT song_id, {country_col} AS cc, date(created_at) AS d, user_id,
+                         MIN(COUNT(*), {DAILY_STREAM_CAP_PER_USER_PER_SONG}) AS capped_plays
+                  FROM streams
+                  WHERE datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
+                  GROUP BY song_id, cc, d, user_id
+                ), tot AS (
+                  SELECT cc AS country_code, song_id, SUM(capped_plays) AS plays
+                  FROM capped
+                  GROUP BY cc, song_id
+                )
+                SELECT country_code, song_id, plays FROM tot
+                """,
+                (f"{window.start} 00:00:00", f"{window.end} 23:59:59"),
             )
-            SELECT song_id, plays FROM tot ORDER BY plays DESC, song_id ASC LIMIT 100
-        """, (f"{window.start} 00:00:00", f"{window.end} 23:59:59"))
-        rows = cur.fetchall()
-        return [("song", int(song_id), float(plays), "plays") for (song_id, plays) in rows]
+            data = cur.fetchall()
+            grouped: Dict[Optional[str], List[Tuple[int, float]]] = defaultdict(list)
+            for cc, song_id, plays in data:
+                grouped[cc].append((int(song_id), float(plays)))
+            out: List[Tuple[Optional[str], str, int, float, str]] = []
+            for cc, vals in grouped.items():
+                vals.sort(key=lambda x: (-x[1], x[0]))
+                for song_id, plays in vals[:100]:
+                    out.append((cc, "song", song_id, plays, "plays"))
+            return out
+        else:
+            cur.execute(
+                f"""
+                WITH capped AS (
+                  SELECT song_id, date(created_at) AS d, user_id,
+                         MIN(COUNT(*), {DAILY_STREAM_CAP_PER_USER_PER_SONG}) AS capped_plays
+                  FROM streams
+                  WHERE datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
+                  GROUP BY song_id, d, user_id
+                ), tot AS (
+                  SELECT song_id, SUM(capped_plays) AS plays FROM capped GROUP BY song_id
+                )
+                SELECT song_id, plays FROM tot ORDER BY plays DESC, song_id ASC LIMIT 100
+                """,
+                (f"{window.start} 00:00:00", f"{window.end} 23:59:59"),
+            )
+            rows = cur.fetchall()
+            return [(None, "song", int(song_id), float(plays), "plays") for (song_id, plays) in rows]
 
-    def _aggregate_digital_song(self, cur, window: Window) -> List[Tuple[str,int,float,str]]:
+    def _aggregate_digital_song(
+        self, cur, window: Window
+    ) -> List[Tuple[Optional[str], str, int, float, str]]:
         if not self._table_exists(cur, "digital_sales"):
             return []
-        cur.execute("""
-            SELECT work_id, SUM(price_cents) as cents
-            FROM digital_sales
-            WHERE work_type = 'song'
-              AND datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
-            GROUP BY work_id
-            ORDER BY cents DESC, work_id ASC
-            LIMIT 100
-        """, (f"{window.start} 00:00:00", f"{window.end} 23:59:59"))
-        return [("song", int(work_id), float(cents), "digital_cents") for (work_id, cents) in cur.fetchall()]
 
-    def _aggregate_digital_album(self, cur, window: Window) -> List[Tuple[str,int,float,str]]:
+        country_col = None
+        if self._has_column(cur, "digital_sales", "country_code"):
+            country_col = "country_code"
+        elif self._has_column(cur, "digital_sales", "country"):
+            country_col = "country"
+
+        if country_col:
+            cur.execute(
+                f"""
+                SELECT {country_col} AS cc, work_id, SUM(price_cents) as cents
+                FROM digital_sales
+                WHERE work_type = 'song'
+                  AND datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
+                GROUP BY cc, work_id
+                """,
+                (f"{window.start} 00:00:00", f"{window.end} 23:59:59"),
+            )
+            data = cur.fetchall()
+            grouped: Dict[Optional[str], List[Tuple[int, float]]] = defaultdict(list)
+            for cc, wid, cents in data:
+                grouped[cc].append((int(wid), float(cents)))
+            out: List[Tuple[Optional[str], str, int, float, str]] = []
+            for cc, vals in grouped.items():
+                vals.sort(key=lambda x: (-x[1], x[0]))
+                for wid, cents in vals[:100]:
+                    out.append((cc, "song", wid, cents, "digital_cents"))
+            return out
+        else:
+            cur.execute(
+                """
+                SELECT work_id, SUM(price_cents) as cents
+                FROM digital_sales
+                WHERE work_type = 'song'
+                  AND datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
+                GROUP BY work_id
+                ORDER BY cents DESC, work_id ASC
+                LIMIT 100
+                """,
+                (f"{window.start} 00:00:00", f"{window.end} 23:59:59"),
+            )
+            return [
+                (None, "song", int(work_id), float(cents), "digital_cents")
+                for (work_id, cents) in cur.fetchall()
+            ]
+
+    def _aggregate_digital_album(
+        self, cur, window: Window
+    ) -> List[Tuple[Optional[str], str, int, float, str]]:
         if not self._table_exists(cur, "digital_sales"):
             return []
-        cur.execute("""
-            SELECT work_id, SUM(price_cents) as cents
-            FROM digital_sales
-            WHERE work_type = 'album'
-              AND datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
-            GROUP BY work_id
-            ORDER BY cents DESC, work_id ASC
-            LIMIT 100
-        """, (f"{window.start} 00:00:00", f"{window.end} 23:59:59"))
-        return [("album", int(work_id), float(cents), "digital_cents") for (work_id, cents) in cur.fetchall()]
 
-    def _aggregate_vinyl_album(self, cur, window: Window) -> List[Tuple[str,int,float,str]]:
-        needed = ["vinyl_order_items","vinyl_orders","vinyl_skus"]
+        country_col = None
+        if self._has_column(cur, "digital_sales", "country_code"):
+            country_col = "country_code"
+        elif self._has_column(cur, "digital_sales", "country"):
+            country_col = "country"
+
+        if country_col:
+            cur.execute(
+                f"""
+                SELECT {country_col} AS cc, work_id, SUM(price_cents) as cents
+                FROM digital_sales
+                WHERE work_type = 'album'
+                  AND datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
+                GROUP BY cc, work_id
+                """,
+                (f"{window.start} 00:00:00", f"{window.end} 23:59:59"),
+            )
+            data = cur.fetchall()
+            grouped: Dict[Optional[str], List[Tuple[int, float]]] = defaultdict(list)
+            for cc, wid, cents in data:
+                grouped[cc].append((int(wid), float(cents)))
+            out: List[Tuple[Optional[str], str, int, float, str]] = []
+            for cc, vals in grouped.items():
+                vals.sort(key=lambda x: (-x[1], x[0]))
+                for wid, cents in vals[:100]:
+                    out.append((cc, "album", wid, cents, "digital_cents"))
+            return out
+        else:
+            cur.execute(
+                """
+                SELECT work_id, SUM(price_cents) as cents
+                FROM digital_sales
+                WHERE work_type = 'album'
+                  AND datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
+                GROUP BY work_id
+                ORDER BY cents DESC, work_id ASC
+                LIMIT 100
+                """,
+                (f"{window.start} 00:00:00", f"{window.end} 23:59:59"),
+            )
+            return [
+                (None, "album", int(work_id), float(cents), "digital_cents")
+                for (work_id, cents) in cur.fetchall()
+            ]
+
+    def _aggregate_vinyl_album(
+        self, cur, window: Window
+    ) -> List[Tuple[Optional[str], str, int, float, str]]:
+        needed = ["vinyl_order_items", "vinyl_orders", "vinyl_skus"]
         if not all(self._table_exists(cur, t) for t in needed):
             return []
-        cur.execute("""
-            SELECT s.album_id, SUM(oi.unit_price_cents * (oi.qty - oi.refunded_qty)) as cents
-            FROM vinyl_order_items oi
-            JOIN vinyl_orders o ON o.id = oi.order_id
-            JOIN vinyl_skus s ON s.id = oi.sku_id
-            WHERE o.status = 'confirmed'
-              AND datetime(o.created_at) >= datetime(?)
-              AND datetime(o.created_at) <= datetime(?)
-            GROUP BY s.album_id
-            ORDER BY cents DESC, s.album_id ASC
-            LIMIT 100
-        """, (f"{window.start} 00:00:00", f"{window.end} 23:59:59"))
-        return [("album", int(album_id), float(cents), "vinyl_cents") for (album_id, cents) in cur.fetchall()]
 
-    def _aggregate_combined_song(self, cur, window: Window) -> List[Tuple[str,int,float,str]]:
+        country_col = None
+        if self._has_column(cur, "vinyl_orders", "country_code"):
+            country_col = "country_code"
+        elif self._has_column(cur, "vinyl_orders", "country"):
+            country_col = "country"
+
+        if country_col:
+            cur.execute(
+                f"""
+                SELECT o.{country_col} AS cc, s.album_id,
+                       SUM(oi.unit_price_cents * (oi.qty - oi.refunded_qty)) as cents
+                FROM vinyl_order_items oi
+                JOIN vinyl_orders o ON o.id = oi.order_id
+                JOIN vinyl_skus s ON s.id = oi.sku_id
+                WHERE o.status = 'confirmed'
+                  AND datetime(o.created_at) >= datetime(?)
+                  AND datetime(o.created_at) <= datetime(?)
+                GROUP BY cc, s.album_id
+                """,
+                (f"{window.start} 00:00:00", f"{window.end} 23:59:59"),
+            )
+            data = cur.fetchall()
+            grouped: Dict[Optional[str], List[Tuple[int, float]]] = defaultdict(list)
+            for cc, album_id, cents in data:
+                grouped[cc].append((int(album_id), float(cents)))
+            out: List[Tuple[Optional[str], str, int, float, str]] = []
+            for cc, vals in grouped.items():
+                vals.sort(key=lambda x: (-x[1], x[0]))
+                for aid, cents in vals[:100]:
+                    out.append((cc, "album", aid, cents, "vinyl_cents"))
+            return out
+        else:
+            cur.execute(
+                """
+                SELECT s.album_id, SUM(oi.unit_price_cents * (oi.qty - oi.refunded_qty)) as cents
+                FROM vinyl_order_items oi
+                JOIN vinyl_orders o ON o.id = oi.order_id
+                JOIN vinyl_skus s ON s.id = oi.sku_id
+                WHERE o.status = 'confirmed'
+                  AND datetime(o.created_at) >= datetime(?)
+                  AND datetime(o.created_at) <= datetime(?)
+                GROUP BY s.album_id
+                ORDER BY cents DESC, s.album_id ASC
+                LIMIT 100
+                """,
+                (f"{window.start} 00:00:00", f"{window.end} 23:59:59"),
+            )
+            return [
+                (None, "album", int(album_id), float(cents), "vinyl_cents")
+                for (album_id, cents) in cur.fetchall()
+            ]
+
+    def _aggregate_combined_song(
+        self, cur, window: Window
+    ) -> List[Tuple[Optional[str], str, int, float, str]]:
         # streams + digital revenue
         streams = {sid: float(plays)*STREAMS_PLAY_WEIGHT for sid, plays in self._map_streams(cur, window).items()}
         digital = {sid: float(cents)*REVENUE_CENTS_WEIGHT for sid, cents in self._map_digital(cur, window, "song").items()}
         keys = set(streams) | set(digital)
-        combined = []
+        combined: List[Tuple[Optional[str], str, int, float, str]] = []
         for k in keys:
-            combined.append(("song", int(k), float(streams.get(k,0.0)+digital.get(k,0.0)), "score(streams+digital)"))
-        combined.sort(key=lambda x: (-x[2], x[1]))
+            combined.append((None, "song", int(k), float(streams.get(k,0.0)+digital.get(k,0.0)), "score(streams+digital)"))
+        combined.sort(key=lambda x: (-x[3], x[2]))
         return combined[:100]
 
-    def _aggregate_combined_album(self, cur, window: Window) -> List[Tuple[str,int,float,str]]:
+    def _aggregate_combined_album(
+        self, cur, window: Window
+    ) -> List[Tuple[Optional[str], str, int, float, str]]:
         digital = {aid: float(cents)*REVENUE_CENTS_WEIGHT for aid, cents in self._map_digital(cur, window, "album").items()}
         vinyl = {aid: float(cents)*REVENUE_CENTS_WEIGHT for aid, cents in self._map_vinyl(cur, window).items()}
         keys = set(digital) | set(vinyl)
-        rows = []
+        rows: List[Tuple[Optional[str], str, int, float, str]] = []
         for k in keys:
-            rows.append(("album", int(k), float(digital.get(k,0.0)+vinyl.get(k,0.0)), "score(digital+vinyl)"))
-        rows.sort(key=lambda x: (-x[2], x[1]))
+            rows.append((None, "album", int(k), float(digital.get(k,0.0)+vinyl.get(k,0.0)), "score(digital+vinyl)"))
+        rows.sort(key=lambda x: (-x[3], x[2]))
         return rows[:100]
 
     # maps for combined

--- a/tests/test_jobs_charts_multi_country.py
+++ b/tests/test_jobs_charts_multi_country.py
@@ -1,0 +1,104 @@
+import sys
+import types
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+# Stub heavy dependencies before importing routes
+auth_deps = types.ModuleType("backend.auth.dependencies")
+auth_deps.get_current_user_id = lambda req=None: 1
+sys.modules["backend.auth.dependencies"] = auth_deps
+
+chart_service_stub = types.ModuleType("backend.services.chart_service")
+chart_service_stub.calculate_weekly_chart = lambda *a, **k: {}
+chart_service_stub.get_chart = lambda *a, **k: []
+sys.modules["backend.services.chart_service"] = chart_service_stub
+
+from backend import database
+from backend.services.jobs_charts import ChartsJobsService
+from backend.routes import chart_routes
+
+def _setup_db(tmp_path):
+    db = tmp_path / "charts.sqlite"
+    database.DB_PATH = str(db)
+    chart_routes.DB_PATH = str(db)
+    svc = ChartsJobsService(db_path=str(db))
+    with sqlite3.connect(db) as conn:
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE songs (id INTEGER PRIMARY KEY, band_id INTEGER, title TEXT)")
+        cur.execute(
+            """
+            CREATE TABLE streams (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                song_id INTEGER,
+                user_id INTEGER,
+                country_code TEXT,
+                created_at TEXT
+            )
+            """
+        )
+        conn.commit()
+    return db, svc
+
+
+def test_multi_country_stream_charts(tmp_path):
+    db, svc = _setup_db(tmp_path)
+    with sqlite3.connect(db) as conn:
+        cur = conn.cursor()
+        cur.executemany(
+            "INSERT INTO songs (id, band_id, title) VALUES (?, ?, ?)",
+            [(1, 1, "Song A"), (2, 1, "Song B")],
+        )
+        for _ in range(60):
+            cur.execute(
+                "INSERT INTO streams (song_id, user_id, country_code, created_at) VALUES (1, 1, 'US', '2024-01-01 00:00:00')"
+            )
+        for _ in range(5):
+            cur.execute(
+                "INSERT INTO streams (song_id, user_id, country_code, created_at) VALUES (1, 2, 'US', '2024-01-01 00:00:00')"
+            )
+        for _ in range(30):
+            cur.execute(
+                "INSERT INTO streams (song_id, user_id, country_code, created_at) VALUES (2, 3, 'US', '2024-01-01 00:00:00')"
+            )
+        for _ in range(10):
+            cur.execute(
+                "INSERT INTO streams (song_id, user_id, country_code, created_at) VALUES (1, 4, 'UK', '2024-01-01 00:00:00')"
+            )
+        for _ in range(40):
+            cur.execute(
+                "INSERT INTO streams (song_id, user_id, country_code, created_at) VALUES (2, 5, 'UK', '2024-01-01 00:00:00')"
+            )
+        conn.commit()
+    svc.run_daily("2024-01-01")
+    with sqlite3.connect(db) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT country_code, rank, work_id, metric_value
+            FROM chart_snapshots
+            WHERE chart_type='streams_song' AND period='daily'
+            ORDER BY country_code, rank
+            """
+        )
+        rows = cur.fetchall()
+    assert rows == [
+        ("UK", 1, 2, 40.0),
+        ("UK", 2, 1, 10.0),
+        ("US", 1, 1, 55.0),
+        ("US", 2, 2, 30.0),
+    ]
+
+    app = FastAPI()
+    app.include_router(chart_routes.router)
+    client = TestClient(app)
+    resp = client.get("/charts/US", params={"chart_type": "streams_song", "period": "daily"})
+    assert resp.status_code == 200
+    assert [r["work_id"] for r in resp.json()] == [1, 2]


### PR DESCRIPTION
## Summary
- extend chart_snapshots schema with country_code and related indexes
- group chart aggregations by country and expose /charts/{country} route
- test multi-country chart generation

## Testing
- `pytest tests/test_jobs_charts_multi_country.py::test_multi_country_stream_charts -q`
- `pytest -q` *(fails: IndentationError in backend/services/skill_service.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bea399ebec83258d7e705feb6aeb62