### PR TITLE
refactor: deprecate sync db helpers

### DIFF
--- a/backend/db/README.md
+++ b/backend/db/README.md
@@ -4,6 +4,12 @@ This package contains lightweight SQL migrations for the SQLite database
 used by Rockmundo.  Migrations are stored in the `migrations/` directory
 and executed in filename order by `apply_migrations`.
 
+## Deprecation notice
+
+The synchronous database helpers located in ``backend/utils/db.py`` (such as
+``get_conn`` and ``cached_query``) are deprecated.  New development should use
+the asynchronous interfaces instead.
+
 ## New schema additions
 
 - **Lifestyle:** Added `appearance_score`, `exercise_minutes`, and


### PR DESCRIPTION
## Summary
- replace direct `asyncio.run` usages with a loop-aware `_run` helper
- mark synchronous DB helpers as deprecated and document async preference

## Testing
- `ruff check backend/utils/db.py`
- `pytest -q` *(fails: ImportError: cannot import name 'BookIn' from 'backend.routes.admin_book_routes')*


------
https://chatgpt.com/codex/tasks/task_e_68bec25e58d88325be348607b7cdc64e