### PR TITLE
Add avatar editing and skin marketplace features

### DIFF
--- a/backend/schemas/skin.py
+++ b/backend/schemas/skin.py
@@ -1,5 +1,8 @@
-from pydantic import BaseModel
 from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
 
 class SkinBase(BaseModel):
     name: str
@@ -10,8 +13,28 @@ class SkinBase(BaseModel):
     author: str
     price: int
 
+
 class SkinCreate(SkinBase):
+    """Schema for creating new skins."""
+
     pass
+
+
+class SkinUpdate(BaseModel):
+    """Schema for updating existing skins.
+
+    All fields are optional so callers may perform partial updates.
+    """
+
+    name: Optional[str] = None
+    category: Optional[str] = None
+    mesh_url: Optional[str] = None
+    texture_url: Optional[str] = None
+    rarity: Optional[str] = None
+    author: Optional[str] = None
+    price: Optional[int] = None
+    is_approved: Optional[bool] = None
+    is_official: Optional[bool] = None
 
 class SkinResponse(SkinBase):
     id: int

--- a/backend/services/skin_service.py
+++ b/backend/services/skin_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from models.avatar import Avatar, Base as AvatarBase
 from models.skin import Skin
 from models.avatar_skin import AvatarSkin
+from schemas.skin import SkinCreate, SkinUpdate
 
 # Reuse the same SQLite database as AvatarService
 from services.avatar_service import DB_PATH
@@ -31,6 +32,50 @@ class SkinService:
     def list_skins(self) -> list[Skin]:
         with self.session_factory() as session:
             return session.query(Skin).all()
+
+    # ------------------------------------------------------------------
+    def get_skin(self, skin_id: int) -> Optional[Skin]:
+        """Retrieve a single skin by ID."""
+
+        with self.session_factory() as session:
+            return session.get(Skin, skin_id)
+
+    # ------------------------------------------------------------------
+    def create_skin(self, data: SkinCreate) -> Skin:
+        """Create a new skin in the marketplace."""
+
+        with self.session_factory() as session:
+            skin = Skin(**data.model_dump())
+            session.add(skin)
+            session.commit()
+            session.refresh(skin)
+            return skin
+
+    # ------------------------------------------------------------------
+    def update_skin(self, skin_id: int, data: SkinUpdate) -> Optional[Skin]:
+        """Update an existing skin and return the updated row."""
+
+        with self.session_factory() as session:
+            skin = session.get(Skin, skin_id)
+            if not skin:
+                return None
+            for field, value in data.model_dump(exclude_unset=True).items():
+                setattr(skin, field, value)
+            session.commit()
+            session.refresh(skin)
+            return skin
+
+    # ------------------------------------------------------------------
+    def delete_skin(self, skin_id: int) -> bool:
+        """Delete a skin.  Returns ``True`` if the skin existed."""
+
+        with self.session_factory() as session:
+            skin = session.get(Skin, skin_id)
+            if not skin:
+                return False
+            session.delete(skin)
+            session.commit()
+            return True
 
     # ------------------------------------------------------------------
     def purchase_skin(self, avatar_id: int, skin_id: int) -> AvatarSkin:

--- a/frontend/pages/avatar_editor.html
+++ b/frontend/pages/avatar_editor.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Avatar Editor</title>
+  </head>
+  <body>
+    <h1>Avatar Editor</h1>
+    <form id="avatarForm">
+      <label>
+        Avatar ID
+        <input id="avatarId" type="number" required />
+      </label>
+      <label>
+        Nickname
+        <input id="nickname" />
+      </label>
+      <label>
+        Body Type
+        <input id="bodyType" />
+      </label>
+      <button type="submit">Save</button>
+    </form>
+
+    <script>
+      const form = document.getElementById('avatarForm');
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const id = document.getElementById('avatarId').value;
+        const payload = {
+          display_name: document.getElementById('nickname').value || undefined,
+          body_type: document.getElementById('bodyType').value || undefined,
+        };
+        await fetch(`/api/avatars/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        alert('Avatar updated');
+      });
+    </script>
+  </body>
+</html>
+

--- a/frontend/pages/skin_marketplace.html
+++ b/frontend/pages/skin_marketplace.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Skin Marketplace</title>
+  </head>
+  <body>
+    <h1>Skin Marketplace</h1>
+    <ul id="skinList"></ul>
+
+    <script>
+      async function loadSkins() {
+        const res = await fetch('/api/skins');
+        const skins = await res.json();
+        const list = document.getElementById('skinList');
+        list.innerHTML = '';
+        skins.forEach((skin) => {
+          const item = document.createElement('li');
+          item.textContent = `${skin.name} - ${skin.price}`;
+          const btn = document.createElement('button');
+          btn.textContent = 'Buy';
+          btn.onclick = async () => {
+            await fetch(`/api/skins/${skin.id}/purchase`, { method: 'POST' });
+            alert('Purchased ' + skin.name);
+          };
+          item.appendChild(btn);
+          list.appendChild(item);
+        });
+      }
+
+      loadSkins();
+    </script>
+  </body>
+</html>
+


### PR DESCRIPTION
## Summary
- enhance avatar editing service with validation and updated-return behaviour
- implement full CRUD for skin marketplace service and expose create/update/delete helpers
- add simple frontend pages for avatar editing and skin marketplace purchasing

## Testing
- `pytest backend/tests/avatar/test_skin_marketplace.py::test_list_and_purchase_and_apply_skin -q`
- `pytest backend/tests/avatars/test_avatar_service.py::test_crud_lifecycle -q` *(fails: IndentationError in test file)*

------
https://chatgpt.com/codex/tasks/task_e_68beee540d8c8325816520e9d58a079f