### PR TITLE
Add skin submission moderation queue and admin UI

### DIFF
--- a/backend/services/skin_service.py
+++ b/backend/services/skin_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, Optional
+from dataclasses import dataclass
+from typing import Callable, Optional, List
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -21,11 +22,37 @@ Skin.__table__.create(bind=engine, checkfirst=True)
 AvatarBase.metadata.create_all(bind=engine)
 
 
+@dataclass
+class SkinSubmission:
+    """A user submitted skin awaiting moderation."""
+
+    id: int
+    name: str
+    data: dict
+    creator_id: int | None = None
+    status: str = "pending"
+
+
+@dataclass
+class SkinReview:
+    """Record of a moderation decision for a skin submission."""
+
+    id: int
+    submission_id: int
+    reviewer_id: int
+    decision: str  # "approved" or "rejected"
+    comment: str = ""
+
+
 class SkinService:
-    """Marketplace operations for avatar skins."""
+    """Marketplace operations for avatar skins and submission moderation."""
 
     def __init__(self, session_factory: Callable[[], Session] | sessionmaker = SessionLocal):
         self.session_factory = session_factory
+        self._submissions: List[SkinSubmission] = []
+        self._reviews: List[SkinReview] = []
+        self._next_submission_id = 1
+        self._next_review_id = 1
 
     # ------------------------------------------------------------------
     def list_skins(self) -> list[Skin]:
@@ -73,3 +100,41 @@ class SkinService:
             session.commit()
             session.refresh(avatar)
             return avatar
+
+    # ------------------------------------------------------------------
+    # Moderation helpers
+    def submit_skin(self, name: str, data: dict, creator_id: int | None = None) -> SkinSubmission:
+        """Add a new skin submission to the moderation queue."""
+
+        submission = SkinSubmission(
+            id=self._next_submission_id, name=name, data=data, creator_id=creator_id
+        )
+        self._next_submission_id += 1
+        self._submissions.append(submission)
+        return submission
+
+    def list_submission_queue(self) -> list[SkinSubmission]:
+        """Return all submissions still pending review."""
+
+        return [s for s in self._submissions if s.status == "pending"]
+
+    def review_submission(
+        self, submission_id: int, reviewer_id: int, approved: bool, comment: str = ""
+    ) -> SkinReview:
+        """Record a review decision for a submission."""
+
+        submission = next((s for s in self._submissions if s.id == submission_id), None)
+        if not submission:
+            raise ValueError("Submission not found")
+
+        submission.status = "approved" if approved else "rejected"
+        review = SkinReview(
+            id=self._next_review_id,
+            submission_id=submission_id,
+            reviewer_id=reviewer_id,
+            decision=submission.status,
+            comment=comment,
+        )
+        self._next_review_id += 1
+        self._reviews.append(review)
+        return review

--- a/backend/tests/admin/test_media_moderation_queue.py
+++ b/backend/tests/admin/test_media_moderation_queue.py
@@ -1,0 +1,37 @@
+import asyncio
+
+from fastapi import Request
+
+from backend.routes import admin_media_moderation_routes as routes
+
+
+def _setup(monkeypatch):
+    """Patch authentication dependencies for isolated testing."""
+
+    async def fake_current_user(req: Request):
+        return 1
+
+    async def fake_require_permission(roles, user_id):
+        return True
+
+    monkeypatch.setattr(routes, "get_current_user_id", fake_current_user)
+    monkeypatch.setattr(routes, "require_permission", fake_require_permission)
+
+
+def test_queue_and_review(monkeypatch):
+    _setup(monkeypatch)
+
+    # ensure clean state
+    routes.skin_service._submissions.clear()
+    routes.skin_service._reviews.clear()
+
+    submission = routes.skin_service.submit_skin("Test", {"mesh": "m"}, creator_id=2)
+
+    req = Request({"type": "http"})
+
+    queue = asyncio.run(routes.list_submission_queue(req))
+    assert any(item["id"] == submission.id for item in queue)
+
+    asyncio.run(routes.review_submission(submission.id, "approve", req))
+    assert routes.skin_service.list_submission_queue() == []
+

--- a/frontend/src/admin/moderation/ModerationQueue.tsx
+++ b/frontend/src/admin/moderation/ModerationQueue.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+
+interface Submission {
+  id: number;
+  name: string;
+  status: string;
+}
+
+const ModerationQueue: React.FC = () => {
+  const [queue, setQueue] = useState<Submission[]>([]);
+
+  const load = async () => {
+    try {
+      const res = await fetch('/admin/media/queue');
+      const data = await res.json();
+      setQueue(data);
+    } catch {
+      // ignore errors for now
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const review = async (id: number, decision: 'approve' | 'reject') => {
+    await fetch(`/admin/media/review/${id}/${decision}`, { method: 'POST' });
+    load();
+  };
+
+  if (queue.length === 0) {
+    return <div>No submissions</div>;
+  }
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-xl font-semibold mb-4">Pending Skins</h2>
+      <ul>
+        {queue.map((s) => (
+          <li key={s.id} className="flex items-center justify-between mb-2">
+            <span>{s.name}</span>
+            <div>
+              <button
+                className="px-2 py-1 bg-green-500 text-white rounded mr-2"
+                onClick={() => review(s.id, 'approve')}
+              >
+                Approve
+              </button>
+              <button
+                className="px-2 py-1 bg-red-500 text-white rounded"
+                onClick={() => review(s.id, 'reject')}
+              >
+                Reject
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ModerationQueue;
+

--- a/frontend/src/admin/moderation/index.ts
+++ b/frontend/src/admin/moderation/index.ts
@@ -1,0 +1,2 @@
+export { default as ModerationQueue } from './ModerationQueue';
+

--- a/frontend/tests/ModerationQueue.test.tsx
+++ b/frontend/tests/ModerationQueue.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { ModerationQueue } from '../src/admin/moderation';
+
+test('lists submissions and posts review', async () => {
+  const fetchMock = vi
+    .fn()
+    // initial load
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([{ id: 1, name: 'Skin', status: 'pending' }]),
+        { headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    // review call
+    .mockResolvedValueOnce(new Response('{}', { headers: { 'Content-Type': 'application/json' } }))
+    // reload after review
+    .mockResolvedValueOnce(new Response('[]', { headers: { 'Content-Type': 'application/json' } }));
+
+  // override global fetch for this test
+  (global as any).fetch = fetchMock;
+
+  render(<ModerationQueue />);
+  expect(await screen.findByText('Skin')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('Approve'));
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith('/admin/media/review/1/approve', { method: 'POST' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- introduce in-memory submission queue and review tracking in `SkinService`
- extend admin media moderation routes with queue listing and review endpoints
- add React moderation queue component with accompanying tests

## Testing
- `pytest backend/tests/admin/test_media_moderation_queue.py`
- `pytest` *(fails: 37 errors during collection)*
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68beee709e0083258f0919641f8f914e