### PR TITLE
Add timezone-aware admin event calendar with drag-and-drop

### DIFF
--- a/backend/routes/admin_events_routes.py
+++ b/backend/routes/admin_events_routes.py
@@ -1,0 +1,59 @@
+"""Admin routes for managing scheduled world events."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, Depends
+
+from backend.auth.dependencies import require_permission
+from backend.schemas.events_schemas import (
+    EndEventSchema,
+    EventResponse,
+    ScheduleEventSchema,
+    UpdateEventSchema,
+    UpcomingEventsResponse,
+)
+from backend.services.events_service import (
+    cancel_scheduled_event,
+    get_upcoming_events,
+    schedule_event,
+    update_scheduled_event,
+)
+
+router = APIRouter(prefix="/events", dependencies=[Depends(require_permission(["admin"]))])
+
+
+def _to_utc_naive(ts: str, tz: str) -> str:
+    """Convert an ISO timestamp to naive UTC based on provided timezone."""
+
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    zone = ZoneInfo(tz)
+    return dt.astimezone(zone).astimezone(ZoneInfo("UTC")).replace(tzinfo=None).isoformat()
+
+
+@router.post("/schedule", response_model=EventResponse)
+def schedule(payload: ScheduleEventSchema) -> EventResponse:
+    start = _to_utc_naive(payload.start_time, payload.timezone)
+    end = _to_utc_naive(payload.end_time, payload.timezone)
+    data = payload.model_dump()
+    data["start_time"] = start
+    data["end_time"] = end
+    return schedule_event(data)
+
+
+@router.post("/update", response_model=EventResponse)
+def update(payload: UpdateEventSchema) -> EventResponse:
+    start = _to_utc_naive(payload.start_time_utc, payload.timezone)
+    end = _to_utc_naive(payload.end_time_utc, payload.timezone)
+    return update_scheduled_event(payload.event_id, start, end, payload.timezone)
+
+
+@router.post("/cancel", response_model=EventResponse)
+def cancel(payload: EndEventSchema) -> EventResponse:
+    return cancel_scheduled_event(payload.event_id)
+
+
+@router.get("/upcoming", response_model=UpcomingEventsResponse)
+def upcoming() -> UpcomingEventsResponse:
+    return get_upcoming_events()
+

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -13,6 +13,7 @@ from .admin_book_routes import router as book_router
 from .admin_business_routes import router as business_router
 from .admin_city_shop_routes import router as city_shop_router
 from .admin_course_routes import router as course_router
+from .admin_events_routes import router as events_router
 from .admin_economy_routes import router as economy_router
 from .admin_item_routes import router as item_router
 from .admin_drug_routes import router as drug_router
@@ -79,6 +80,7 @@ router.include_router(lifestyle_router)
 
 router.include_router(course_router)
 router.include_router(book_router)
+router.include_router(events_router)
 router.include_router(workshop_router)
 router.include_router(shop_event_router)
 router.include_router(online_tutorial_router)

--- a/backend/schemas/events_schemas.py
+++ b/backend/schemas/events_schemas.py
@@ -51,9 +51,19 @@ class ScheduleEventSchema(BaseModel):
     description: str
     start_time: str
     end_time: str
+    timezone: str = "UTC"
     modifiers: Dict[str, Any]
     start_callback: Optional[str] = None
     end_callback: Optional[str] = None
+
+
+class UpdateEventSchema(BaseModel):
+    """Payload for updating the timing of a scheduled event."""
+
+    event_id: str
+    start_time_utc: str
+    end_time_utc: str
+    timezone: str = "UTC"
 
 
 class EventResponse(BaseModel):

--- a/backend/tests/services/test_events_service_timezone.py
+++ b/backend/tests/services/test_events_service_timezone.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timedelta
+
+from backend.services import events_service
+
+
+def test_schedule_event_stores_timezone(monkeypatch):
+    start = datetime.utcnow() + timedelta(hours=1)
+    end = start + timedelta(hours=2)
+    data = {
+        "event_id": "tz1",
+        "name": "Test",
+        "theme": "none",
+        "description": "desc",
+        "start_time": start.isoformat(),
+        "end_time": end.isoformat(),
+        "timezone": "UTC",
+        "modifiers": {},
+    }
+    result = events_service.schedule_event(data)
+    assert result["event"]["timezone"] == "UTC"
+    events_service.cancel_scheduled_event("tz1")
+
+
+def test_update_event_changes_times(monkeypatch):
+    start = datetime.utcnow() + timedelta(hours=1)
+    end = start + timedelta(hours=2)
+    data = {
+        "event_id": "tz2",
+        "name": "Test",
+        "theme": "none",
+        "description": "desc",
+        "start_time": start.isoformat(),
+        "end_time": end.isoformat(),
+        "timezone": "UTC",
+        "modifiers": {},
+    }
+    events_service.schedule_event(data)
+    new_start = start + timedelta(hours=2)
+    new_end = end + timedelta(hours=2)
+    update = events_service.update_scheduled_event(
+        "tz2", new_start.isoformat(), new_end.isoformat(), "UTC"
+    )
+    assert update["event"]["start_date"].startswith(new_start.isoformat()[:19])
+    events_service.cancel_scheduled_event("tz2")

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,11 @@
     "react-scripts": "5.0.1",
     "tailwindcss": "^3.3.2",
     "chart.js": "^4.4.0",
-    "react-chartjs-2": "^5.2.0"
+    "react-chartjs-2": "^5.2.0",
+    "react-big-calendar": "^1.8.5",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
+    "date-fns": "^3.6.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
## Summary
- Integrate react-big-calendar with drag-and-drop for admin event scheduling
- Add timezone-aware admin event routes with update endpoint
- Store timezone data in events service and add tests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*
- `pytest` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bef1850f8c83259cbc99b24b89840b