### PR TITLE
Persist chat messages in SQLite

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -592,6 +592,39 @@ def init_db():
             """
         )
 
+        # Chat tables
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS direct_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                sender_id INTEGER NOT NULL,
+                recipient_id INTEGER NOT NULL,
+                content TEXT NOT NULL,
+                timestamp TEXT NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS group_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                group_id TEXT NOT NULL,
+                sender_id INTEGER NOT NULL,
+                content TEXT NOT NULL,
+                timestamp TEXT NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS group_members (
+                group_id TEXT NOT NULL,
+                user_id INTEGER NOT NULL,
+                PRIMARY KEY (group_id, user_id)
+            )
+            """
+        )
+
         # Support tickets allow players to file issues and admins to resolve them
         cur.execute(
             """

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -1,56 +1,127 @@
+import sqlite3
 from datetime import datetime
 
-# TODO: Replace in-memory stores with persistent storage to avoid data loss on
-# restart.
-chat_store = {}
-group_chat_store = {}
-group_members = {}
+from backend.database import DB_PATH
 
 
-def add_user_to_group(group_id, user_id):
-    if group_id not in group_members:
-        group_members[group_id] = set()
-    group_members[group_id].add(user_id)
+def _ensure_tables() -> None:
+    """Create chat tables if they do not yet exist."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS direct_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                sender_id INTEGER NOT NULL,
+                recipient_id INTEGER NOT NULL,
+                content TEXT NOT NULL,
+                timestamp TEXT NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS group_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                group_id TEXT NOT NULL,
+                sender_id INTEGER NOT NULL,
+                content TEXT NOT NULL,
+                timestamp TEXT NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS group_members (
+                group_id TEXT NOT NULL,
+                user_id INTEGER NOT NULL,
+                PRIMARY KEY (group_id, user_id)
+            )
+            """
+        )
+        conn.commit()
 
 
-def send_message(data):
+def add_user_to_group(group_id: str, user_id: int) -> None:
+    _ensure_tables()
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO group_members (group_id, user_id) VALUES (?, ?)",
+            (group_id, user_id),
+        )
+        conn.commit()
+
+
+def remove_user_from_group(group_id: str, user_id: int) -> None:
+    _ensure_tables()
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "DELETE FROM group_members WHERE group_id=? AND user_id=?",
+            (group_id, user_id),
+        )
+        conn.commit()
+
+
+def send_message(data: dict) -> dict:
+    _ensure_tables()
     sender = data["sender_id"]
     recipient = data["recipient_id"]
+    timestamp = str(datetime.utcnow())
     message = {
         "sender_id": sender,
         "recipient_id": recipient,
         "content": data["content"],
-        "timestamp": str(datetime.utcnow()),
+        "timestamp": timestamp,
     }
-    if recipient not in chat_store:
-        chat_store[recipient] = []
-    if sender not in chat_store:
-        chat_store[sender] = []
-    chat_store[recipient].append(message)
-    chat_store[sender].append(message)
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO direct_messages (sender_id, recipient_id, content, timestamp)"
+            " VALUES (?, ?, ?, ?)",
+            (sender, recipient, data["content"], timestamp),
+        )
+        conn.commit()
     return {"status": "message_sent", "message": message}
 
 
-def send_group_chat(data):
+def send_group_chat(data: dict) -> dict:
+    _ensure_tables()
     group_id = data["group_id"]
     add_user_to_group(group_id, data["sender_id"])
-    if group_id not in group_chat_store:
-        group_chat_store[group_id] = []
-    group_chat_store[group_id].append(
-        {
-            "sender_id": data["sender_id"],
-            "content": data["content"],
-            "timestamp": str(datetime.utcnow()),
-        }
-    )
+    timestamp = str(datetime.utcnow())
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO group_messages (group_id, sender_id, content, timestamp)"
+            " VALUES (?, ?, ?, ?)",
+            (group_id, data["sender_id"], data["content"], timestamp),
+        )
+        conn.commit()
     return {"status": "group_message_sent"}
 
 
-def get_user_chat_history(user_id):
-    user_groups = [
-        group_id for group_id, members in group_members.items() if user_id in members
-    ]
-    return {
-        "direct_messages": chat_store.get(user_id, []),
-        "group_chats": {group_id: group_chat_store.get(group_id, []) for group_id in user_groups},
-    }
+def get_user_chat_history(user_id: int) -> dict:
+    _ensure_tables()
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute(
+            "SELECT sender_id, recipient_id, content, timestamp FROM direct_messages"
+            " WHERE sender_id=? OR recipient_id=? ORDER BY id",
+            (user_id, user_id),
+        )
+        direct_messages = [dict(row) for row in cur.fetchall()]
+
+        cur = conn.execute(
+            "SELECT group_id FROM group_members WHERE user_id=?",
+            (user_id,),
+        )
+        group_ids = [row["group_id"] for row in cur.fetchall()]
+        group_chats = {}
+        for gid in group_ids:
+            cur = conn.execute(
+                "SELECT sender_id, content, timestamp FROM group_messages"
+                " WHERE group_id=? ORDER BY id",
+                (gid,),
+            )
+            group_chats[gid] = [dict(row) for row in cur.fetchall()]
+
+    return {"direct_messages": direct_messages, "group_chats": group_chats}
+

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -1,0 +1,35 @@
+import sqlite3
+
+from backend.services import chat_service
+
+
+def _setup_db(tmp_path, monkeypatch):
+    db = tmp_path / "chat.db"
+    monkeypatch.setattr(chat_service, "DB_PATH", str(db))
+    # ensure a clean database
+    sqlite3.connect(chat_service.DB_PATH).close()
+
+
+def test_direct_messages_persist(tmp_path, monkeypatch):
+    _setup_db(tmp_path, monkeypatch)
+    msg = {"sender_id": 1, "recipient_id": 2, "content": "hi"}
+    chat_service.send_message(msg)
+
+    history1 = chat_service.get_user_chat_history(1)
+    history2 = chat_service.get_user_chat_history(2)
+
+    assert history1["direct_messages"] == history2["direct_messages"]
+    assert history1["direct_messages"][0]["content"] == "hi"
+
+
+def test_group_messages_persist(tmp_path, monkeypatch):
+    _setup_db(tmp_path, monkeypatch)
+
+    chat_service.send_group_chat({"group_id": "band", "sender_id": 1, "content": "hello"})
+    chat_service.add_user_to_group("band", 2)
+
+    history = chat_service.get_user_chat_history(2)
+
+    assert "band" in history["group_chats"]
+    assert history["group_chats"]["band"][0]["content"] == "hello"
+


### PR DESCRIPTION
## Summary
- store direct and group messages in SQLite tables
- add database-backed helpers for messages and group membership
- test that both direct and group chats persist for all participants

## Testing
- `ruff check backend/services/chat_service.py tests/test_chat_service.py backend/database.py`
- `python -m pytest tests/test_chat_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bedac42f148325ba69b59bb15ca4c7