### PR TITLE
Fix refresh token expiry comparison

### DIFF
--- a/backend/auth/service.py
+++ b/backend/auth/service.py
@@ -127,7 +127,7 @@ class AuthService:
             user_id = int(row[0])
             if row[2] is not None:
                 raise ValueError("REFRESH_REVOKED")
-            if row[1] < _now().isoformat():
+            if datetime.fromisoformat(row[1]) < _now():
                 raise ValueError("REFRESH_EXPIRED")
             await conn.execute(
                 "UPDATE refresh_tokens SET revoked_at=datetime('now') WHERE token_hash=?",

--- a/backend/tests/auth/test_refresh_expiry.py
+++ b/backend/tests/auth/test_refresh_expiry.py
@@ -1,0 +1,40 @@
+import sqlite3
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.auth.service import AuthService
+
+
+def test_refresh_token_expired(tmp_path):
+    db_path = tmp_path / "auth.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE refresh_tokens (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            token_hash TEXT NOT NULL,
+            issued_at TEXT,
+            expires_at TEXT NOT NULL,
+            revoked_at TEXT,
+            user_agent TEXT,
+            ip TEXT
+        )"""
+    )
+    conn.commit()
+
+    svc = AuthService(db_path=str(db_path))
+    token = "expiredtoken"
+    token_hash = svc._hash_refresh(token)
+    past = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+    conn.execute(
+        "INSERT INTO refresh_tokens (user_id, token_hash, expires_at) VALUES (?,?,?)",
+        (1, token_hash, past),
+    )
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(svc.refresh(token))
+    assert str(exc.value) == "REFRESH_EXPIRED"


### PR DESCRIPTION
## Summary
- compare refresh token expiry using timezone-aware datetime
- add regression test for expired refresh token handling

## Testing
- `pytest backend/tests/auth/test_refresh_expiry.py -q`
- `pytest backend/tests/test_auth_flow.py -q` *(fails: email-validator is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c096e8a3f8832592efb5ea8a8d09c1