### PR TITLE
Refactor global search styling for theme support

### DIFF
--- a/frontend/components/globalSearch.js
+++ b/frontend/components/globalSearch.js
@@ -7,20 +7,7 @@
 
   function initGlobalSearch(container){
     if(!container) return;
-    if(!document.getElementById('global-search-styles')){
-      const style=document.createElement('style');
-      style.id='global-search-styles';
-      style.textContent=`
-        .global-search-wrapper{position:relative;margin-left:1rem;}
-        .global-search-results{position:absolute;top:100%;left:0;right:0;background:#fff;border:1px solid #ccc;z-index:1000;font-size:14px;max-height:300px;overflow-y:auto;}
-        .global-search-results ul{list-style:none;margin:0;padding:0;}
-        .global-search-results li{padding:4px 8px;}
-        .global-search-results li.active{background:#eee;}
-        .global-search-results .group-title{font-weight:bold;padding:4px 8px;border-top:1px solid #ddd;background:#f9f9f9;}
-        .global-search-results .group-title:first-child{border-top:none;}
-      `;
-      document.head.appendChild(style);
-    }
+    // Styles are now handled in CSS via globalSearch.css
 
     const wrapper=document.createElement('div');
     wrapper.className='global-search-wrapper';

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -1,9 +1,13 @@
 @import './styles/tailwind.css';
+@import './styles/globalSearch.css';
 
 :root {
   --bg-color: #ffffff;
   --text-color: #000000;
   --accent-color: #ff4081;
+  --surface-color: #ffffff;
+  --surface-hover-color: #f0f0f0;
+  --border-color: #cccccc;
 }
 
 body {
@@ -15,6 +19,9 @@ body {
   --bg-color: #1a1a1a;
   --text-color: #e0e0e0;
   --accent-color: #ff79c6;
+  --surface-color: #2b2b2b;
+  --surface-hover-color: #3a3a3a;
+  --border-color: #555555;
 }
 
 header {

--- a/frontend/styles/globalSearch.css
+++ b/frontend/styles/globalSearch.css
@@ -1,0 +1,7 @@
+.global-search-wrapper{position:relative;margin-left:1rem;}
+.global-search-results{position:absolute;top:100%;left:0;right:0;background:var(--surface-color);border:1px solid var(--border-color);z-index:1000;font-size:14px;max-height:300px;overflow-y:auto;}
+.global-search-results ul{list-style:none;margin:0;padding:0;}
+.global-search-results li{padding:4px 8px;}
+.global-search-results li.active{background:var(--surface-hover-color);}
+.global-search-results .group-title{font-weight:bold;padding:4px 8px;border-top:1px solid var(--border-color);background:var(--surface-hover-color);}
+.global-search-results .group-title:first-child{border-top:none;}


### PR DESCRIPTION
## Summary
- externalize global search styles into build-managed CSS
- define surface and border color variables for light and dark themes
- remove runtime style injection from global search script

## Testing
- ⚠️ `npm test` *(vitest: not found)*
- ⚠️ `npm install` *(403 Forbidden for @testing-library/jest-dom)*
- ✅ `python - <<'PY' ...` (contrast ratios for light and dark surfaces)


------
https://chatgpt.com/codex/tasks/task_e_68bee27a4b9c832594cfd081deef51a0