### PR TITLE
Return float song popularity score

### DIFF
--- a/backend/services/song_popularity_service.py
+++ b/backend/services/song_popularity_service.py
@@ -1,5 +1,4 @@
 import math
-import math
 import sqlite3
 from datetime import datetime
 from typing import Dict, List, Optional
@@ -142,7 +141,7 @@ class SongPopularityService:
                 "song_id": song_id,
                 "region_code": region_code,
                 "platform": platform,
-                "score": int(new_score),
+                "score": new_score,
             }
 
     def list_events(


### PR DESCRIPTION
## Summary
- return raw float score in SongPopularityService.add_event
- clean up duplicate imports

## Testing
- `ruff check backend/services/song_popularity_service.py`
- `pytest` *(fails: 91 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68beb7899d6c8325840e83fc4f8f9181