### PR TITLE
feat: make live album publish async

### DIFF
--- a/backend/routes/live_album_routes.py
+++ b/backend/routes/live_album_routes.py
@@ -34,9 +34,9 @@ def update_live_album_tracks(album_id: int, payload: TrackUpdateRequest):
 
 
 @router.post("/live_albums/{album_id}/publish")
-def publish_live_album(album_id: int):
+async def publish_live_album(album_id: int):
     try:
-        new_id = service.publish_album(album_id)
+        new_id = await service.publish_album(album_id)
         return {"album_id": new_id}
     except ValueError as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=404, detail=str(exc))

--- a/backend/services/live_album_service.py
+++ b/backend/services/live_album_service.py
@@ -7,10 +7,9 @@ from typing import Dict, List
 from models.album import Album
 
 from backend.database import DB_PATH
-from backend.services import audio_mixing_service
+from backend.services import audio_mixing_service, chart_service
 from backend.services.ai_art_service import ai_art_service
 from backend.services.sales_service import SalesService
-from backend.services import chart_service
 
 
 class LiveAlbumService:
@@ -207,7 +206,7 @@ class LiveAlbumService:
         return album
 
     # ------------------------------------------------------------------
-    def publish_album(self, album_id: int) -> int:
+    async def publish_album(self, album_id: int) -> int:
         """Persist a drafted live album and register it for sales and charts.
 
         Parameters
@@ -300,15 +299,13 @@ class LiveAlbumService:
         # auxiliary for this service.
         try:
             sales = SalesService(self.db_path)
-            asyncio.run(sales.ensure_schema())
-            asyncio.run(
-                sales.record_digital_sale(
-                    buyer_user_id=0,
-                    work_type="album",
-                    work_id=release_id,
-                    price_cents=0,
-                    album_type=album["album_type"],
-                )
+            await sales.ensure_schema()
+            await sales.record_digital_sale(
+                buyer_user_id=0,
+                work_type="album",
+                work_id=release_id,
+                price_cents=0,
+                album_type=album["album_type"],
             )
         except Exception:
             pass

--- a/backend/tests/live_album/test_live_album_service.py
+++ b/backend/tests/live_album/test_live_album_service.py
@@ -159,7 +159,7 @@ async def test_publish_album_records_show_data(tmp_path, monkeypatch):
 
     service = LiveAlbumService(str(db_file))
     album = await service.compile_live_album([1, 2, 3, 4, 5], "Best Live")
-    release_id = service.publish_album(album["id"])
+    release_id = await service.publish_album(album["id"])
 
     conn = sqlite3.connect(db_file)
     cur = conn.cursor()


### PR DESCRIPTION
## Summary
- make `publish_album` asynchronous and await sales integration
- update live album route to await publishing
- fix tests to await new async API

## Testing
- `ruff check backend/services/live_album_service.py backend/routes/live_album_routes.py backend/tests/live_album/test_live_album_service.py`
- `pytest` *(fails: missing dependencies during collection)*
- `pytest backend/tests/live_album/test_live_album_service.py` *(fails: async tests unsupported, missing pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68beccc38fac8325912c904e44fe88d5