### PR TITLE
Add seasonal scoring with scheduler and admin controls

### DIFF
--- a/backend/migrations/sql/070_world_pulse.sql
+++ b/backend/migrations/sql/070_world_pulse.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS world_pulse_metrics (
   sales_digital  INTEGER NOT NULL DEFAULT 0,
   sales_vinyl    INTEGER NOT NULL DEFAULT 0,
   score          REAL    NOT NULL DEFAULT 0,
+  season         TEXT,
   PRIMARY KEY (date, artist_id)
 );
 CREATE INDEX IF NOT EXISTS idx_world_pulse_metrics_date ON world_pulse_metrics(date);
@@ -34,12 +35,13 @@ CREATE INDEX IF NOT EXISTS idx_world_pulse_metrics_artist ON world_pulse_metrics
 -- Daily rankings (toplist for a given date)
 CREATE TABLE IF NOT EXISTS world_pulse_rankings (
   date        TEXT    NOT NULL,
+  season      TEXT,
   rank        INTEGER NOT NULL,
   artist_id   INTEGER NOT NULL,
   name        TEXT    NOT NULL,
   pct_change  REAL,             -- vs previous day (fraction, e.g. 0.12 = +12%)
   score       REAL    NOT NULL,
-  PRIMARY KEY (date, rank)
+  PRIMARY KEY (date, season, rank)
 );
 CREATE INDEX IF NOT EXISTS idx_world_pulse_rankings_artist ON world_pulse_rankings(artist_id);
 

