### PR TITLE
Add festival proposal voting tracking and genre trend UI

### DIFF
--- a/backend/routes/festival_proposals_routes.py
+++ b/backend/routes/festival_proposals_routes.py
@@ -43,8 +43,10 @@ async def submit_proposal(
 
 
 @router.post("/{proposal_id}/vote")
-async def vote(proposal_id: int) -> dict:
-    votes = svc.vote(proposal_id)
+async def vote(
+    proposal_id: int, user_id: int = Depends(get_current_user_id)
+) -> dict:
+    votes = svc.vote(proposal_id, user_id)
     return {"votes": votes}
 
 

--- a/frontend/pages/genre_trends.html
+++ b/frontend/pages/genre_trends.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Festival Genre Trends</title>
+</head>
+<body>
+<h2>Festival Genre Trends</h2>
+<ul id="trendList"></ul>
+<script>
+async function loadTrends() {
+  const res = await fetch('/festival/proposals/trends/genres');
+  const data = await res.json();
+  const list = document.getElementById('trendList');
+  list.innerHTML = '';
+  Object.entries(data).forEach(([genre, votes]) => {
+    const li = document.createElement('li');
+    li.innerText = `${genre}: ${votes}`;
+    list.appendChild(li);
+  });
+}
+loadTrends();
+</script>
+</body>
+</html>

--- a/tests/test_festival_proposals.py
+++ b/tests/test_festival_proposals.py
@@ -27,9 +27,10 @@ def test_approval_and_trends(tmp_path: Path) -> None:
     pid2 = svc.submit_proposal(
         ProposalIn(proposer_id=2, name="Jazz Fest", description=None, genre="jazz")
     )
-    svc.vote(pid1)
-    svc.vote(pid1)
-    svc.vote(pid2)
+    svc.vote(pid1, voter_id=10)
+    svc.vote(pid1, voter_id=11)
+    svc.vote(pid1, voter_id=10)  # duplicate vote ignored
+    svc.vote(pid2, voter_id=12)
 
     svc.approve(pid1)
     p1 = svc.get(pid1)


### PR DESCRIPTION
## Summary
- persist festival proposal votes and ignore duplicates to keep vote counts accurate
- require authenticated user when voting on proposals
- introduce basic frontend page displaying aggregated festival genre trends

## Testing
- `pytest tests/test_festival_proposals.py -q`
- `npm test` *(fails: vitest not found; attempted `npm install` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68beee6bad048325b897f861a9471fe0