### PR TITLE
Handle S3 existence errors

### DIFF
--- a/backend/tests/test_storage_s3_mock.py
+++ b/backend/tests/test_storage_s3_mock.py
@@ -1,7 +1,12 @@
 import os
+import logging
+from unittest.mock import patch
+
 import boto3
 import pytest
 from moto import mock_aws
+from botocore.exceptions import ClientError
+
 from backend.storage.s3 import S3Storage
 
 @mock_aws
@@ -34,3 +39,38 @@ def test_s3_roundtrip(monkeypatch, tmp_path):
     # delete & exists
     store.delete("k/hello.txt")
     assert store.exists("k/hello.txt") is False
+
+
+@mock_aws
+def test_exists_missing_key(monkeypatch):
+    region = "eu-west-2"
+    bucket = "test-bucket"
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "x")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "y")
+
+    s3 = boto3.client("s3", region_name=region)
+    s3.create_bucket(Bucket=bucket, CreateBucketConfiguration={"LocationConstraint": region})
+
+    store = S3Storage(bucket=bucket, region=region, endpoint_url=None, force_path_style=True)
+    err = ClientError({"Error": {"Code": "NoSuchKey", "Message": "missing"}}, "HeadObject")
+    with patch.object(store.client, "head_object", side_effect=err):
+        assert store.exists("missing.txt") is False
+
+
+@mock_aws
+def test_exists_unexpected_failure(monkeypatch, caplog):
+    region = "eu-west-2"
+    bucket = "test-bucket"
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "x")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "y")
+
+    s3 = boto3.client("s3", region_name=region)
+    s3.create_bucket(Bucket=bucket, CreateBucketConfiguration={"LocationConstraint": region})
+
+    store = S3Storage(bucket=bucket, region=region, endpoint_url=None, force_path_style=True)
+    err = ClientError({"Error": {"Code": "500", "Message": "boom"}}, "HeadObject")
+    with patch.object(store.client, "head_object", side_effect=err):
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(ClientError):
+                store.exists("foo.txt")
+    assert "Client error checking existence" in caplog.text


### PR DESCRIPTION
## Summary
- add logging and detailed ClientError handling in S3 storage exists
- add tests for missing keys and unexpected failures

## Testing
- `pytest backend/tests/test_storage_s3_mock.py -q` *(fails: No module named 'boto3')*
- `pip install boto3 moto -q` *(fails: Could not find a version that satisfies the requirement boto3)*

------
https://chatgpt.com/codex/tasks/task_e_68c0982751048325ad69fea39d32ca6e