### PR TITLE
Refactor sales startup

### DIFF
--- a/backend/routes/sales.py
+++ b/backend/routes/sales.py
@@ -14,13 +14,18 @@ except Exception:  # pragma: no cover
 
         return _noop
 
-import asyncio
 from services.sales_service import SalesError, SalesService
 
 router = APIRouter(prefix="/sales", tags=["Sales"])
 
 svc = SalesService()
-asyncio.run(svc.ensure_schema())
+
+
+async def startup() -> None:
+    await svc.ensure_schema()
+
+
+router.add_event_handler("startup", startup)
 
 
 class DigitalSaleIn(BaseModel):


### PR DESCRIPTION
## Summary
- initialize sales service schema during FastAPI startup instead of module import

## Testing
- `ruff check backend/routes/sales.py`
- `pytest -q` *(fails: ImportError in multiple test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bec254cdec8325aefb7e46e8d22c16