### PR TITLE
Improve chat history tracking and group membership

### DIFF
--- a/backend/routes/chat_routes.py
+++ b/backend/routes/chat_routes.py
@@ -1,12 +1,13 @@
-from schemas.chat_schemas import GroupMessageSchema, MessageSchema
+from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
+from schemas.chat_schemas import GroupMembershipSchema, GroupMessageSchema, MessageSchema
 
 from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from backend.services.chat_service import (
+    add_user_to_group,
     get_user_chat_history,
     send_group_chat,
     send_message,
 )
-from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 
 router = APIRouter()
 
@@ -22,6 +23,12 @@ def send_direct_message(payload: MessageSchema):
 @router.post("/chat/send_group")
 def send_group_message(payload: GroupMessageSchema):
     return send_group_chat(payload.dict())
+
+
+@router.post("/chat/join_group")
+def join_group(payload: GroupMembershipSchema):
+    add_user_to_group(payload.group_id, payload.user_id)
+    return {"status": "group_joined"}
 
 
 @router.get("/chat/history/")

--- a/backend/schemas/chat_schemas.py
+++ b/backend/schemas/chat_schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+
 class MessageSchema(BaseModel):
     sender_id: int
     recipient_id: int
@@ -9,3 +10,8 @@ class GroupMessageSchema(BaseModel):
     sender_id: int
     group_id: str
     content: str
+
+
+class GroupMembershipSchema(BaseModel):
+    user_id: int
+    group_id: str

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -1,7 +1,17 @@
 from datetime import datetime
 
+# TODO: Replace in-memory stores with persistent storage to avoid data loss on
+# restart.
 chat_store = {}
 group_chat_store = {}
+group_members = {}
+
+
+def add_user_to_group(group_id, user_id):
+    if group_id not in group_members:
+        group_members[group_id] = set()
+    group_members[group_id].add(user_id)
+
 
 def send_message(data):
     sender = data["sender_id"]
@@ -10,29 +20,37 @@ def send_message(data):
         "sender_id": sender,
         "recipient_id": recipient,
         "content": data["content"],
-        "timestamp": str(datetime.utcnow())
+        "timestamp": str(datetime.utcnow()),
     }
     if recipient not in chat_store:
         chat_store[recipient] = []
+    if sender not in chat_store:
+        chat_store[sender] = []
     chat_store[recipient].append(message)
+    chat_store[sender].append(message)
     return {"status": "message_sent", "message": message}
+
 
 def send_group_chat(data):
     group_id = data["group_id"]
+    add_user_to_group(group_id, data["sender_id"])
     if group_id not in group_chat_store:
         group_chat_store[group_id] = []
-    group_chat_store[group_id].append({
-        "sender_id": data["sender_id"],
-        "content": data["content"],
-        "timestamp": str(datetime.utcnow())
-    })
+    group_chat_store[group_id].append(
+        {
+            "sender_id": data["sender_id"],
+            "content": data["content"],
+            "timestamp": str(datetime.utcnow()),
+        }
+    )
     return {"status": "group_message_sent"}
 
+
 def get_user_chat_history(user_id):
+    user_groups = [
+        group_id for group_id, members in group_members.items() if user_id in members
+    ]
     return {
         "direct_messages": chat_store.get(user_id, []),
-        "group_chats": {
-            group_id: msgs for group_id, msgs in group_chat_store.items()
-            if any(msg["sender_id"] == user_id for msg in msgs)
-        }
+        "group_chats": {group_id: group_chat_store.get(group_id, []) for group_id in user_groups},
     }


### PR DESCRIPTION
## Summary
- Track direct messages for both participants
- Maintain group membership and expose join endpoint
- Note TODO for persisting chat stores

## Testing
- `ruff check backend/services/chat_service.py backend/routes/chat_routes.py backend/schemas/chat_schemas.py`
- `pytest` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68becddcb7648325860e85442bdee8fc