### PR TITLE
Log ChemistryService initialization failures and test

### DIFF
--- a/backend/services/chemistry_service.py
+++ b/backend/services/chemistry_service.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import random
 from pathlib import Path
 from typing import Callable
 
 from sqlalchemy import create_engine, func
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 
 from backend.models.player_chemistry import Base, PlayerChemistry
@@ -19,6 +21,8 @@ SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
 Base.metadata.create_all(bind=engine)
 
+logger = logging.getLogger(__name__)
+
 
 class ChemistryService:
     """Handles initialization and adjustment of player chemistry."""
@@ -29,8 +33,9 @@ class ChemistryService:
         self.session_factory = session_factory
         try:
             Base.metadata.create_all(bind=self.session_factory().get_bind())
-        except Exception:
-            pass
+        except SQLAlchemyError:
+            logger.exception("Failed to initialize ChemistryService database")
+            raise
 
     @staticmethod
     def _normalize(a_id: int, b_id: int) -> tuple[int, int]:

--- a/tests/test_chemistry_service.py
+++ b/tests/test_chemistry_service.py
@@ -1,0 +1,33 @@
+"""Tests for chemistry service initialization logging."""
+
+# ruff: noqa: E402,I001
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.extend([str(ROOT), str(ROOT / "backend")])
+
+from backend.services import chemistry_service
+from backend.services.chemistry_service import ChemistryService
+from backend.models.player_chemistry import Base
+
+def test_init_logs_and_raises_on_metadata_creation_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    chemistry_service.DB_PATH.unlink(missing_ok=True)
+
+    def failing_create_all(*args, **kwargs):
+        raise SQLAlchemyError("boom")
+
+    monkeypatch.setattr(Base.metadata, "create_all", failing_create_all)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SQLAlchemyError, match="boom"):
+            ChemistryService()
+
+    assert "Failed to initialize ChemistryService database" in caplog.text
+    chemistry_service.DB_PATH.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- add detailed logging and exception handling for ChemistryService initialization
- cover initialization error path with new test

## Testing
- `ruff check backend/services/chemistry_service.py tests/test_chemistry_service.py`
- `mypy backend/services/chemistry_service.py tests/test_chemistry_service.py` *(fails: aiosqlite.py arg-type, return-value)*
- `pytest tests/test_chemistry_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c096ea223c8325a44389415995b2eb