### PR TITLE
Add regional album chart support and country ranking UI

### DIFF
--- a/backend/routes/chart_routes.py
+++ b/backend/routes/chart_routes.py
@@ -48,6 +48,17 @@ def get_country_charts(country: str, chart_type: str = "streams_song", period: s
     ]
 
 
+@router.get("/country/{country}/{week_start}")
+def get_country_chart(
+    country: str,
+    week_start: str,
+    _req: Request,
+    user_id: int = Depends(get_current_user_id),
+):
+    """Retrieve weekly chart entries for a specific country."""
+    return get_chart("Global Top 100", country.upper(), week_start)
+
+
 @router.get("/{region}/{week_start}")
 def get_global_chart(
     region: str,

--- a/backend/services/chart_service.py
+++ b/backend/services/chart_service.py
@@ -154,7 +154,10 @@ def get_historical_charts(chart_type: str, region: str, weeks: int = 4) -> dict:
 
 
 def calculate_album_chart(
-    album_type: str = "studio", start_date: str | None = None, fame_service=None
+    album_type: str = "studio",
+    start_date: str | None = None,
+    region: str = "global",
+    fame_service=None,
 ) -> dict:
     """Generate a simple album chart based on digital sales revenue.
 
@@ -165,6 +168,8 @@ def calculate_album_chart(
     fame_service:
         Optional service providing ``award_fame`` used to grant fame to the
         chart topper.
+    region:
+        Geographic region or country code for which to generate the chart.
     """
 
     conn = sqlite3.connect(DB_PATH)
@@ -199,10 +204,11 @@ def calculate_album_chart(
             """
             INSERT INTO chart_entries
             (chart_type, region, week_start, position, song_id, band_name, score, generated_at)
-            VALUES (?, 'global', ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 f"{album_type.title()} Album Chart",
+                region,
                 start_date,
                 position,
                 album_id,
@@ -226,7 +232,7 @@ def calculate_album_chart(
     entries = [(a, t, b, r) for (a, t, _, b, r) in top]
     return {
         "chart_type": f"{album_type.title()} Album Chart",
-        "region": "global",
+        "region": region,
         "week_start": start_date,
         "entries": entries,
     }

--- a/frontend/src/charts/CountryChart.tsx
+++ b/frontend/src/charts/CountryChart.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+interface Entry {
+  position: number;
+  song_id: number;
+  band_name: string;
+  score: number;
+}
+
+interface Props {
+  country: string;
+  weekStart: string;
+}
+
+/**
+ * Display ranking entries for a given country.
+ */
+export function CountryChart({ country, weekStart }: Props) {
+  const [entries, setEntries] = useState<Entry[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/charts/country/${country}/${weekStart}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (!cancelled) setEntries(data);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [country, weekStart]);
+
+  return (
+    <ol>
+      {entries.map((e) => (
+        <li key={e.position}>
+          {e.position}. {e.band_name} ({e.score})
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/tests/CountryChart.test.tsx
+++ b/frontend/tests/CountryChart.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CountryChart } from '../src/charts/CountryChart';
+
+test('renders country chart rankings', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () =>
+        Promise.resolve([
+          { position: 1, song_id: 1, band_name: 'Alpha', score: 100 },
+          { position: 2, song_id: 2, band_name: 'Beta', score: 80 },
+        ]),
+    })
+  ) as any;
+
+  render(<CountryChart country="US" weekStart="2024-01-01" />);
+
+  expect(await screen.findByText('1. Alpha (100)')).toBeInTheDocument();
+  expect(await screen.findByText('2. Beta (80)')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- extend album chart calculation with region awareness
- expose `/charts/country/{country}/{week_start}` for country queries
- add React `CountryChart` component with tests for ranking display

## Testing
- `pytest` *(fails: ImportError and missing modules)*
- `npm --prefix frontend test` *(fails: vitest not found)
- `npm --prefix frontend install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68beee54e6408325ba197193c5e0ac5d