### PR TITLE
feat: improve payment gateway abstraction

### DIFF
--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 
 import httpx
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Type
 from uuid import uuid4
@@ -18,17 +19,19 @@ class PaymentError(Exception):
 
 
 @dataclass
-class PaymentGateway:
+class PaymentGateway(ABC):
     """Minimal gateway interface used for testing.
 
     Real implementations would integrate with providers like Stripe or PayPal.
     """
 
-    def create_payment(self, amount_cents: int, currency: str) -> str:  # pragma: no cover - interface
-        raise NotImplementedError
+    @abstractmethod
+    def create_payment(self, amount_cents: int, currency: str) -> str:
+        """Create a payment request and return its provider identifier."""
 
-    def verify_payment(self, payment_id: str) -> bool:  # pragma: no cover - interface
-        raise NotImplementedError
+    @abstractmethod
+    def verify_payment(self, payment_id: str) -> bool:
+        """Return ``True`` if the payment completed successfully."""
 
 
 @dataclass
@@ -80,10 +83,14 @@ class StripeAPIGateway(PaymentGateway):
     """
 
     base_url: str = "https://api.stripe.com/v1"
-    api_key: str = field(default_factory=lambda: os.environ["STRIPE_API_KEY"])
+    api_key: str = field(default_factory=lambda: os.getenv("STRIPE_API_KEY", ""))
     webhook_secret: Optional[str] = field(
-        default_factory=lambda: os.environ.get("STRIPE_WEBHOOK_SECRET")
+        default_factory=lambda: os.getenv("STRIPE_WEBHOOK_SECRET")
     )
+
+    def __post_init__(self) -> None:
+        if not self.api_key:
+            raise PaymentError("Stripe API key not configured")
 
     def create_payment(self, amount_cents: int, currency: str) -> str:
         data = {
@@ -91,17 +98,26 @@ class StripeAPIGateway(PaymentGateway):
             "currency": currency,
             "payment_method_types[]": "card",
         }
-        resp = httpx.post(
-            f"{self.base_url}/payment_intents", data=data, auth=(self.api_key, "")
-        )
-        resp.raise_for_status()
-        return resp.json()["id"]
+        try:
+            resp = httpx.post(
+                f"{self.base_url}/payment_intents", data=data, auth=(self.api_key, "")
+            )
+            resp.raise_for_status()
+        except Exception as exc:  # pragma: no cover - network errors
+            raise PaymentError(f"Stripe create_payment failed: {exc}") from exc
+        try:
+            return resp.json()["id"]
+        except KeyError as exc:
+            raise PaymentError("Stripe response missing id") from exc
 
     def verify_payment(self, payment_id: str) -> bool:
-        resp = httpx.get(
-            f"{self.base_url}/payment_intents/{payment_id}", auth=(self.api_key, "")
-        )
-        resp.raise_for_status()
+        try:
+            resp = httpx.get(
+                f"{self.base_url}/payment_intents/{payment_id}", auth=(self.api_key, "")
+            )
+            resp.raise_for_status()
+        except Exception as exc:  # pragma: no cover - network errors
+            raise PaymentError(f"Stripe verify_payment failed: {exc}") from exc
         return resp.json().get("status") == "succeeded"
 
 

--- a/backend/tests/payment/test_payment_service.py
+++ b/backend/tests/payment/test_payment_service.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 from pathlib import Path
 
+import httpx
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
@@ -12,6 +13,7 @@ from backend.services.payment_service import (
     PaymentError,
     PaymentService,
     PayPalGateway,
+    StripeAPIGateway,
     StripeGateway,
 )
 
@@ -41,3 +43,41 @@ def test_purchase_failure(gateway_cls):
     with pytest.raises(PaymentError):
         svc.verify_callback(pid)
     assert svc.economy_service.get_balance(1) == 0
+
+
+def setup_stripe_service(monkeypatch, post_resp: httpx.Response, get_resp: httpx.Response):
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    econ = EconomyService(db_path=path)
+    econ.ensure_schema()
+    monkeypatch.setenv("STRIPE_API_KEY", "test")
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: post_resp)
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: get_resp)
+    gateway = StripeAPIGateway()
+    svc = PaymentService(gateway, econ)
+    return svc
+
+
+def test_stripe_api_success(monkeypatch):
+    post_resp = httpx.Response(200, json={"id": "pi_test"}, request=httpx.Request("POST", "http://test"))
+    get_resp = httpx.Response(200, json={"status": "succeeded"}, request=httpx.Request("GET", "http://test"))
+    svc = setup_stripe_service(monkeypatch, post_resp, get_resp)
+    pid = svc.initiate_purchase(user_id=1, amount_cents=500)
+    svc.verify_callback(pid)
+    assert svc.economy_service.get_balance(1) == 500
+
+
+def test_stripe_api_failure(monkeypatch):
+    post_resp = httpx.Response(200, json={"id": "pi_test"}, request=httpx.Request("POST", "http://test"))
+    get_resp = httpx.Response(200, json={"status": "requires_payment_method"}, request=httpx.Request("GET", "http://test"))
+    svc = setup_stripe_service(monkeypatch, post_resp, get_resp)
+    pid = svc.initiate_purchase(user_id=1, amount_cents=500)
+    with pytest.raises(PaymentError):
+        svc.verify_callback(pid)
+    assert svc.economy_service.get_balance(1) == 0
+
+
+def test_stripe_api_missing_key(monkeypatch):
+    monkeypatch.delenv("STRIPE_API_KEY", raising=False)
+    with pytest.raises(PaymentError):
+        StripeAPIGateway()


### PR DESCRIPTION
## Summary
- make PaymentGateway an abstract base class
- add robust Stripe API gateway with error handling
- expand payment tests for Stripe API success and failure

## Testing
- `pytest backend/tests/payment/test_payment_service.py -q`
- `pytest backend/tests/routes/test_payment_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bed8e1adc08325919810a616b01a13