### PR TITLE
Add admin session monitoring endpoints and dashboard widget

### DIFF
--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict
+
+DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+
+class SessionService:
+    """Service for tracking active sessions."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        self.db_path = str(db_path or DB_PATH)
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id TEXT PRIMARY KEY,
+                    user_id INTEGER NOT NULL,
+                    ip TEXT,
+                    user_agent TEXT,
+                    created_at TEXT NOT NULL,
+                    terminated INTEGER DEFAULT 0
+                )
+                """
+            )
+            conn.commit()
+
+    def add_session(self, session_id: str, user_id: int, ip: str = "", user_agent: str = "") -> None:
+        created = datetime.utcnow().isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO sessions (id, user_id, ip, user_agent, created_at, terminated)
+                VALUES (?, ?, ?, ?, ?, 0)
+                """,
+                (session_id, user_id, ip, user_agent, created),
+            )
+            conn.commit()
+
+    def list_sessions(self) -> List[Dict]:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT id, user_id, ip, user_agent, created_at FROM sessions WHERE terminated=0"
+            )
+            rows = cur.fetchall()
+            return [
+                {
+                    "id": r[0],
+                    "user_id": r[1],
+                    "ip": r[2],
+                    "user_agent": r[3],
+                    "created_at": r[4],
+                }
+                for r in rows
+            ]
+
+    def terminate_session(self, session_id: str) -> bool:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("UPDATE sessions SET terminated=1 WHERE id=?", (session_id,))
+            conn.commit()
+            return cur.rowcount > 0
+
+    def clear(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM sessions")
+            conn.commit()
+
+
+session_service = SessionService()
+
+
+def get_session_service() -> SessionService:
+    return session_service

--- a/backend/tests/admin/test_monitoring_sessions.py
+++ b/backend/tests/admin/test_monitoring_sessions.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import backend.routes.admin_monitoring_routes as monitoring_routes
+from backend.services.session_service import SessionService, get_session_service
+
+
+def create_app(svc: SessionService) -> TestClient:
+    app = FastAPI()
+    app.include_router(monitoring_routes.router)
+    app.dependency_overrides[monitoring_routes.get_session_service] = lambda: svc
+
+    async def fake_current_user_id(_req):
+        return 1
+
+    async def fake_require_permission(_roles, _uid):
+        return True
+
+    monitoring_routes.get_current_user_id = fake_current_user_id
+    monitoring_routes.require_permission = fake_require_permission
+    return TestClient(app)
+
+
+def test_list_and_terminate_sessions(tmp_path):
+    db_path = tmp_path / 'sessions.db'
+    svc = SessionService(db_path)
+    svc.add_session('s1', 1, '127.0.0.1', 'ua')
+    svc.add_session('s2', 2, '127.0.0.2', 'ua2')
+
+    client = create_app(svc)
+
+    resp = client.get('/monitoring/sessions')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+
+    resp = client.delete('/monitoring/sessions/s1')
+    assert resp.status_code == 200
+    assert resp.json()['status'] == 'terminated'
+
+    resp = client.get('/monitoring/sessions')
+    assert len(resp.json()) == 1
+
+    resp = client.delete('/monitoring/sessions/doesnotexist')
+    assert resp.status_code == 404

--- a/frontend/src/admin/dashboard/Dashboard.tsx
+++ b/frontend/src/admin/dashboard/Dashboard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import MetricsWidget from './MetricsWidget';
+import SessionsWidget from './SessionsWidget';
 import WebsocketMetricsWidget from './WebsocketMetricsWidget';
 import AlertsWidget from './AlertsWidget';
 import RbacControls from './RbacControls';
@@ -10,6 +11,7 @@ const Dashboard: React.FC = () => (
     <DailyLoopWidget />
     <h2 className="text-xl font-semibold mb-2">Monitoring</h2>
     <MetricsWidget />
+    <SessionsWidget />
     <WebsocketMetricsWidget />
     <h3 className="text-lg font-semibold">Alerts</h3>
     <AlertsWidget />

--- a/frontend/src/admin/dashboard/SessionsWidget.tsx
+++ b/frontend/src/admin/dashboard/SessionsWidget.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+
+interface Session {
+  id: string;
+  user_id: number;
+  ip: string;
+  user_agent: string;
+  created_at: string;
+}
+
+const SessionsWidget: React.FC = () => {
+  const [sessions, setSessions] = useState<Session[]>([]);
+
+  const load = async () => {
+    try {
+      const res = await fetch('/admin/monitoring/sessions');
+      const data = await res.json();
+      setSessions(data);
+    } catch {
+      // ignore
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const terminate = async (id: string) => {
+    await fetch(`/admin/monitoring/sessions/${id}`, { method: 'DELETE' });
+    setSessions((prev) => prev.filter((s) => s.id !== id));
+  };
+
+  return (
+    <table className="min-w-full text-sm mb-4">
+      <thead>
+        <tr>
+          <th className="text-left">ID</th>
+          <th>User</th>
+          <th>IP</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {sessions.map((s) => (
+          <tr key={s.id}>
+            <td>{s.id}</td>
+            <td>{s.user_id}</td>
+            <td>{s.ip}</td>
+            <td>
+              <button
+                onClick={() => terminate(s.id)}
+                className="text-red-600 hover:underline"
+              >
+                Terminate
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default SessionsWidget;

--- a/frontend/src/admin/dashboard/index.ts
+++ b/frontend/src/admin/dashboard/index.ts
@@ -1,5 +1,6 @@
 export { default as Dashboard } from './Dashboard';
 export { default as MetricsWidget } from './MetricsWidget';
+export { default as SessionsWidget } from './SessionsWidget';
 export { default as AlertsWidget } from './AlertsWidget';
 export { default as RbacControls } from './RbacControls';
 export { default as DailyLoopWidget } from './DailyLoopWidget';


### PR DESCRIPTION
## Summary
- track active sessions in SQLite with new session service
- expose admin monitoring endpoints to list and terminate sessions
- show active sessions in admin dashboard with terminate buttons

## Testing
- `pytest backend/tests/admin/test_monitoring_sessions.py -q`
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68bef1861fd4832599a81ede0bd7a241