### PR TITLE
Switch mail service to async DB helper

### DIFF
--- a/backend/routes/mail_routes.py
+++ b/backend/routes/mail_routes.py
@@ -24,20 +24,17 @@ class MailSendIn(BaseModel):
 @router.post("/")
 async def send_mail(payload: MailSendIn, user_id: int = Depends(get_current_user_id)):
     """Send a mail message from the authenticated user."""
-
-    return send_message(user_id, payload.recipient_id, payload.subject, payload.body)
+    return await send_message(user_id, payload.recipient_id, payload.subject, payload.body)
 
 
 @router.get("/")
 async def list_mail(user_id: int = Depends(get_current_user_id)):
     """Return the inbox for the authenticated user."""
-
-    return get_inbox(user_id)
+    return await get_inbox(user_id)
 
 
 @router.delete("/{message_id}")
 async def delete_mail(message_id: int, user_id: int = Depends(get_current_user_id)):
     """Delete a mail message owned by the authenticated user."""
-
-    return delete_message(message_id, user_id)
+    return await delete_message(message_id, user_id)
 

--- a/backend/services/mailbox_service.py
+++ b/backend/services/mailbox_service.py
@@ -1,62 +1,89 @@
-import sqlite3
 from datetime import datetime
-from backend.database import DB_PATH
+from typing import Dict, List
 
-def send_message(sender_id: int, receiver_id: int, subject: str, body: str) -> dict:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute("""
-        INSERT INTO messages (sender_id, receiver_id, subject, body, sent_at, read, deleted)
-        VALUES (?, ?, ?, ?, ?, 0, 0)
-    """, (sender_id, receiver_id, subject, body, datetime.utcnow().isoformat()))
-    message_id = cur.lastrowid
-    conn.commit()
-    conn.close()
+from backend.database import DB_PATH
+from utils.db import aget_conn
+
+
+async def send_message(
+    sender_id: int, receiver_id: int, subject: str, body: str
+) -> Dict[str, int | str]:
+    async with aget_conn(DB_PATH) as conn:
+        cur = await conn.execute(
+            """
+            INSERT INTO messages (sender_id, receiver_id, subject, body, sent_at, read, deleted)
+            VALUES (?, ?, ?, ?, ?, 0, 0)
+            """,
+            (sender_id, receiver_id, subject, body, datetime.utcnow().isoformat()),
+        )
+        message_id = cur.lastrowid
     return {"status": "ok", "message_id": message_id}
 
-def get_inbox(user_id: int) -> list:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute("""
-        SELECT id, sender_id, subject, body, sent_at, read
-        FROM messages
-        WHERE receiver_id = ? AND deleted = 0
-        ORDER BY sent_at DESC
-    """, (user_id,))
-    rows = cur.fetchall()
-    conn.close()
-    return [dict(zip(["message_id", "sender_id", "subject", "body", "sent_at", "read"], row)) for row in rows]
 
-def get_sent(user_id: int) -> list:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute("""
-        SELECT id, receiver_id, subject, body, sent_at
-        FROM messages
-        WHERE sender_id = ? AND deleted = 0
-        ORDER BY sent_at DESC
-    """, (user_id,))
-    rows = cur.fetchall()
-    conn.close()
-    return [dict(zip(["message_id", "receiver_id", "subject", "body", "sent_at"], row)) for row in rows]
+async def get_inbox(user_id: int) -> List[Dict[str, object]]:
+    async with aget_conn(DB_PATH) as conn:
+        cur = await conn.execute(
+            """
+            SELECT id, sender_id, subject, body, sent_at, read
+            FROM messages
+            WHERE receiver_id = ? AND deleted = 0
+            ORDER BY sent_at DESC
+            """,
+            (user_id,),
+        )
+        rows = await cur.fetchall()
+    return [
+        {
+            "message_id": row[0],
+            "sender_id": row[1],
+            "subject": row[2],
+            "body": row[3],
+            "sent_at": row[4],
+            "read": row[5],
+        }
+        for row in rows
+    ]
 
