### PR TITLE
Make live album compilation async

### DIFF
--- a/backend/routes/live_album_routes.py
+++ b/backend/routes/live_album_routes.py
@@ -18,9 +18,9 @@ class TrackUpdateRequest(BaseModel):
 
 
 @router.post("/live_albums/compile")
-def compile_live_album(payload: CompileRequest):
+async def compile_live_album(payload: CompileRequest):
     try:
-        return service.compile_live_album(payload.show_ids, payload.album_title)
+        return await service.compile_live_album(payload.show_ids, payload.album_title)
     except ValueError as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=400, detail=str(exc))
 

--- a/backend/services/live_album_service.py
+++ b/backend/services/live_album_service.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import sqlite3
 from datetime import datetime
@@ -25,7 +24,7 @@ class LiveAlbumService:
         self._albums: Dict[int, Dict] = {}
         self._next_id = 1
 
-    def compile_live_album(self, performance_ids: List[int], title: str) -> Dict:
+    async def compile_live_album(self, performance_ids: List[int], title: str) -> Dict:
         if len(performance_ids) != 5:
             raise ValueError("Exactly five performance IDs are required")
         conn = sqlite3.connect(self.db_path)
@@ -128,9 +127,7 @@ class LiveAlbumService:
 
         themes = list(cities | venues)
         try:
-            cover_url = asyncio.run(
-                ai_art_service.generate_album_art(title, themes)
-            )
+            cover_url = await ai_art_service.generate_album_art(title, themes)
         except Exception:
             cover_url = None
 

--- a/backend/tests/live_album/test_live_album_service.py
+++ b/backend/tests/live_album/test_live_album_service.py
@@ -19,7 +19,8 @@ def _insert_performance(cur, band_id, setlist, skill_gain, city="", venue=""):
     )
 
 
-def test_compile_live_album(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_compile_live_album(tmp_path, monkeypatch):
     db_file = tmp_path / "perf.db"
     conn = sqlite3.connect(db_file)
     cur = conn.cursor()
@@ -81,7 +82,7 @@ def test_compile_live_album(tmp_path, monkeypatch):
     monkeypatch.setattr(audio_mixing_service, "mix_tracks", fake_mix)
 
     service = LiveAlbumService(str(db_file))
-    album = service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
+    album = await service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
 
     assert album["album_type"] == "live"
     assert [s["song_id"] for s in album["songs"]] == [1, 2]
@@ -96,7 +97,8 @@ def test_compile_live_album(tmp_path, monkeypatch):
     assert album["cover_art"]
 
 
-def test_publish_album_records_show_data(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_publish_album_records_show_data(tmp_path, monkeypatch):
     db_file = tmp_path / "perf.db"
     conn = sqlite3.connect(db_file)
     cur = conn.cursor()
@@ -156,7 +158,7 @@ def test_publish_album_records_show_data(tmp_path, monkeypatch):
     )
 
     service = LiveAlbumService(str(db_file))
-    album = service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
+    album = await service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
     release_id = service.publish_album(album["id"])
 
     conn = sqlite3.connect(db_file)
@@ -172,7 +174,8 @@ def test_publish_album_records_show_data(tmp_path, monkeypatch):
     assert all(row[1] == 5 for row in rows)
     assert all(row[2] == 80 for row in rows)
 
-def test_update_tracks_validation(tmp_path):
+@pytest.mark.asyncio
+async def test_update_tracks_validation(tmp_path):
     db_file = tmp_path / "perf.db"
     conn = sqlite3.connect(db_file)
     cur = conn.cursor()
@@ -234,7 +237,7 @@ def test_update_tracks_validation(tmp_path):
     conn.close()
 
     service = LiveAlbumService(str(db_file))
-    album = service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
+    album = await service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
     album_id = album["id"]
 
     # Reorder tracks
@@ -250,7 +253,8 @@ def test_update_tracks_validation(tmp_path):
     assert updated["song_ids"] == [1]
 
 
-def test_compile_live_album_missing_recordings(tmp_path):
+@pytest.mark.asyncio
+async def test_compile_live_album_missing_recordings(tmp_path):
     db_file = tmp_path / "perf.db"
     conn = sqlite3.connect(db_file)
     cur = conn.cursor()
@@ -305,7 +309,7 @@ def test_compile_live_album_missing_recordings(tmp_path):
 
     service = LiveAlbumService(str(db_file))
     with pytest.raises(ValueError) as exc:
-        service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
+        await service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
     assert "4" in str(exc.value)
     assert "2" in str(exc.value)
 

--- a/tests/live_album/test_audio_mixing.py
+++ b/tests/live_album/test_audio_mixing.py
@@ -22,7 +22,8 @@ def _insert_performance(cur, band_id, setlist, skill_gain, city="", venue=""):
     )
 
 
-def test_mixing_invoked_and_tracks_stored(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_mixing_invoked_and_tracks_stored(tmp_path, monkeypatch):
     db_file = tmp_path / "perf.db"
     conn = sqlite3.connect(db_file)
     cur = conn.cursor()
@@ -84,14 +85,15 @@ def test_mixing_invoked_and_tracks_stored(tmp_path, monkeypatch):
     monkeypatch.setattr(audio_mixing_service, "mix_tracks", fake_mix)
 
     service = LiveAlbumService(str(db_file))
-    album = service.compile_live_album([1, 2, 3, 4, 5], "Live")
+    album = await service.compile_live_album([1, 2, 3, 4, 5], "Live")
 
     assert called["ids"] == [5, 5]
     assert [t["track_id"] for t in album["tracks"]] == [505, 505]
     assert all("performance_id" not in t for t in album["tracks"])
 
 
-def test_missing_recording_raises_error(tmp_path):
+@pytest.mark.asyncio
+async def test_missing_recording_raises_error(tmp_path):
     db_file = tmp_path / "perf.db"
     conn = sqlite3.connect(db_file)
     cur = conn.cursor()
@@ -146,7 +148,7 @@ def test_missing_recording_raises_error(tmp_path):
 
     service = LiveAlbumService(str(db_file))
     with pytest.raises(ValueError) as exc:
-        service.compile_live_album([1, 2, 3, 4, 5], "Live")
+        await service.compile_live_album([1, 2, 3, 4, 5], "Live")
     assert "5" in str(exc.value)
     assert "2" in str(exc.value)
 


### PR DESCRIPTION
## Summary
- convert live album compilation to async and await album art generation
- await LiveAlbumService.compile_live_album in API and tests

## Testing
- `pytest tests/live_album/test_audio_mixing.py backend/tests/live_album/test_live_album_service.py -q` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bec25c0acc83259d80380b2cab686b