### PR TITLE
Add accessible icon-based theme toggle

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { ThemeProvider } from '../context/ThemeContext';
+import ThemeToggle from './ThemeToggle';
 
 declare global {
   interface Window {
@@ -17,13 +19,16 @@ const Header: React.FC = () => {
   }, []);
 
   return (
-    <header>
-      <button className="hamburger" onClick={() => setOpen((o) => !o)}>☰</button>
-      <nav ref={navRef} className={open ? 'open' : ''}>
-        <a href="index.html">Home</a>
-        <a href="profile.html">Profile</a>
-      </nav>
-    </header>
+    <ThemeProvider>
+      <header>
+        <button className="hamburger" onClick={() => setOpen((o) => !o)}>☰</button>
+        <nav ref={navRef} className={open ? 'open' : ''}>
+          <a href="index.html">Home</a>
+          <a href="profile.html">Profile</a>
+          <ThemeToggle />
+        </nav>
+      </header>
+    </ThemeProvider>
   );
 };
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,18 +1,6 @@
 import React from 'react';
-import { ThemeProvider, useTheme } from '../context/ThemeContext';
-
-const ThemeToggle: React.FC = () => {
-  const { theme, toggleTheme } = useTheme();
-  return (
-    <button
-      onClick={toggleTheme}
-      className="p-2 rounded border border-gray-300"
-      aria-label="toggle theme"
-    >
-      {theme === 'light' ? 'Dark' : 'Light'} Mode
-    </button>
-  );
-};
+import { ThemeProvider } from '../context/ThemeContext';
+import ThemeToggle from './ThemeToggle';
 
 const Navigation: React.FC = () => (
   <nav className="bg-[var(--bg-color)] border-t md:border-t-0 md:border-r border-gray-200">

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useTheme } from '../context/ThemeContext';
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-pressed={isDark}
+      className="p-2 rounded text-[var(--text-color)] hover:bg-[var(--accent-color)] hover:text-[var(--bg-color)] focus:bg-[var(--accent-color)] focus:text-[var(--bg-color)] focus:outline-none"
+    >
+      <span className="sr-only">Toggle dark mode</span>
+      <span aria-hidden="true">{isDark ? '🌙' : '☀️'}</span>
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/tests/Layout.test.tsx
+++ b/frontend/tests/Layout.test.tsx
@@ -14,12 +14,14 @@ test('toggles theme and persists choice', () => {
     </Layout>
   );
 
-  const button = screen.getByRole('button', { name: /toggle theme/i });
+  const button = screen.getByRole('button', { name: /toggle dark mode/i });
+  expect(button).toHaveAttribute('aria-pressed', 'false');
   expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   expect(localStorage.getItem('theme')).toBe('light');
 
   button.click();
 
+  expect(button).toHaveAttribute('aria-pressed', 'true');
   expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
   expect(localStorage.getItem('theme')).toBe('dark');
 });


### PR DESCRIPTION
## Summary
- replace text theme toggle with icon button using aria-pressed
- add screen-reader text and theme-aware hover/focus styling
- include theme toggle in header navigation and update test

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee27ea40c832582af80e6009aa8c5