### PR TITLE
feat: add admin notifications center

### DIFF
--- a/backend/routes/admin_notifications_routes.py
+++ b/backend/routes/admin_notifications_routes.py
@@ -1,0 +1,54 @@
+"""Admin notification management routes."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from auth.dependencies import get_current_user_id, require_permission
+from services.admin_notifications_service import AdminNotificationsService
+
+router = APIRouter(prefix="/notifications", tags=["AdminNotifications"])
+svc = AdminNotificationsService()
+
+
+@router.get("")
+async def list_notifications(
+    limit: int = 100,
+    offset: int = 0,
+    admin_id: int = Depends(get_current_user_id),
+):
+    await require_permission(["admin"], admin_id)
+    items = svc.list(limit=limit, offset=offset)
+    return {"notifications": items, "unread": svc.unread_count()}
+
+
+@router.post("")
+async def create_notification(
+    payload: dict,
+    admin_id: int = Depends(get_current_user_id),
+):
+    await require_permission(["admin"], admin_id)
+    message = payload.get("message", "")
+    severity = payload.get("severity", "info")
+    notif_id = svc.create(message, severity)
+    return {"id": notif_id}
+
+
+@router.post("/{notification_id}/read")
+async def mark_read(
+    notification_id: int,
+    admin_id: int = Depends(get_current_user_id),
+):
+    await require_permission(["admin"], admin_id)
+    if not svc.mark_read(notification_id):
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return {"ok": True}
+
+
+@router.delete("/{notification_id}")
+async def delete_notification(
+    notification_id: int,
+    admin_id: int = Depends(get_current_user_id),
+):
+    await require_permission(["admin"], admin_id)
+    if not svc.delete(notification_id):
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return {"ok": True}

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -28,6 +28,7 @@ from .admin_npc_routes import router as npc_router
 from .admin_online_tutorial_routes import router as online_tutorial_router
 from .admin_player_shop_routes import router as player_shop_router
 from .admin_quest_routes import router as quest_router
+from .admin_notifications_routes import router as notifications_router
 from .admin_schema_routes import router as schema_router
 from .admin_shop_event_routes import router as shop_event_router
 from .admin_song_popularity_routes import router as song_popularity_router
@@ -71,6 +72,7 @@ router.include_router(modding_router)
 router.include_router(npc_router)
 router.include_router(npc_dialogue_router)
 router.include_router(quest_router)
+router.include_router(notifications_router)
 router.include_router(schema_router)
 router.include_router(song_popularity_router)
 router.include_router(item_router)

--- a/backend/services/admin_notifications_service.py
+++ b/backend/services/admin_notifications_service.py
@@ -1,0 +1,87 @@
+"""Admin notification service managing persistent alerts.
+
+This module provides CRUD helpers for a simple ``admin_notifications`` table
+stored in SQLite.  Each notification includes a severity level and a boolean
+read state so the admin interface can highlight unread messages.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from backend.utils.db import get_conn
+
+
+class AdminNotificationsService:
+    """Service layer for admin notifications."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = db_path
+        self._ensure_table()
+
+    # ------------------------------------------------------------------
+    def _ensure_table(self) -> None:
+        with get_conn(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS admin_notifications (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    message TEXT NOT NULL,
+                    severity TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    read INTEGER NOT NULL DEFAULT 0
+                );
+                """
+            )
+
+    # ------------------------------------------------------------------
+    def create(self, message: str, severity: str = "info") -> int:
+        """Insert a new admin notification and return its id."""
+        with get_conn(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO admin_notifications (message, severity) VALUES (?, ?)",
+                (message, severity),
+            )
+            return int(cur.lastrowid)
+
+    def list(self, limit: int = 100, offset: int = 0) -> List[Dict[str, Any]]:
+        """Return notifications ordered by unread first then newest."""
+        with get_conn(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT id, message, severity, created_at, read
+                FROM admin_notifications
+                ORDER BY read ASC, created_at DESC
+                LIMIT ? OFFSET ?
+                """,
+                (limit, offset),
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+    def mark_read(self, notif_id: int) -> bool:
+        """Mark a notification as read."""
+        with get_conn(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "UPDATE admin_notifications SET read = 1 WHERE id = ? AND read = 0",
+                (notif_id,),
+            )
+            return cur.rowcount > 0
+
+    def delete(self, notif_id: int) -> bool:
+        """Remove a notification."""
+        with get_conn(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM admin_notifications WHERE id = ?", (notif_id,))
+            return cur.rowcount > 0
+
+    def unread_count(self) -> int:
+        """Return the number of unread notifications."""
+        with get_conn(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT COUNT(*) FROM admin_notifications WHERE read = 0"
+            )
+            return int(cur.fetchone()[0])

--- a/frontend/src/admin/App.tsx
+++ b/frontend/src/admin/App.tsx
@@ -16,6 +16,7 @@ import MentorsAdmin from './learning/MentorsAdmin';
 import CityShopsAdmin from './economy/CityShopsAdmin';
 import ShopAnalytics from './economy/ShopAnalytics';
 import PlayerShopAdmin from './economy/PlayerShopAdmin';
+import NotificationCenter from './notifications/NotificationCenter';
 
 const App: React.FC = () => {
   const path = window.location.pathname;
@@ -56,6 +57,8 @@ const App: React.FC = () => {
     content = <TutorsAdmin />;
   } else if (path.includes('/admin/learning/mentors')) {
     content = <MentorsAdmin />;
+  } else if (path.includes('/admin/notifications')) {
+    content = <NotificationCenter />;
   }
 
   return (

--- a/frontend/src/admin/components/Sidebar.tsx
+++ b/frontend/src/admin/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface NavItem {
   label: string;
@@ -27,23 +27,43 @@ const navItems: NavItem[] = [
   { label: 'Modding', href: '/admin/modding' },
 ];
 
-const Sidebar: React.FC = () => (
-  <aside className="w-64 bg-gray-800 text-white h-screen p-4">
-    <nav>
-      <ul>
-        {navItems.map((item) => (
-          <li key={item.href} className="mb-2">
+const Sidebar: React.FC = () => {
+  const [notifCount, setNotifCount] = useState(0);
+
+  useEffect(() => {
+    (window as any).setAdminNotifCount = setNotifCount;
+    fetch('/admin/notifications')
+      .then((r) => r.json())
+      .then((d) => setNotifCount(d.unread || 0))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <aside className="w-64 bg-gray-800 text-white h-screen p-4">
+      <nav>
+        <ul>
+          {navItems.map((item) => (
+            <li key={item.href} className="mb-2">
+              <a
+                href={item.href}
+                className="block px-2 py-1 rounded hover:bg-gray-700"
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+          <li className="mb-2">
             <a
-              href={item.href}
+              href="/admin/notifications"
               className="block px-2 py-1 rounded hover:bg-gray-700"
             >
-              {item.label}
+              Notifications ({notifCount})
             </a>
           </li>
-        ))}
-      </ul>
-    </nav>
-  </aside>
-);
+        </ul>
+      </nav>
+    </aside>
+  );
+};
 
 export default Sidebar;

--- a/frontend/src/admin/notifications/NotificationCenter.tsx
+++ b/frontend/src/admin/notifications/NotificationCenter.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+
+type Notification = {
+  id: number;
+  message: string;
+  severity: string;
+  created_at: string;
+  read: number;
+};
+
+const groupBy = (items: Notification[]) => {
+  return items.reduce<Record<string, Notification[]>>((acc, item) => {
+    acc[item.severity] = acc[item.severity] || [];
+    acc[item.severity].push(item);
+    return acc;
+  }, {});
+};
+
+const NotificationCenter: React.FC = () => {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  const refresh = () => {
+    fetch('/admin/notifications')
+      .then((r) => r.json())
+      .then((data) => {
+        setNotifications(data.notifications || []);
+        if ((window as any).setAdminNotifCount) {
+          (window as any).setAdminNotifCount(data.unread || 0);
+        }
+      })
+      .catch(() => {});
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const markRead = (id: number) => {
+    fetch(`/admin/notifications/${id}/read`, { method: 'POST' })
+      .then(() => {
+        setNotifications((prev) =>
+          prev.map((n) => (n.id === id ? { ...n, read: 1 } : n))
+        );
+        if ((window as any).setAdminNotifCount) {
+          const unread = notifications.filter((n) => !n.read && n.id !== id).length;
+          (window as any).setAdminNotifCount(unread);
+        }
+      })
+      .catch(() => {});
+  };
+
+  const groups = groupBy(notifications);
+
+  return (
+    <div>
+      {Object.entries(groups).map(([severity, items]) => (
+        <div key={severity} className="mb-4">
+          <h2 className="font-bold capitalize">
+            {severity} ({items.filter((i) => !i.read).length}/{items.length})
+          </h2>
+          <ul className="ml-4 list-disc">
+            {items.map((n) => (
+              <li key={n.id} className="mb-1">
+                <span className={n.read ? 'text-gray-600' : 'font-semibold'}>
+                  {n.message}
+                </span>
+                {!n.read && (
+                  <button
+                    onClick={() => markRead(n.id)}
+                    className="ml-2 text-sm text-blue-500"
+                  >
+                    Mark read
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default NotificationCenter;


### PR DESCRIPTION
## Summary
- add AdminNotificationsService with SQLite-backed table for severity and read state
- expose /admin/notifications endpoints for CRUD operations and mark-as-read
- build admin NotificationCenter UI and sidebar count display

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'BookIn' from 'backend.routes.admin_book_routes' and similar)*

------
https://chatgpt.com/codex/tasks/task_e_68bef186981083259721a1533d85a7d6