### PR TITLE
Persist chat history in SQLite and update tests

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -1,14 +1,6 @@
 import sqlite3
 from datetime import datetime
 
-
-# TODO: Replace in-memory stores with persistent storage to avoid data loss on
-# restart.
-chat_store: dict[int, list] = {}
-group_chat_store: dict[int, list] = {}
-group_members: dict[int, set[int]] = {}
-# Registry to track which groups a user belongs to
-user_groups: dict[int, set[int]] = {}
 from backend.database import DB_PATH
 
 
@@ -50,10 +42,6 @@ def _ensure_tables() -> None:
         )
         conn.commit()
 
-    if user_id not in user_groups:
-        user_groups[user_id] = set()
-    user_groups[user_id].add(group_id)
-
 
 def add_user_to_group(group_id: str, user_id: int) -> None:
     _ensure_tables()
@@ -87,9 +75,6 @@ def send_message(data: dict) -> dict:
         "timestamp": timestamp,
     }
 
-    chat_store.setdefault(recipient, []).append(message)
-    chat_store.setdefault(sender, []).append(message)
-
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute(
             "INSERT INTO direct_messages (sender_id, recipient_id, content, timestamp)"
@@ -114,15 +99,6 @@ def send_group_chat(data: dict) -> dict:
         )
         conn.commit()
     return {"status": "group_message_sent"}
-
-
-
-def get_user_chat_history(user_id):
-    groups = user_groups.get(user_id, set())
-    return {
-        "direct_messages": chat_store.get(user_id, []),
-        "group_chats": {gid: group_chat_store.get(gid, []) for gid in groups},
-    }
 
 def get_user_chat_history(user_id: int) -> dict:
     _ensure_tables()

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -1,5 +1,8 @@
 import sys
+import sqlite3
 from pathlib import Path
+
+import pytest
 
 root_dir = Path(__file__).resolve().parents[1]
 sys.path.append(str(root_dir))
@@ -7,44 +10,14 @@ sys.path.append(str(root_dir))
 from backend.services import chat_service  # noqa: E402
 
 
-def setup_function() -> None:  # type: ignore[override]
-    chat_service.chat_store.clear()
-    chat_service.group_chat_store.clear()
-    chat_service.group_members.clear()
-    chat_service.user_groups.clear()
-
-
-def test_sender_sees_message() -> None:
-    chat_service.send_message(
-        {"sender_id": 1, "recipient_id": 2, "content": "hello"}
-    )
-    history_sender = chat_service.get_user_chat_history(1)
-    history_recipient = chat_service.get_user_chat_history(2)
-
-    assert history_sender["direct_messages"][0]["content"] == "hello"
-    assert history_recipient["direct_messages"][0]["content"] == "hello"
-
-
-def test_group_history_available_after_join() -> None:
-    chat_service.add_user_to_group(100, 3)
-    history = chat_service.get_user_chat_history(3)
-
-    assert 100 in history["group_chats"]
-    assert history["group_chats"][100] == []
-import sqlite3
-
-from backend.services import chat_service
-
-
-def _setup_db(tmp_path, monkeypatch):
+@pytest.fixture(autouse=True)
+def setup_db(tmp_path, monkeypatch):
     db = tmp_path / "chat.db"
     monkeypatch.setattr(chat_service, "DB_PATH", str(db))
-    # ensure a clean database
     sqlite3.connect(chat_service.DB_PATH).close()
 
 
-def test_direct_messages_persist(tmp_path, monkeypatch):
-    _setup_db(tmp_path, monkeypatch)
+def test_direct_messages_persist():
     msg = {"sender_id": 1, "recipient_id": 2, "content": "hi"}
     chat_service.send_message(msg)
 
@@ -55,9 +28,7 @@ def test_direct_messages_persist(tmp_path, monkeypatch):
     assert history1["direct_messages"][0]["content"] == "hi"
 
 
-def test_group_messages_persist(tmp_path, monkeypatch):
-    _setup_db(tmp_path, monkeypatch)
-
+def test_group_messages_persist():
     chat_service.send_group_chat({"group_id": "band", "sender_id": 1, "content": "hello"})
     chat_service.add_user_to_group("band", 2)
 


### PR DESCRIPTION
## Summary
- remove in-memory chat stores and rely on SQLite tables for direct and group messages
- fix table setup helper and consolidate chat history retrieval
- add tests for direct and group chat persistence

## Testing
- `pytest tests/test_chat_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee86bfe248325ab63ccecccbe4d7a