-def mark_as_read(message_id: int) -> dict:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute("UPDATE messages SET read = 1 WHERE id = ?", (message_id,))
-    conn.commit()
-    conn.close()
+
+async def get_sent(user_id: int) -> List[Dict[str, object]]:
+    async with aget_conn(DB_PATH) as conn:
+        cur = await conn.execute(
+            """
+            SELECT id, receiver_id, subject, body, sent_at
+            FROM messages
+            WHERE sender_id = ? AND deleted = 0
+            ORDER BY sent_at DESC
+            """,
+            (user_id,),
+        )
+        rows = await cur.fetchall()
+    return [
+        {
+            "message_id": row[0],
+            "receiver_id": row[1],
+            "subject": row[2],
+            "body": row[3],
+            "sent_at": row[4],
+        }
+        for row in rows
+    ]
+
+
+async def mark_as_read(message_id: int) -> Dict[str, str]:
+    async with aget_conn(DB_PATH) as conn:
+        await conn.execute("UPDATE messages SET read = 1 WHERE id = ?", (message_id,))
     return {"status": "ok", "message": "Message marked as read"}
 
-def delete_message(message_id: int, user_id: int) -> dict:
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    # Soft delete: only allow sender or receiver to delete
-    cur.execute("""
-        UPDATE messages
-        SET deleted = 1
-        WHERE id = ? AND (sender_id = ? OR receiver_id = ?)
-    """, (message_id, user_id, user_id))
-    conn.commit()
-    conn.close()
+
+async def delete_message(message_id: int, user_id: int) -> Dict[str, str]:
+    async with aget_conn(DB_PATH) as conn:
+        await conn.execute(
+            """
+            UPDATE messages
+            SET deleted = 1
+            WHERE id = ? AND (sender_id = ? OR receiver_id = ?)
+            """,
+            (message_id, user_id, user_id),
+        )
     return {"status": "ok", "message": "Message deleted"}
+

--- a/backend/tests/test_mail_smoke.py
+++ b/backend/tests/test_mail_smoke.py
@@ -1,6 +1,6 @@
 # File: backend/tests/test_mail_smoke.py
-import sqlite3, os, tempfile
-from utils.db import get_conn
+import pytest
+from utils.db import aget_conn
 from services.mail_service import MailService
 from services.notifications_service import NotificationsService
 
@@ -37,13 +37,15 @@ CREATE TABLE IF NOT EXISTS notifications (
 CREATE INDEX IF NOT EXISTS ix_nm ON notifications(user_id, created_at);
 """
 
-def setup_db(path):
-    with get_conn(path) as conn:
-        conn.executescript(MAIL_DDL)
+async def setup_db(path: str) -> None:
+    async with aget_conn(path) as conn:
+        await conn.executescript(MAIL_DDL)
 
-def test_compose_and_unread_badge(tmp_path):
+
+@pytest.mark.asyncio
+async def test_compose_and_unread_badge(tmp_path):
     db = str(tmp_path / "test_mail.db")
-    setup_db(db)
+    await setup_db(db)
     notif = NotificationsService(db_path=db)
     mail = MailService(db_path=db, notifications=notif)
 

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,23 +1,11 @@
-import sqlite3
-from contextlib import contextmanager
-from pathlib import Path
+"""Convenience re-exports for database helpers.
 
-DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+This module exposes the synchronous and asynchronous connection
+helpers from :mod:`backend.utils.db`.  The synchronous ``get_conn``
+wrapper uses the underlying asynchronous driver but remains available
+for legacy callers.  New code should prefer :func:`aget_conn`.
+"""
 
-@contextmanager
-def get_conn(db_path: str | None = None):
-    conn = sqlite3.connect(db_path or DB_PATH)
-    conn.row_factory = sqlite3.Row
-    try:
-        yield conn
-        conn.commit()
-    finally:
-        conn.close()
-
-# Re-export asynchronous connection helper used in tests and services.
-try:  # pragma: no cover - simple re-export wrapper
-    from backend.utils.db import aget_conn  # type: ignore
-except Exception:  # pragma: no cover
-    aget_conn = None  # type: ignore
+from backend.utils.db import aget_conn, get_conn
 
 __all__ = ["get_conn", "aget_conn"]


### PR DESCRIPTION
## Summary
- re-export async db helpers and drop direct sqlite3 dependency
- convert mailbox service to async database operations
- update mail routes and tests to await async db helpers

## Testing
- `ruff check .`
- `mypy .`
- `pytest backend/tests/test_mail_smoke.py::test_compose_and_unread_badge -q` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bee4c744b083259b5a693e8cb08f08