--- a/backend/routes/admin_season_routes.py
+++ b/backend/routes/admin_season_routes.py
@@ -1,0 +1,34 @@
+"""Admin endpoints for managing seasonal score multipliers."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.auth.dependencies import require_permission
+from backend.database import get_conn
+from backend.services.season_service import activate_season, deactivate_season
+
+router = APIRouter(
+    prefix="/season",
+    tags=["AdminSeason"],
+    dependencies=[Depends(require_permission(["admin"]))],
+)
+
+
+def _conn():
+    return get_conn()
+
+
+@router.post("/{season}/activate")
+def activate(season: str, conn=Depends(_conn)) -> dict:
+    if not activate_season(conn, season):
+        raise HTTPException(status_code=404, detail="season not found")
+    return {"status": "activated", "season": season}
+
+
+@router.post("/{season}/deactivate")
+def deactivate(season: str, conn=Depends(_conn)) -> dict:
+    if not deactivate_season(conn, season):
+        raise HTTPException(status_code=404, detail="season not found")
+    return {"status": "deactivated", "season": season}
+
+
+__all__ = ["router", "activate", "deactivate"]

--- a/backend/services/season_service.py
+++ b/backend/services/season_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, Optional, Tuple
+
+
+def _load_events(conn) -> Dict[str, Dict]:
+    """Load seasonal event configuration from app_config."""
+    row = conn.execute(
+        "SELECT value FROM app_config WHERE key='seasonal_events'"
+    ).fetchone()
+    if not row:
+        return {}
+    try:
+        return json.loads(row["value"])
+    except Exception:
+        return {}
+
+
+def _save_events(conn, events: Dict[str, Dict]) -> None:
+    conn.execute(
+        "INSERT OR REPLACE INTO app_config(key, value) VALUES('seasonal_events', ?)",
+        (json.dumps(events, ensure_ascii=False),),
+    )
+
+
+class SeasonScheduler:
+    """Simple loader to compute active seasonal score multipliers."""
+
+    def __init__(self, conn) -> None:
+        self.conn = conn
+        self.events = _load_events(conn)
+
+    def active_season(self, day: str) -> Tuple[Optional[str], float]:
+        """Return the active season and multiplier for ``day``."""
+        for name, cfg in self.events.items():
+            start = cfg.get("start")
+            end = cfg.get("end")
+            if not (start and end):
+                continue
+            if not cfg.get("active", False):
+                continue
+            if start <= day <= end:
+                return name, float(cfg.get("multiplier", 1.0))
+        return None, 1.0
+
+
+def activate_season(conn, season: str) -> bool:
+    events = _load_events(conn)
+    if season not in events:
+        return False
+    events[season]["active"] = True
+    _save_events(conn, events)
+    return True
+
+
+def deactivate_season(conn, season: str) -> bool:
+    events = _load_events(conn)
+    if season not in events:
+        return False
+    events[season]["active"] = False
+    _save_events(conn, events)
+    return True

--- a/backend/tests/analytics/test_seasonal_scores.py
+++ b/backend/tests/analytics/test_seasonal_scores.py
@@ -1,0 +1,92 @@
+import sqlite3
+
+import pytest
+
+from backend.jobs.world_pulse_jobs import run_daily
+from backend.services.season_service import activate_season
+
+DDL = """
+PRAGMA foreign_keys = ON;
+CREATE TABLE artists (
+  id   INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+CREATE TABLE music_events (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_time    TEXT NOT NULL,
+  artist_id     INTEGER NOT NULL,
+  streams       INTEGER NOT NULL DEFAULT 0,
+  sales_digital INTEGER NOT NULL DEFAULT 0,
+  sales_vinyl   INTEGER NOT NULL DEFAULT 0,
+  FOREIGN KEY(artist_id) REFERENCES artists(id)
+);
+CREATE TABLE app_config (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+INSERT OR IGNORE INTO app_config(key, value) VALUES
+('world_pulse_weights', '{"streams":1.0,"digital":10.0,"vinyl":15.0}');
+INSERT OR REPLACE INTO app_config(key, value) VALUES
+('seasonal_events', '{"SummerFest":{"start":"2025-08-24","end":"2025-08-26","multiplier":2.0,"active":false}}');
+CREATE TABLE job_metadata (
+  job_name   TEXT NOT NULL,
+  run_at     TEXT NOT NULL,
+  status     TEXT NOT NULL,
+  details    TEXT,
+  PRIMARY KEY (job_name, run_at)
+);
+CREATE TABLE world_pulse_metrics (
+  date           TEXT NOT NULL,
+  artist_id      INTEGER NOT NULL,
+  streams        INTEGER NOT NULL DEFAULT 0,
+  sales_digital  INTEGER NOT NULL DEFAULT 0,
+  sales_vinyl    INTEGER NOT NULL DEFAULT 0,
+  score          REAL    NOT NULL DEFAULT 0,
+  season         TEXT,
+  PRIMARY KEY (date, artist_id)
+);
+CREATE TABLE world_pulse_rankings (
+  date        TEXT    NOT NULL,
+  season      TEXT,
+  rank        INTEGER NOT NULL,
+  artist_id   INTEGER NOT NULL,
+  name        TEXT    NOT NULL,
+  pct_change  REAL,
+  score       REAL    NOT NULL,
+  PRIMARY KEY (date, season, rank)
+);
+"""
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(DDL)
+    yield conn
+    conn.close()
+
+
+def test_seasonal_multiplier_applied(conn):
+    conn.execute("INSERT INTO artists(id, name) VALUES(1, 'Neon Fox')")
+    conn.execute(
+        "INSERT INTO music_events(event_time, artist_id, streams, sales_digital, sales_vinyl) VALUES(?,?,?,?,?)",
+        ("2025-08-25T10:00:00", 1, 1000, 20, 5),
+    )
+    activate_season(conn, "SummerFest")
+    run_daily(target_date="2025-08-25", conn_override=conn)
+
+    metric = conn.execute(
+        "SELECT score, season FROM world_pulse_metrics WHERE date='2025-08-25' AND artist_id=1"
+    ).fetchone()
+    ranking = conn.execute(
+        "SELECT score, season FROM world_pulse_rankings WHERE date='2025-08-25'"
+    ).fetchone()
+
+    base = 1000 + 20 * 10 + 5 * 15
+    expected = base * 2.0
+    assert metric["season"] == "SummerFest"
+    assert pytest.approx(metric["score"], rel=1e-6) == expected
+    assert ranking["season"] == "SummerFest"
+    assert pytest.approx(ranking["score"], rel=1e-6) == expected

--- a/backend/tests/test_world_pulse_jobs.py
+++ b/backend/tests/test_world_pulse_jobs.py
@@ -50,17 +50,19 @@ CREATE TABLE world_pulse_metrics (
   sales_digital  INTEGER NOT NULL DEFAULT 0,
   sales_vinyl    INTEGER NOT NULL DEFAULT 0,
   score          REAL    NOT NULL DEFAULT 0,
+  season         TEXT,
   PRIMARY KEY (date, artist_id)
 );
 
 CREATE TABLE world_pulse_rankings (
   date        TEXT    NOT NULL,
+  season      TEXT,
   rank        INTEGER NOT NULL,
   artist_id   INTEGER NOT NULL,
   name        TEXT    NOT NULL,
   pct_change  REAL,
   score       REAL    NOT NULL,
-  PRIMARY KEY (date, rank)
+  PRIMARY KEY (date, season, rank)
 );
 
 CREATE TABLE world_pulse_weekly_cache (


### PR DESCRIPTION
## Summary
- track season and multiplier in world pulse metrics and rankings
- scheduler loads seasonal configs and applies score multipliers
- admin endpoints allow activating or deactivating seasons
- tests cover seasonal scoring logic

## Testing
- `pytest backend/tests/analytics/test_seasonal_scores.py backend/tests/test_world_pulse_jobs.py`
- `ruff check backend/jobs/world_pulse_jobs.py backend/services/season_service.py backend/routes/admin_season_routes.py backend/tests/analytics/test_seasonal_scores.py backend/tests/test_world_pulse_jobs.py`


------
https://chatgpt.com/codex/tasks/task_e_68bea5c947608325a3d5cd9c696c7b14