### PR TITLE
Add seasonal NPC event generator with scheduler integration

### DIFF
--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -12,6 +12,7 @@ from backend.services import chart_service, fan_service, song_popularity_service
 from backend.services.activity_processor import process_previous_day
 from backend.services.books_service import books_service
 from backend.services.event_service import end_shop_event, start_shop_event
+from backend.services.npc_service import npc_service
 from backend.services.peer_learning_service import run_scheduled_session
 from backend.services.schedule_service import schedule_service
 from backend.services.shop_restock_service import restock_handler
@@ -130,6 +131,7 @@ EVENT_HANDLERS = {
     "shop_restock": restock_handler,
     "shop_event_start": start_shop_event,
     "shop_event_end": end_shop_event,
+    "npc_seasonal_event": npc_service.generate_seasonal_event,
     # Add more event handlers here as needed
 }
 
@@ -283,3 +285,12 @@ def schedule_outcome_reminder(user_id: int, day: str, run_at: str) -> dict:
         {"user_id": user_id, "day": day},
         run_at,
     )
+
+
+def schedule_npc_event(npc_id: int, run_at: str, season: str | None = None) -> dict:
+    """Schedule a seasonal event for an NPC."""
+
+    params = {"npc_id": npc_id}
+    if season:
+        params["season"] = season
+    return schedule_task("npc_seasonal_event", params, run_at)

--- a/tests/test_npc_seasonal_events.py
+++ b/tests/test_npc_seasonal_events.py
@@ -1,0 +1,71 @@
+import sys
+import sqlite3
+import random
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Ensure the backend package is importable when tests run standalone
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.append(str(root_dir))
+sys.path.append(str(root_dir / "backend"))
+
+import backend.services.npc_service as npc_service_module
+from backend.services.npc_service import NPCService
+from backend.services import scheduler_service
+
+
+def _setup_scheduler(tmp_path):
+    db = tmp_path / "sched.sqlite"
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE scheduled_tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type TEXT,
+            params TEXT,
+            run_at TEXT,
+            recurring INTEGER,
+            interval_days INTEGER,
+            last_run TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    scheduler_service.DB_PATH = db
+    return db
+
+
+def test_seasonal_event_changes_stats():
+    svc = NPCService()
+    npc = svc.create_npc("Bob", "villager", stats={"fame": 0, "activity": 10})
+    npc_id = npc["id"]
+
+    random.seed(0)
+    svc.generate_seasonal_event(npc_id, season="summer")
+    after_summer = svc.get_npc(npc_id)
+    assert after_summer["stats"]["fame"] > 0
+
+    svc.generate_seasonal_event(npc_id, season="winter")
+    after_winter = svc.get_npc(npc_id)
+    assert after_winter["stats"]["activity"] < 10
+
+
+def test_scheduler_triggers_npc_event(tmp_path):
+    _setup_scheduler(tmp_path)
+
+    svc = NPCService()
+    # Replace global references so the scheduler uses our fresh service
+    npc_service_module.npc_service = svc
+    scheduler_service.npc_service = svc
+    scheduler_service.EVENT_HANDLERS["npc_seasonal_event"] = svc.generate_seasonal_event
+
+    npc = svc.create_npc("Alice", "villager", stats={"fame": 0, "activity": 10})
+    run_at = (datetime.utcnow() - timedelta(seconds=1)).isoformat()
+    scheduler_service.schedule_npc_event(npc["id"], run_at, season="summer")
+
+    scheduler_service.run_due_tasks()
+
+    after = svc.get_npc(npc["id"])
+    assert after["stats"]["fame"] > 0


### PR DESCRIPTION
## Summary
- Add seasonal event generator to NPC service with simple summer/winter events
- Wire scheduler to trigger NPC seasonal events and provide scheduling helper
- Cover seasonal behaviors and scheduling with new unit tests

## Testing
- `pytest tests/test_npc_seasonal_events.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68beee669bd0832592d72dd601c16ee8