### PR TITLE
Add daily XP cap check for baseline rewards

### DIFF
--- a/tests/test_xp_reward_baseline.py
+++ b/tests/test_xp_reward_baseline.py
@@ -1,13 +1,14 @@
 import sqlite3
+import sys
 from datetime import datetime
 from pathlib import Path
-import sys
 
 root_dir = Path(__file__).resolve().parents[1]
 sys.path.append(str(root_dir))
 sys.path.append(str(root_dir / "backend"))
 
-from backend.services import xp_reward_service, scheduler_service
+from backend.models.xp_config import XPConfig, set_config  # noqa: E402
+from backend.services import scheduler_service, xp_reward_service  # noqa: E402
 
 
 def _setup_db(tmp_path):
@@ -56,6 +57,7 @@ def _setup_db(tmp_path):
 
     scheduler_service.DB_PATH = db
     xp_reward_service.xp_reward_service.db_path = str(db)
+    set_config(XPConfig())
 
     return db
 
@@ -121,4 +123,70 @@ def test_lifestyle_influences_amount(tmp_path):
     conn.close()
 
     assert high > low
+
+
+def test_baseline_respects_daily_cap(tmp_path):
+    db = _setup_db(tmp_path)
+    set_config(XPConfig(daily_cap=20))
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO lifestyle (user_id, sleep_hours, drinking, stress, training_discipline, mental_health, nutrition, fitness, last_updated)"
+        " VALUES (?,?,?,?,?,?,?,?,?)",
+        (1, 8, "none", 20, 60, 70, 70, 70, datetime.utcnow().isoformat()),
+    )
+    cur.execute("INSERT INTO user_levels (user_id, level) VALUES (?, ?)", (1, 1))
+    xp_reward_service.xp_reward_service.grant_hidden_xp(
+        1, "gift", 15, conn=conn
+    )
+    conn.commit()
+    conn.close()
+
+    xp_reward_service.xp_reward_service.schedule_baseline_grant(1, hours=0)
+    scheduler_service.run_due_tasks()
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT amount FROM hidden_xp_rewards WHERE user_id = ? ORDER BY id",
+        (1,),
+    )
+    amounts = [row[0] for row in cur.fetchall()]
+    conn.close()
+
+    assert amounts == [15, 5]
+
+
+def test_baseline_skipped_when_cap_reached(tmp_path):
+    db = _setup_db(tmp_path)
+    set_config(XPConfig(daily_cap=20))
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO lifestyle (user_id, sleep_hours, drinking, stress, training_discipline, mental_health, nutrition, fitness, last_updated)"
+        " VALUES (?,?,?,?,?,?,?,?,?)",
+        (1, 8, "none", 20, 60, 70, 70, 70, datetime.utcnow().isoformat()),
+    )
+    cur.execute("INSERT INTO user_levels (user_id, level) VALUES (?, ?)", (1, 1))
+    xp_reward_service.xp_reward_service.grant_hidden_xp(
+        1, "gift", 20, conn=conn
+    )
+    conn.commit()
+    conn.close()
+
+    xp_reward_service.xp_reward_service.schedule_baseline_grant(1, hours=0)
+    scheduler_service.run_due_tasks()
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT COUNT(*) FROM hidden_xp_rewards WHERE user_id = ?",
+        (1,),
+    )
+    count = cur.fetchone()[0]
+    conn.close()
+
+    assert count == 1
 


### PR DESCRIPTION
## Summary
- enforce daily XP cap when granting baseline rewards
- test baseline rewards respecting or skipping at cap

## Testing
- `ruff check backend/services/xp_reward_service.py tests/test_xp_reward_baseline.py`
- `pytest tests/test_xp_reward_baseline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c093c17f1c8325a1952f70e7a3303c