### PR TITLE
feat(frontend): add color tokens and dark theme overrides

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,3 +29,21 @@ python -m http.server --directory pages
 ```
 
 When the backend is running, these files are also served under the `/frontend` path.
+
+## Design Tokens
+
+The frontend uses CSS variables as color tokens. Define new colors in `index.css` and `src/index.css` and consume them via `var(--token-name)` or the Tailwind color names configured in `tailwind.config.js`.
+
+| Token | Purpose |
+|-------|---------|
+| `--bg-color` | Page background |
+| `--text-color` | Default text color |
+| `--accent-color` | Primary accent for interactive elements |
+| `--border-color` | Subtle borders and separators |
+| `--surface-color` | Panels and surfaces |
+| `--muted-text` | Secondary text |
+| `--success-color` | Positive/confirmation backgrounds |
+| `--error-color` | Error/destructive backgrounds |
+| `--inverse-text-color` | Text used on colored surfaces |
+
+Dark theme overrides live under `[data-theme="dark"]`.

--- a/frontend/components/NotificationCenter.jsx
+++ b/frontend/components/NotificationCenter.jsx
@@ -60,7 +60,7 @@ function NotificationCenter() {
       open &&
         React.createElement(
           'ul',
-          { key: 'list', style: { position: 'absolute', background: '#fff', border: '1px solid #ccc', padding: '4px', listStyle: 'none' } },
+          { key: 'list', style: { position: 'absolute', background: 'var(--surface-color)', border: '1px solid var(--border-color)', padding: '4px', listStyle: 'none' } },
           notifications.map((n) =>
             React.createElement(
               'li',

--- a/frontend/components/globalSearch.js
+++ b/frontend/components/globalSearch.js
@@ -12,11 +12,11 @@
       style.id='global-search-styles';
       style.textContent=`
         .global-search-wrapper{position:relative;margin-left:1rem;}
-        .global-search-results{position:absolute;top:100%;left:0;right:0;background:#fff;border:1px solid #ccc;z-index:1000;font-size:14px;max-height:300px;overflow-y:auto;}
+        .global-search-results{position:absolute;top:100%;left:0;right:0;background:var(--surface-color);border:1px solid var(--border-color);z-index:1000;font-size:14px;max-height:300px;overflow-y:auto;}
         .global-search-results ul{list-style:none;margin:0;padding:0;}
         .global-search-results li{padding:4px 8px;}
-        .global-search-results li.active{background:#eee;}
-        .global-search-results .group-title{font-weight:bold;padding:4px 8px;border-top:1px solid #ddd;background:#f9f9f9;}
+        .global-search-results li.active{background:var(--border-color);}
+        .global-search-results .group-title{font-weight:bold;padding:4px 8px;border-top:1px solid var(--border-color);background:var(--surface-color);}
         .global-search-results .group-title:first-child{border-top:none;}
       `;
       document.head.appendChild(style);

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -4,6 +4,12 @@
   --bg-color: #ffffff;
   --text-color: #000000;
   --accent-color: #ff4081;
+  --border-color: #cccccc;
+  --surface-color: #f0f0f0;
+  --muted-text: #666666;
+  --success-color: #4caf50;
+  --error-color: #f44336;
+  --inverse-text-color: #ffffff;
 }
 
 body {
@@ -15,6 +21,12 @@ body {
   --bg-color: #1a1a1a;
   --text-color: #e0e0e0;
   --accent-color: #ff79c6;
+  --border-color: #333333;
+  --surface-color: #2a2a2a;
+  --muted-text: #aaaaaa;
+  --success-color: #388e3c;
+  --error-color: #d32f2f;
+  --inverse-text-color: #000000;
 }
 
 header {
@@ -54,16 +66,16 @@ header .hamburger {
   top: 20px;
   right: 20px;
   padding: 10px 15px;
-  color: #fff;
+  color: var(--inverse-text-color);
   border-radius: 4px;
   z-index: 1000;
   font-family: sans-serif;
 }
 
 .notification.success {
-  background: #4caf50;
+  background: var(--success-color);
 }
 
 .notification.error {
-  background: #f44336;
+  background: var(--error-color);
 }

--- a/frontend/pages/chat.html
+++ b/frontend/pages/chat.html
@@ -13,7 +13,7 @@
     }
     #conversation-list {
       width: 30%;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--border-color);
       overflow-y: auto;
     }
     #message-panel {
@@ -29,7 +29,7 @@
     #input-area {
       display: flex;
       padding: 10px;
-      border-top: 1px solid #ccc;
+      border-top: 1px solid var(--border-color);
     }
     #message-input {
       flex: 1;
@@ -37,11 +37,11 @@
     }
     .conversation {
       padding: 10px;
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid var(--border-color);
       cursor: pointer;
     }
     .conversation:hover {
-      background: #f0f0f0;
+      background: var(--surface-color);
     }
     .msg {
       margin: 5px 0;

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -32,8 +32,8 @@
     <tbody></tbody>
   </table>
   <style>
-    #chemistry-table .chem-high { background-color: #c8e6c9; }
-    #chemistry-table .chem-low { background-color: #ffcdd2; }
+    #chemistry-table .chem-high { background-color: var(--success-color); }
+    #chemistry-table .chem-low { background-color: var(--error-color); }
   </style>
   <script src="../components/themeToggle.js"></script>
   <script src="../components/globalSearch.js"></script>

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -10,7 +10,7 @@
     .tab-content { display: none; }
     .tab-content.active { display: block; }
     #plannerGrid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 2px; }
-    #plannerGrid .slot { border: 1px solid #ccc; height: 40px; }
+    #plannerGrid .slot { border: 1px solid var(--border-color); height: 40px; }
   </style>
 </head>
 <body>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,12 +6,24 @@
   --bg-color: #ffffff;
   --text-color: #000000;
   --accent-color: #ff4081;
+  --border-color: #cccccc;
+  --surface-color: #f0f0f0;
+  --muted-text: #666666;
+  --success-color: #4caf50;
+  --error-color: #f44336;
+  --inverse-text-color: #ffffff;
 }
 
 [data-theme='dark'] {
   --bg-color: #1a1a1a;
   --text-color: #e0e0e0;
   --accent-color: #ff79c6;
+  --border-color: #333333;
+  --surface-color: #2a2a2a;
+  --muted-text: #aaaaaa;
+  --success-color: #388e3c;
+  --error-color: #d32f2f;
+  --inverse-text-color: #000000;
 }
 
 body {

--- a/frontend/src/tour/Planner.tsx
+++ b/frontend/src/tour/Planner.tsx
@@ -146,7 +146,7 @@ export const Planner: React.FC = () => {
             }
           }}
           onDragOver={(e) => e.preventDefault()}
-          style={{ border: '1px solid #ccc', padding: '2px', minHeight: '20px' }}
+          style={{ border: '1px solid var(--border-color)', padding: '2px', minHeight: '20px' }}
         >
           {content}
         </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,19 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./pages/**/*.{html,js,jsx}', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'var(--bg-color)',
+        text: 'var(--text-color)',
+        accent: 'var(--accent-color)',
+        border: 'var(--border-color)',
+        surface: 'var(--surface-color)',
+        muted: 'var(--muted-text)',
+        success: 'var(--success-color)',
+        error: 'var(--error-color)',
+        inverseText: 'var(--inverse-text-color)',
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
- introduce expanded color token palette with dark-mode support
- switch existing pages and components to use CSS variables
- expose tokens via Tailwind config and document usage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68bee27548548325b6dce733649310d7