### PR TITLE
Ensure metrics output ends with newline

### DIFF
--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -25,3 +25,9 @@ def test_histogram_observe():
     assert "test_histogram_bucket{label=\"value\",le=\"1.0\"} 1" in output
     assert "test_histogram_count{label=\"value\"} 1" in output
     assert "test_histogram_sum{label=\"value\"} 0.5" in output
+
+
+def test_generate_latest_has_trailing_newline():
+    c = Counter("newline_counter", "newline test")
+    c.labels().inc()
+    assert generate_latest().endswith(b"\n")

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -168,7 +168,7 @@ def generate_latest() -> bytes:
                 else:
                     lines.append(f"{c.name}_sum {data['sum']}")
                     lines.append(f"{c.name}_count {data['count']}")
-    return "\n".join(lines).encode("utf-8")
+    return ("\n".join(lines) + "\n").encode("utf-8")
 
 
 CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"


### PR DESCRIPTION
## Summary
- append newline to metrics exposition output
- verify trailing newline with a dedicated test

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'tests.realtime')*
- `pytest backend/tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68c096ea8c2c83258bb99f14d3133248