### PR TITLE
Implement sponsorship revenue payouts

### DIFF
--- a/backend/services/jobs_royalties.py
+++ b/backend/services/jobs_royalties.py
@@ -131,13 +131,34 @@ class RoyaltyJobsService:
             return None
         return None
 
-    def _emit_line(self, cur, run_id: int, work_type: str, work_id: Optional[int],
-                   band_id: Optional[int], collaborator_band_id: Optional[int],
-                   source: str, amount_cents: int, meta: Dict[str, Any]) -> None:
-        cur.execute("""
+    def _emit_line(
+        self,
+        cur,
+        run_id: int,
+        work_type: str,
+        work_id: Optional[int],
+        band_id: Optional[int],
+        collaborator_band_id: Optional[int],
+        source: str,
+        amount_cents: int,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        cur.execute(
+            """
             INSERT INTO royalty_run_lines (run_id, work_type, work_id, band_id, collaborator_band_id, source, amount_cents, meta_json)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        """, (run_id, work_type, work_id, band_id, collaborator_band_id, source, int(amount_cents), json.dumps(meta) if meta else None))
+            """,
+            (
+                run_id,
+                work_type,
+                work_id,
+                band_id,
+                collaborator_band_id,
+                source,
+                int(amount_cents),
+                json.dumps(meta) if meta else None,
+            ),
+        )
 
     # -------- channels --------
     def _process_streams(self, cur, run_id: int, window: RunWindow) -> None:
@@ -252,6 +273,7 @@ class RoyaltyJobsService:
             WHERE e.event_type = 'impression'
               AND datetime(e.occurred_at) >= datetime(?)
               AND datetime(e.occurred_at) <= datetime(?)
+              AND vs.is_active = 1
             GROUP BY vs.venue_id
             """,
             (f"{window.start} 00:00:00", f"{window.end} 23:59:59"),

--- a/backend/tests/royalties/test_venue_sponsorship_payouts.py
+++ b/backend/tests/royalties/test_venue_sponsorship_payouts.py
@@ -1,0 +1,37 @@
+import sqlite3
+from backend.config import revenue
+from backend.services.venue_sponsorships_service import VenueSponsorshipsService, SponsorshipIn
+from backend.services.jobs_royalties import RoyaltyJobsService
+
+
+def test_venue_sponsorship_payout(tmp_path):
+    db_path = tmp_path / "sponsor.db"
+    svc = VenueSponsorshipsService(str(db_path))
+    svc.ensure_schema()
+
+    sid = svc.upsert_sponsorship(
+        SponsorshipIn(
+            venue_id=1,
+            sponsor_name="MegaCorp",
+            start_date="2024-01-01",
+            end_date=None,
+            is_active=True,
+        )
+    )
+
+    svc.record_impression(sid)
+
+    payout = svc.calculate_payout(sid)
+    expected = revenue.SPONSOR_IMPRESSION_RATE_CENTS * revenue.SPONSOR_PAYOUT_SPLIT["venue"] // 100
+    assert payout["impressions"] == 1
+    assert payout["venue_cents"] == expected
+
+    rsvc = RoyaltyJobsService(str(db_path))
+    stats = rsvc.run_royalties("2000-01-01", "2030-01-01")
+    assert stats["sponsorship"] == 1
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT amount_cents FROM royalty_run_lines WHERE source='sponsorship'")
+        amount = cur.fetchone()[0]
+    assert amount == expected


### PR DESCRIPTION
## Summary
- compute royalty lines with active venue sponsorship revenue
- extend venue sponsorship service with ad event logging and payout calculation
- verify sponsorship payouts flow into royalty runs

## Testing
- `pytest backend/tests/royalties/test_sponsorship_reconciliation.py backend/tests/royalties/test_venue_sponsorship_payouts.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bee9a27ca8832594f55c3cc854b4db