### PR TITLE
Add simple tour planner UI and endpoints

### DIFF
--- a/frontend/src/tour/Planner.tsx
+++ b/frontend/src/tour/Planner.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 const plannerBus = new EventTarget();
 
 export async function fetchSchedule(): Promise<Record<string, any>> {
-  const res = await fetch('/api/tour-collab/schedule');
+  const res = await fetch('/api/tours/planner/schedule');
   if (!res.ok) {
     throw new Error('Failed to fetch schedule');
   }
@@ -12,7 +12,7 @@ export async function fetchSchedule(): Promise<Record<string, any>> {
 }
 
 export async function saveSlot(time: string, value: any, durationDays = 1) {
-  const res = await fetch(`/api/tour-collab/schedule/${encodeURIComponent(time)}`, {
+  const res = await fetch(`/api/tours/planner/schedule/${encodeURIComponent(time)}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ value, durationDays })
@@ -24,7 +24,7 @@ export async function saveSlot(time: string, value: any, durationDays = 1) {
 }
 
 export async function deleteSlot(time: string) {
-  const res = await fetch(`/api/tour-collab/schedule/${encodeURIComponent(time)}`, {
+  const res = await fetch(`/api/tours/planner/schedule/${encodeURIComponent(time)}`, {
     method: 'DELETE'
   });
   if (!res.ok) {
@@ -74,7 +74,7 @@ export const Planner: React.FC = () => {
     const date = (form.elements.namedItem('date') as HTMLInputElement).value;
     const venue = (form.elements.namedItem('venue') as HTMLInputElement).value;
     const item = { date, venue };
-    await fetch('/api/tour-collab/schedule', {
+    await fetch('/api/tours/planner/schedule', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(item)
@@ -85,7 +85,7 @@ export const Planner: React.FC = () => {
 
   const handleDeleteDate = async (idx: number) => {
     const item = schedule[idx];
-    await fetch('/api/tour-collab/schedule', {
+    await fetch('/api/tours/planner/schedule', {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(item)
@@ -99,7 +99,7 @@ export const Planner: React.FC = () => {
     const description = (form.elements.namedItem('description') as HTMLInputElement).value;
     const amount = parseFloat((form.elements.namedItem('amount') as HTMLInputElement).value);
     const item = { description, amount };
-    await fetch('/api/tour-collab/expenses', {
+    await fetch('/api/tours/planner/expenses', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(item)
@@ -110,7 +110,7 @@ export const Planner: React.FC = () => {
 
   const handleDeleteExpense = async (idx: number) => {
     const item = expenses[idx];
-    await fetch('/api/tour-collab/expenses', {
+    await fetch('/api/tours/planner/expenses', {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(item)

--- a/frontend/src/tour/TourManager.tsx
+++ b/frontend/src/tour/TourManager.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+
+interface ShowItem {
+  city: string;
+  venue: string;
+  date: string;
+}
+
+/**
+ * Simple component that lets a user create a tour and then schedule shows for
+ * it.  This is intentionally lightweight – the backend endpoints are mocked in
+ * tests so the component only needs to issue fetch calls.
+ */
+const TourManager: React.FC = () => {
+  const [tourId, setTourId] = useState<number | null>(null);
+  const [shows, setShows] = useState<ShowItem[]>([]);
+
+  const handleCreate = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const bandId = parseInt((form.elements.namedItem('bandId') as HTMLInputElement).value, 10);
+    const title = (form.elements.namedItem('title') as HTMLInputElement).value;
+
+    const res = await fetch('/api/tours', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ band_id: bandId, title })
+    });
+    const data = await res.json();
+    setTourId(data.id);
+    form.reset();
+  };
+
+  const handleSchedule = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const city = (form.elements.namedItem('city') as HTMLInputElement).value;
+    const venue = (form.elements.namedItem('venue') as HTMLInputElement).value;
+    const date = (form.elements.namedItem('date') as HTMLInputElement).value;
+
+    await fetch('/api/tours/schedule', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tour_id: tourId,
+        city,
+        venue,
+        date,
+        ticket_tiers: [],
+        expenses: []
+      })
+    });
+
+    setShows((prev) => [...prev, { city, venue, date }]);
+    form.reset();
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleCreate}>
+        <input name="bandId" placeholder="Band ID" required />
+        <input name="title" placeholder="Title" required />
+        <button type="submit">Create Tour</button>
+      </form>
+
+      {tourId && (
+        <form onSubmit={handleSchedule}>
+          <input name="city" placeholder="City" required />
+          <input name="venue" placeholder="Venue" required />
+          <input name="date" placeholder="Date" required />
+          <button type="submit">Schedule Show</button>
+        </form>
+      )}
+
+      <ul>
+        {shows.map((s, i) => (
+          <li key={`${s.city}-${s.venue}-${i}`}>{`${s.city} @ ${s.venue} on ${s.date}`}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TourManager;
+

--- a/frontend/tests/tour/create_schedule.test.tsx
+++ b/frontend/tests/tour/create_schedule.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import TourManager from '../../src/tour/TourManager';
+import { vi } from 'vitest';
+
+describe('tour creation and scheduling', () => {
+  test('creates tour then schedules show', async () => {
+    const fetchMock = vi
+      .fn()
+      // create tour response
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 1 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+      // schedule show response
+      .mockResolvedValue(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      );
+
+    const originalFetch = global.fetch;
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<TourManager />);
+
+    // create tour
+    fireEvent.change(screen.getByPlaceholderText('Band ID'), {
+      target: { value: '7' }
+    });
+    fireEvent.change(screen.getByPlaceholderText('Title'), {
+      target: { value: 'World Domination' }
+    });
+    fireEvent.click(screen.getByText('Create Tour'));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/tours',
+        expect.objectContaining({ method: 'POST' })
+      )
+    );
+
+    // schedule show
+    fireEvent.change(screen.getByPlaceholderText('City'), {
+      target: { value: 'New York' }
+    });
+    fireEvent.change(screen.getByPlaceholderText('Venue'), {
+      target: { value: 'MSG' }
+    });
+    fireEvent.change(screen.getByPlaceholderText('Date'), {
+      target: { value: '2025-01-01' }
+    });
+    fireEvent.click(screen.getByText('Schedule Show'));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/tours/schedule',
+        expect.objectContaining({ method: 'POST' })
+      )
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('New York @ MSG on 2025-01-01')).toBeInTheDocument()
+    );
+
+    (globalThis as any).fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+});
+

--- a/frontend/tests/tour/planner.test.tsx
+++ b/frontend/tests/tour/planner.test.tsx
@@ -29,7 +29,7 @@ describe('tour planner', () => {
 
     await updateSlot('00:15', 'Practice');
     expect(fetchMock).toHaveBeenCalledWith(
-      '/api/tour-collab/schedule/00:15',
+      '/api/tours/planner/schedule/00:15',
       expect.objectContaining({ method: 'PUT' })
     );
     await waitFor(() => expect(screen.getByText('Practice')).toBeInTheDocument());


### PR DESCRIPTION
## Summary
- expose in-memory planner schedule and expense endpoints on tour routes
- update planner UI to use `/api/tours/planner` and add a TourManager for creating tours and scheduling shows
- add UI tests for planner grid and tour creation flow

## Testing
- `pytest backend/tests/tour/test_tour.py::test_routes -q`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beee5297948325b3899a44acb95156