### PR TITLE
Add viewport meta tags to frontend pages

### DIFF
--- a/frontend/pages/album_form.html
+++ b/frontend/pages/album_form.html
@@ -1,4 +1,11 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Album Form</title>
+</head>
+<body>
 <h2>Create Release</h2>
 <form id="albumForm">
   <input type="text" name="title" placeholder="Title" required />
@@ -153,3 +160,5 @@
     }
   });
 </script>
+</body>
+</html>

--- a/frontend/pages/arrangement_form.html
+++ b/frontend/pages/arrangement_form.html
@@ -1,3 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Arrangement Form</title>
+</head>
+<body>
 <h2>Plan Arrangement</h2>
 <form id="arrangementForm">
   <input type="number" name="song_id" placeholder="Song ID" required />
@@ -19,3 +27,5 @@
     e.target.reset();
   });
 </script>
+</body>
+</html>

--- a/frontend/pages/chart_page.html
+++ b/frontend/pages/chart_page.html
@@ -1,4 +1,11 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Chart Page</title>
+</head>
+<body>
 <h2>Global Top 100 Chart</h2>
 
 <div>
@@ -23,3 +30,5 @@ async function loadChart() {
   });
 }
 </script>
+</body>
+</html>

--- a/frontend/pages/chat.html
+++ b/frontend/pages/chat.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Chat</title>
   <style>
     body {

--- a/frontend/pages/cover_licensing.html
+++ b/frontend/pages/cover_licensing.html
@@ -1,3 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Cover Licensing</title>
+</head>
+<body>
 <h2>Cover Licensing</h2>
 <table id="royalties">
   <thead>
@@ -39,3 +47,5 @@
     loadRoyalties();
   });
 </script>
+</body>
+</html>

--- a/frontend/pages/cover_marketplace.html
+++ b/frontend/pages/cover_marketplace.html
@@ -1,3 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Cover Marketplace</title>
+</head>
+<body>
 <h2>Cover Marketplace</h2>
 <div id="catalog"></div>
 
@@ -29,3 +37,5 @@
 
   loadCatalog();
 </script>
+</body>
+</html>

--- a/frontend/pages/fame_dashboard.html
+++ b/frontend/pages/fame_dashboard.html
@@ -1,4 +1,11 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fame Dashboard</title>
+</head>
+<body>
 <h2>Fame Dashboard</h2>
 
 <div>
@@ -28,3 +35,5 @@ async function loadFame() {
   });
 }
 </script>
+</body>
+</html>

--- a/frontend/pages/gig_simulator.html
+++ b/frontend/pages/gig_simulator.html
@@ -1,3 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Gig Simulator</title>
+</head>
+<body>
 <h2>Live Gig Simulator</h2>
 
 <form id="gigForm">
@@ -101,4 +109,5 @@ document.getElementById('gigForm').addEventListener('submit', async (e) => {
 
 renderSetlist();
 </script>
-
+</body>
+</html>

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>RockMundo Daily</title>
     <link rel="stylesheet" href="../index.css">
 </head>

--- a/frontend/pages/indie_release_form.html
+++ b/frontend/pages/indie_release_form.html
@@ -1,3 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Indie Release Form</title>
+</head>
+<body>
 <h2>Indie Release Purchase</h2>
 <form id="indieReleaseForm">
   <input type="number" name="band_id" placeholder="Band ID" required />
@@ -19,3 +27,5 @@
   <input type="number" name="vendor_fee_cents" placeholder="Vendor Fee (cents)" />
   <button type="submit">Purchase Release</button>
 </form>
+</body>
+</html>

--- a/frontend/pages/karma_dashboard.html
+++ b/frontend/pages/karma_dashboard.html
@@ -1,4 +1,11 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Karma Dashboard</title>
+</head>
+<body>
 <h2>Karma Dashboard</h2>
 
 <div>
@@ -26,3 +33,5 @@ async function loadKarma() {
   });
 }
 </script>
+</body>
+</html>

--- a/frontend/pages/login.html
+++ b/frontend/pages/login.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title data-i18n="login.title">Login</title>
 </head>
 <body>

--- a/frontend/pages/media_mentions.html
+++ b/frontend/pages/media_mentions.html
@@ -1,3 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Media Mentions</title>
+</head>
+<body>
 <h2>Media Mentions Monitor</h2>
 <button onclick="pollFeed()">Poll Media Feed</button>
 <ul id="mentions"></ul>
@@ -52,3 +60,5 @@ async function sendAdjust() {
 }
 loadMentions();
 </script>
+</body>
+</html>

--- a/frontend/pages/music_library.html
+++ b/frontend/pages/music_library.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Music Library</title>
   <link rel="stylesheet" href="../index.css" />
 </head>

