### PR TITLE
feat: configure react router for admin frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "react-scripts": "5.0.1",
     "tailwindcss": "^3.3.2",
     "chart.js": "^4.4.0",
-    "react-chartjs-2": "^5.2.0"
+    "react-chartjs-2": "^5.2.0",
+    "react-router-dom": "^6.22.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/admin/App.tsx
+++ b/frontend/src/admin/App.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Routes, Route } from 'react-router-dom';
 
 import Sidebar from './components/Sidebar';
 import NPCForm from './components/NPCForm';
@@ -17,53 +18,38 @@ import CityShopsAdmin from './economy/CityShopsAdmin';
 import ShopAnalytics from './economy/ShopAnalytics';
 import PlayerShopAdmin from './economy/PlayerShopAdmin';
 
-const App: React.FC = () => {
-  const path = window.location.pathname;
+const DashboardHome = () => (
+  <>
+    <h1 className="text-2xl font-bold mb-4">Admin Dashboard</h1>
+    <p className="text-gray-700">Select a module from the sidebar to begin.</p>
+    <Dashboard />
+  </>
+);
 
-  let content: React.ReactNode = (
-    <>
-      <h1 className="text-2xl font-bold mb-4">Admin Dashboard</h1>
-      <p className="text-gray-700">Select a module from the sidebar to begin.</p>
-      <Dashboard />
-    </>
-  );
-
-  if (path.includes('/admin/npcs/dialogue')) {
-    content = <DialogueEditor />;
-  } else if (path.includes('/admin/npcs')) {
-    content = <NPCForm />;
-  } else if (path.includes('/admin/audit')) {
-    content = <AuditTable />;
-  } else if (path.includes('/admin/xp-events')) {
-    content = <XPEventForm />;
-  } else if (path.includes('/admin/xp-items')) {
-    content = <XPItemForm />;
-  } else if (path.includes('/admin/modding')) {
-    content = <PluginManager />;
-  } else if (path.includes('/admin/economy/analytics')) {
-    content = <ShopAnalytics />;
-  } else if (path.includes('/admin/economy/player-shops')) {
-    content = <PlayerShopAdmin />;
-  } else if (path.includes('/admin/economy/city-shops')) {
-    content = <CityShopsAdmin />;
-  } else if (path.includes('/admin/events')) {
-    content = <EventsCalendar />;
-  } else if (path.includes('/admin/learning/books')) {
-    content = <BooksAdmin />;
-  } else if (path.includes('/admin/learning/tutorials')) {
-    content = <TutorialsAdmin />;
-  } else if (path.includes('/admin/learning/tutors')) {
-    content = <TutorsAdmin />;
-  } else if (path.includes('/admin/learning/mentors')) {
-    content = <MentorsAdmin />;
-  }
-
-  return (
-    <div className="flex min-h-screen">
-      <Sidebar />
-      <main className="flex-1 p-4">{content}</main>
-    </div>
-  );
-};
+const App: React.FC = () => (
+  <div className="flex min-h-screen">
+    <Sidebar />
+    <main className="flex-1 p-4">
+      <Routes>
+        <Route path="/admin/npcs/dialogue" element={<DialogueEditor />} />
+        <Route path="/admin/npcs" element={<NPCForm />} />
+        <Route path="/admin/audit" element={<AuditTable />} />
+        <Route path="/admin/xp-events" element={<XPEventForm />} />
+        <Route path="/admin/xp-items" element={<XPItemForm />} />
+        <Route path="/admin/modding" element={<PluginManager />} />
+        <Route path="/admin/economy/analytics" element={<ShopAnalytics />} />
+        <Route path="/admin/economy/player-shops" element={<PlayerShopAdmin />} />
+        <Route path="/admin/economy/city-shops" element={<CityShopsAdmin />} />
+        <Route path="/admin/events" element={<EventsCalendar />} />
+        <Route path="/admin/learning/books" element={<BooksAdmin />} />
+        <Route path="/admin/learning/tutorials" element={<TutorialsAdmin />} />
+        <Route path="/admin/learning/tutors" element={<TutorsAdmin />} />
+        <Route path="/admin/learning/mentors" element={<MentorsAdmin />} />
+        <Route path="/dashboard" element={<DashboardHome />} />
+        <Route path="*" element={<DashboardHome />} />
+      </Routes>
+    </main>
+  </div>
+);
 
 export default App;

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 interface NavItem {
   label: string;
@@ -33,12 +34,12 @@ const Sidebar: React.FC = () => (
       <ul>
         {navItems.map((item) => (
           <li key={item.href} className="mb-2">
-            <a
-              href={item.href}
+            <Link
+              to={item.href}
               className="block px-2 py-1 rounded hover:bg-gray-700"
             >
               {item.label}
-            </a>
+            </Link>
           </li>
         ))}
       </ul>

--- a/frontend/src/admin/index.tsx
+++ b/frontend/src/admin/index.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import '../index.css';
 
 const rootElement = document.getElementById('root');
 if (rootElement) {
   const root = ReactDOM.createRoot(rootElement);
-  root.render(<App />);
+  root.render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
 }


### PR DESCRIPTION
## Summary
- add `react-router-dom` to frontend dependencies
- route admin modules using `Routes` and `Route`
- replace sidebar anchors with `Link`

## Testing
- `npm test` *(fails: vitest not found)*
- `pytest` *(fails: ModuleNotFoundError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bef184417483259b556c4a262694c5