### PR TITLE
Use additive stacking for XP events

### DIFF
--- a/backend/services/xp_event_service.py
+++ b/backend/services/xp_event_service.py
@@ -70,5 +70,5 @@ class XPEventService:
     def get_active_multiplier(self, skill: str | None = None) -> float:
         mult = 1.0
         for e in self.get_active_events(skill):
-            mult *= e.multiplier
+            mult += e.multiplier - 1
         return mult

--- a/backend/tests/services/test_xp_event_service.py
+++ b/backend/tests/services/test_xp_event_service.py
@@ -1,0 +1,31 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from backend.models.xp_event import XPEvent
+from backend.services.xp_event_service import XPEventService
+
+
+def test_additive_stacking(tmp_path):
+    svc = XPEventService(path=tmp_path / "xp_events.json")
+    now = datetime.utcnow()
+    svc.create_event(
+        XPEvent(
+            id=None,
+            name="double",
+            start_time=now,
+            end_time=now + timedelta(hours=1),
+            multiplier=2.0,
+        )
+    )
+    svc.create_event(
+        XPEvent(
+            id=None,
+            name="triple",
+            start_time=now,
+            end_time=now + timedelta(hours=1),
+            multiplier=3.0,
+        )
+    )
+
+    assert svc.get_active_multiplier() == pytest.approx(4.0)


### PR DESCRIPTION
## Summary
- switch XP event stacking from multiplicative to additive accumulation
- add unit test ensuring multiple events stack additively

## Testing
- `pytest backend/tests/services/test_xp_event_service.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'tests.realtime', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0914885e483259d2fa2f1416d6881