### PR TITLE
Integrate Tailwind CSS into frontend build

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -1,3 +1,5 @@
+@import './styles/tailwind.css';
+
 :root {
   --bg-color: #ffffff;
   --text-color: #000000;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,8 @@
     "@testing-library/jest-dom": "^6.0.0",
     "vitest": "^1.6.0",
     "@vitejs/plugin-react": "^4.2.0",
-    "jsdom": "^23.0.1"
+    "jsdom": "^23.0.1",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,4 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./pages/**/*.{html,js,jsx}', './src/**/*.{js,jsx,ts,tsx}'],
+};


### PR DESCRIPTION
## Summary
- add Tailwind config pointing at pages and src files
- import Tailwind layers and link into root stylesheet
- configure PostCSS and dependencies for Tailwind processing

## Testing
- `npm --prefix frontend test` *(fails: sh: 1: vitest: not found)*
- `npm --prefix frontend run build` *(fails: sh: 1: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bedd3f99a08325ab74e1941118e137