### PR TITLE
feat: add layout with theme context

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ThemeProvider, useTheme } from '../context/ThemeContext';
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded border border-gray-300"
+      aria-label="toggle theme"
+    >
+      {theme === 'light' ? 'Dark' : 'Light'} Mode
+    </button>
+  );
+};
+
+const Navigation: React.FC = () => (
+  <nav className="bg-[var(--bg-color)] border-t md:border-t-0 md:border-r border-gray-200">
+    <ul className="flex justify-around md:flex-col md:justify-start p-4 gap-4">
+      <li><a href="#" className="hover:text-[var(--accent-color)]">Home</a></li>
+      <li><a href="#" className="hover:text-[var(--accent-color)]">About</a></li>
+    </ul>
+  </nav>
+);
+
+const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider>
+    <div className="min-h-screen grid grid-rows-[auto_1fr] bg-[var(--bg-color)] text-[var(--text-color)]">
+      <header className="flex items-center justify-between p-4 border-b border-gray-200">
+        <h1 className="text-xl font-bold">Rockmundo</h1>
+        <ThemeToggle />
+      </header>
+      <div className="grid grid-cols-1 md:grid-cols-[200px_1fr] lg:grid-cols-[250px_1fr] flex-1">
+        <Navigation />
+        <main className="p-4">{children}</main>
+      </div>
+    </div>
+  </ThemeProvider>
+);
+
+export default Layout;
+

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() =>
+    (localStorage.getItem('theme') as Theme) || 'light'
+  );
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,20 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --accent-color: #ff4081;
+}
+
+[data-theme='dark'] {
+  --bg-color: #1a1a1a;
+  --text-color: #e0e0e0;
+  --accent-color: #ff79c6;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}

--- a/frontend/tests/Layout.test.tsx
+++ b/frontend/tests/Layout.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Layout from '../src/components/Layout';
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
+});
+
+test('toggles theme and persists choice', () => {
+  render(
+    <Layout>
+      <div>content</div>
+    </Layout>
+  );
+
+  const button = screen.getByRole('button', { name: /toggle theme/i });
+  expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  expect(localStorage.getItem('theme')).toBe('light');
+
+  button.click();
+
+  expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  expect(localStorage.getItem('theme')).toBe('dark');
+});


### PR DESCRIPTION
## Summary
- add responsive layout with header, navigation and theme toggle
- implement theme context with localStorage persistence and CSS variables
- document light/dark theme variables in Tailwind index
- test layout theme toggling behavior

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bedd413f2883258be8caac7fed5f8d