### PR TITLE
test: expand jam gateway ws coverage

### DIFF
--- a/backend/realtime/jam_gateway.py
+++ b/backend/realtime/jam_gateway.py
@@ -106,6 +106,17 @@ async def jam_ws(ws: WebSocket, session_id: str, user_id: int = Depends(get_curr
             elif op == "stop_stream":
                 jam_service.stop_stream(session_id, user_id)
                 await hub.publish(session_id, {"type": "stream_stopped", "user_id": user_id})
+            elif op == "pause_stream":
+                jam_service.pause_stream(session_id, user_id)
+                await hub.publish(session_id, {"type": "stream_paused", "user_id": user_id})
+            elif op == "resume_stream":
+                jam_service.resume_stream(session_id, user_id)
+                await hub.publish(session_id, {"type": "stream_resumed", "user_id": user_id})
+            elif op == "invite":
+                jam_service.invite(session_id, user_id, int(msg.get("invitee_id", 0)))
+                await hub.publish(
+                    session_id, {"type": "invited", "user_id": int(msg.get("invitee_id", 0))}
+                )
             elif op == "ping":
                 await ws.send_text(json.dumps({"op": "pong"}))
     except WebSocketDisconnect:  # pragma: no cover - network

--- a/tests/realtime/conftest.py
+++ b/tests/realtime/conftest.py
@@ -1,0 +1,40 @@
+import importlib
+import pathlib
+import sys
+import types
+
+import pytest
+from fastapi import FastAPI
+
+# Ensure project root on sys.path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from tests.realtime.fake_jam_service import FakeJamService
+
+
+@pytest.fixture
+def jam_app():
+    fake_module = types.ModuleType("jam_service")
+    fake_module.JamService = FakeJamService
+    original_mod = sys.modules.get("backend.services.jam_service")
+    sys.modules["backend.services.jam_service"] = fake_module
+
+    jam_gateway = importlib.reload(importlib.import_module("backend.realtime.jam_gateway"))
+
+    app = FastAPI()
+    service = FakeJamService()
+    jam_gateway.jam_service = service
+    app.include_router(jam_gateway.router)
+
+    async def _uid() -> int:
+        return 1
+
+    app.dependency_overrides[jam_gateway.get_current_user_id_dep] = _uid
+    try:
+        yield app, service
+    finally:
+        if original_mod is not None:
+            sys.modules["backend.services.jam_service"] = original_mod
+        else:
+            sys.modules.pop("backend.services.jam_service", None)
+        importlib.reload(jam_gateway)

--- a/tests/realtime/fake_jam_service.py
+++ b/tests/realtime/fake_jam_service.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Test helpers providing a fake JamService for websocket tests."""
+
+from dataclasses import dataclass
+from typing import Dict, Set, Tuple
+
+
+@dataclass
+class FakeStream:
+    user_id: int
+    stream_id: str
+    codec: str
+    premium: bool
+    started_at: str = "now"
+    paused: bool = False
+
+
+class FakeJamService:
+    def __init__(self) -> None:
+        self.sessions: Dict[str, Set[int]] = {}
+        self.streams: Dict[Tuple[str, int], FakeStream] = {}
+        self.invites: Dict[str, Set[int]] = {}
+
+    def invite(self, session_id: str, inviter_id: int, invitee_id: int) -> None:
+        self.invites.setdefault(session_id, set()).add(invitee_id)
+
+    def join_session(self, session_id: str, user_id: int) -> None:
+        self.sessions.setdefault(session_id, set()).add(user_id)
+
+    def leave_session(self, session_id: str, user_id: int) -> None:
+        users = self.sessions.get(session_id)
+        if users:
+            users.discard(user_id)
+            self.streams.pop((session_id, user_id), None)
+            if not users:
+                self.sessions.pop(session_id, None)
+                self.invites.pop(session_id, None)
+                for key in list(self.streams):
+                    if key[0] == session_id:
+                        del self.streams[key]
+
+    def start_stream(
+        self, session_id: str, user_id: int, stream_id: str, codec: str, premium: bool = False
+    ) -> FakeStream:
+        stream = FakeStream(user_id, stream_id, codec, premium)
+        self.streams[(session_id, user_id)] = stream
+        return stream
+
+    def stop_stream(self, session_id: str, user_id: int) -> None:
+        self.streams.pop((session_id, user_id), None)
+
+    def pause_stream(self, session_id: str, user_id: int) -> None:
+        stream = self.streams.get((session_id, user_id))
+        if stream:
+            stream.paused = True
+
+    def resume_stream(self, session_id: str, user_id: int) -> None:
+        stream = self.streams.get((session_id, user_id))
+        if stream:
+            stream.paused = False

--- a/tests/realtime/test_jam_gateway_ws.py
+++ b/tests/realtime/test_jam_gateway_ws.py
@@ -1,70 +1,8 @@
-import pathlib
-import sys
-import types
-
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-# Ensure the project root is on sys.path for imports
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
-
-class FakeStream:
-    def __init__(self, user_id: int, stream_id: str, codec: str, premium: bool):
-        self.user_id = user_id
-        self.stream_id = stream_id
-        self.codec = codec
-        self.premium = premium
-        self.started_at = "now"
-
-
-class FakeJamService:
-    def __init__(self) -> None:
-        self.sessions: dict[str, set[int]] = {}
-        self.streams: dict[tuple[str, int], FakeStream] = {}
-
-    def join_session(self, session_id: str, user_id: int) -> None:
-        self.sessions.setdefault(session_id, set()).add(user_id)
-
-    def leave_session(self, session_id: str, user_id: int) -> None:
-        users = self.sessions.get(session_id)
-        if users:
-            users.discard(user_id)
-            if not users:
-                self.sessions.pop(session_id, None)
-
-    def start_stream(
-        self, session_id: str, user_id: int, stream_id: str, codec: str, premium: bool = False
-    ) -> FakeStream:
-        stream = FakeStream(user_id, stream_id, codec, premium)
-        self.streams[(session_id, user_id)] = stream
-        return stream
-
-    def stop_stream(self, session_id: str, user_id: int) -> None:
-        self.streams.pop((session_id, user_id), None)
-
-
-# Inject our fake JamService module before importing the gateway
-fake_module = types.ModuleType("jam_service")
-fake_module.JamService = FakeJamService
-sys.modules["backend.services.jam_service"] = fake_module
-
-from backend.realtime import jam_gateway  # noqa: E402
-
-
-def create_app() -> FastAPI:
-    app = FastAPI()
-    jam_gateway.jam_service = FakeJamService()
-    app.include_router(jam_gateway.router)
-    async def _uid() -> int:
-        return 1
-    app.dependency_overrides[jam_gateway.get_current_user_id_dep] = _uid
-    return app
-
-
-def test_jam_gateway_ping_and_stream():
-    app = create_app()
-    service = jam_gateway.jam_service
+def test_jam_gateway_ping_and_stream(jam_app):
+    app, service = jam_app
     client = TestClient(app)
     with client.websocket_connect("/jam/ws/s1") as ws:
         joined = ws.receive_json()
@@ -74,12 +12,23 @@ def test_jam_gateway_ping_and_stream():
         ws.send_json({"op": "ping"})
         assert ws.receive_json() == {"op": "pong"}
 
-        ws.send_json({"op": "start_stream", "stream_id": "sA", "codec": "opus", "premium": True})
+        ws.send_json(
+            {"op": "start_stream", "stream_id": "sA", "codec": "opus", "premium": True}
+        )
         started = ws.receive_json()
         assert started["type"] == "stream_started"
         assert started["user_id"] == 1
         assert started["stream"]["stream_id"] == "sA"
-        assert service.streams[("s1", 1)].stream_id == "sA"
+
+        ws.send_json({"op": "pause_stream"})
+        paused = ws.receive_json()
+        assert paused == {"type": "stream_paused", "user_id": 1}
+        assert service.streams[("s1", 1)].paused is True
+
+        ws.send_json({"op": "resume_stream"})
+        resumed = ws.receive_json()
+        assert resumed == {"type": "stream_resumed", "user_id": 1}
+        assert service.streams[("s1", 1)].paused is False
 
         ws.send_json({"op": "stop_stream"})
         stopped = ws.receive_json()
@@ -87,4 +36,19 @@ def test_jam_gateway_ping_and_stream():
         assert ("s1", 1) not in service.streams
 
     assert service.sessions == {}
+    assert service.streams == {}
+    assert service.invites == {}
 
+
+def test_jam_gateway_invite(jam_app):
+    app, service = jam_app
+    client = TestClient(app)
+    with client.websocket_connect("/jam/ws/s1") as ws:
+        ws.receive_json()
+        ws.send_json({"op": "invite", "invitee_id": 2})
+        invited = ws.receive_json()
+        assert invited == {"type": "invited", "user_id": 2}
+        assert service.invites == {"s1": {2}}
+
+    assert service.invites == {}
+    assert service.sessions == {}


### PR DESCRIPTION
## Summary
- add reusable fake JamService fixture with invite and stream pause/resume support
- extend jam_gateway to handle invite/pause/resume websocket ops
- test invite flow, pause/resume, and session cleanup via websocket

## Testing
- `pytest tests/realtime/test_jam_gateway_ws.py tests/realtime/test_polling_ws.py -q`
- `pytest backend/tests/jam_sessions/test_jam_gateway.py::test_jam_session_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee4c6ea348325a0bac9a6b0e11478