### PR TITLE
Refactor payment service to require explicit gateway injection

### DIFF
--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -6,8 +6,9 @@ import os
 
 import httpx
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Type
+from typing import Dict, Optional
 from uuid import uuid4
+from abc import ABC, abstractmethod
 
 from backend.models.payment import PremiumCurrency, PurchaseRecord, SubscriptionPlan
 from backend.services.economy_service import EconomyService
@@ -18,17 +19,20 @@ class PaymentError(Exception):
 
 
 @dataclass
-class PaymentGateway:
-    """Minimal gateway interface used for testing.
+class PaymentGateway(ABC):
+    """Abstract payment gateway definition.
 
-    Real implementations would integrate with providers like Stripe or PayPal.
+    Concrete subclasses integrate with providers like Stripe or PayPal and
+    must implement the methods below.
     """
 
-    def create_payment(self, amount_cents: int, currency: str) -> str:  # pragma: no cover - interface
-        raise NotImplementedError
+    @abstractmethod
+    def create_payment(self, amount_cents: int, currency: str) -> str:
+        """Create a remote payment and return its provider identifier."""
 
-    def verify_payment(self, payment_id: str) -> bool:  # pragma: no cover - interface
-        raise NotImplementedError
+    @abstractmethod
+    def verify_payment(self, payment_id: str) -> bool:
+        """Return ``True`` if the payment succeeded on the provider side."""
 
 
 @dataclass
@@ -108,20 +112,12 @@ class StripeAPIGateway(PaymentGateway):
 class PaymentService:
     """Main entry point for handling payment operations."""
 
-    # registry of available gateways for simple configuration
-    gateway_registry: Dict[str, Type[PaymentGateway]] = {
-        "stripe": StripeGateway,
-        "paypal": PayPalGateway,
-        "stripe_api": StripeAPIGateway,
-    }
-
-    def __init__(self, gateway: Optional[PaymentGateway], economy_service: EconomyService,
-                 premium_currency: Optional[PremiumCurrency] = None, gateway_name: str = "stripe"):
-        if gateway is None:
-            gateway_cls = self.gateway_registry.get(gateway_name.lower())
-            if not gateway_cls:
-                raise ValueError(f"Unsupported gateway: {gateway_name}")
-            gateway = gateway_cls()
+    def __init__(
+        self,
+        gateway: PaymentGateway,
+        economy_service: EconomyService,
+        premium_currency: Optional[PremiumCurrency] = None,
+    ) -> None:
         self.gateway = gateway
         self.economy_service = economy_service
         self.premium_currency = premium_currency or PremiumCurrency(

--- a/backend/tests/payment/test_stripe_api_gateway.py
+++ b/backend/tests/payment/test_stripe_api_gateway.py
@@ -7,7 +7,11 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from backend.services.economy_service import EconomyService
-from backend.services.payment_service import PaymentError, PaymentService
+from backend.services.payment_service import (
+    PaymentError,
+    PaymentService,
+    StripeAPIGateway,
+)
 
 
 def setup_service(monkeypatch, tmp_path, success: bool):
@@ -42,7 +46,8 @@ def setup_service(monkeypatch, tmp_path, success: bool):
     monkeypatch.setattr(httpx, "post", fake_post)
     monkeypatch.setattr(httpx, "get", fake_get)
 
-    svc = PaymentService(None, econ, gateway_name="stripe_api")
+    gateway = StripeAPIGateway()
+    svc = PaymentService(gateway, econ)
     return svc, econ
 
 

--- a/backend/tests/routes/test_payment_routes.py
+++ b/backend/tests/routes/test_payment_routes.py
@@ -1,23 +1,25 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from routes import payment_routes
-from services.economy_service import EconomyService
-from services.payment_service import PaymentService
+from backend.services.economy_service import EconomyService
+from backend.services.payment_service import PaymentService
 
 
-def create_app(tmp_path):
+def create_app(tmp_path, succeed: bool = True):
     db = tmp_path / "test.db"
     economy = EconomyService(str(db))
     economy.ensure_schema()
+    gateway = payment_routes.MockGateway(succeed=succeed)
+    payment_routes._gateway = gateway
     payment_routes._economy = economy
-    payment_routes.svc = PaymentService(payment_routes._gateway, economy)
+    payment_routes.svc = PaymentService(gateway, economy)
     app = FastAPI()
     app.include_router(payment_routes.router)
-    return app, economy
+    return app, economy, gateway
 
 
 def test_purchase_and_callback(tmp_path):
-    app, economy = create_app(tmp_path)
+    app, economy, _ = create_app(tmp_path, succeed=True)
     client = TestClient(app)
     r = client.post("/payment/purchase", json={"user_id": 1, "amount_cents": 500})
     assert r.status_code == 200
@@ -26,3 +28,14 @@ def test_purchase_and_callback(tmp_path):
     assert r.status_code == 200
     assert r.json()["status"] == "completed"
     assert economy.get_balance(1) > 0
+
+
+def test_purchase_failure(tmp_path):
+    app, economy, _ = create_app(tmp_path, succeed=False)
+    client = TestClient(app)
+    r = client.post("/payment/purchase", json={"user_id": 1, "amount_cents": 500})
+    assert r.status_code == 200
+    pid = r.json()["payment_id"]
+    r = client.post("/payment/callback", json={"payment_id": pid})
+    assert r.status_code == 400
+    assert economy.get_balance(1) == 0


### PR DESCRIPTION
## Summary
- make PaymentGateway an abstract base class
- require PaymentService callers to pass a concrete gateway
- add tests covering successful and failed payment callbacks

## Testing
- `pytest backend/tests/payment/test_payment_service.py backend/tests/payment/test_stripe_api_gateway.py backend/tests/routes/test_payment_routes.py backend/tests/routes/test_merch_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68bed728a1648325a4d25b22fd70e73b