--- a/frontend/pages/npc_band_admin.html
+++ b/frontend/pages/npc_band_admin.html
@@ -1,4 +1,11 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Npc Band Admin</title>
+</head>
+<body>
 <h2>NPC Band Admin</h2>
 
 <button onclick="createBand()">Create NPC Band</button>
@@ -24,3 +31,5 @@ function log(message) {
   document.getElementById('log').appendChild(li);
 }
 </script>
+</body>
+</html>

--- a/frontend/pages/playlist_manager.html
+++ b/frontend/pages/playlist_manager.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Playlist Manager</title>
   <link rel="stylesheet" href="../index.css" />
 </head>

--- a/frontend/pages/playlist_view.html
+++ b/frontend/pages/playlist_view.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>View Playlist</title>
   <link rel="stylesheet" href="../index.css" />
 </head>

--- a/frontend/pages/popularity_dashboard.html
+++ b/frontend/pages/popularity_dashboard.html
@@ -1,3 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Popularity Dashboard</title>
+</head>
+<body>
 <h2>Song Popularity Dashboard</h2>
 
 <div>
@@ -101,4 +109,5 @@ function renderTrendChart(popularityHistory, sentimentHistory) {
   });
 }
 </script>
-
+</body>
+</html>

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Profile</title>
   <link rel="stylesheet" href="../index.css" />
 </head>

--- a/frontend/pages/recording_session_form.html
+++ b/frontend/pages/recording_session_form.html
@@ -1,3 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Recording Session Form</title>
+</head>
+<body>
 <h2>Book Recording Session</h2>
 <form id="bookingForm">
   <input type="text" name="studio" placeholder="Studio" required />
@@ -15,3 +23,5 @@
   <input type="text" name="status" placeholder="Status" required />
   <button type="submit">Update Status</button>
 </form>
+</body>
+</html>

--- a/frontend/pages/revenue_dashboard.html
+++ b/frontend/pages/revenue_dashboard.html
@@ -1,4 +1,11 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Revenue Dashboard</title>
+</head>
+<body>
 <h2>Revenue Dashboard</h2>
 
 <div>
@@ -18,3 +25,5 @@ async function fetchRevenue() {
   container.innerHTML = "<pre>" + JSON.stringify(data, null, 2) + "</pre>";
 }
 </script>
+</body>
+</html>

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Schedule Planner</title>
   <link rel="stylesheet" href="../index.css" />
   <style>

--- a/frontend/pages/schedule_mobile.html
+++ b/frontend/pages/schedule_mobile.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Mobile Schedule Planner</title>
   <link rel="stylesheet" href="../index.css" />
   <link rel="stylesheet" href="../styles/schedule.css" />

--- a/frontend/pages/setlist_review.html
+++ b/frontend/pages/setlist_review.html
@@ -1,3 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Setlist Review</title>
+</head>
+<body>
 <h2>Setlist Review</h2>
 
 <input type="number" id="performanceId" placeholder="Performance ID" />
@@ -39,4 +47,5 @@ document.getElementById('loadBtn').onclick = async () => {
   }
 };
 </script>
-
+</body>
+</html>

--- a/frontend/pages/song_collab.html
+++ b/frontend/pages/song_collab.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Song Collaboration</title>
   <script>
     async function loadVersions(draftId) {

--- a/frontend/pages/song_form.html
+++ b/frontend/pages/song_form.html
@@ -1,4 +1,11 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Song Form</title>
+</head>
+<body>
 <h2>Create Song</h2>
 <div id="skillInfo">
   Songwriting Level: <span id="skillLevel">1</span>
@@ -226,3 +233,5 @@
     }
   });
 </script>
+</body>
+</html>

--- a/frontend/pages/tour_collab.html
+++ b/frontend/pages/tour_collab.html
@@ -1,3 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tour Collab</title>
+</head>
+<body>
 <h2>Tour Collaboration Planner</h2>
 <form id="collabForm">
   <label>Band IDs (comma separated):</label>
@@ -72,3 +80,5 @@ document.getElementById('collabForm').addEventListener('submit', async (e) => {
   document.getElementById('result').innerText = JSON.stringify(data, null, 2);
 });
 </script>
+</body>
+</html>

--- a/frontend/pages/tour_planner.html
+++ b/frontend/pages/tour_planner.html
@@ -1,4 +1,11 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tour Planner</title>
+</head>
+<body>
 <h2>Tour Planner</h2>
 
 <link
@@ -137,3 +144,5 @@ document.getElementById('tourForm').addEventListener('submit', async (e) => {
   });
 });
 </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ensure all pages under `frontend/pages` include responsive viewport metadata
- wrap snippet pages in basic HTML structure for consistency

## Testing
- `pytest`
- `npm test` (fails: sh: 1: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bedd2b45008325a8ff02cbf5e8a9d4