### PR TITLE
Prioritize unread notifications

### DIFF
--- a/backend/services/notifications_service.py
+++ b/backend/services/notifications_service.py
@@ -74,7 +74,7 @@ class NotificationsService:
                 """SELECT id, user_id, type, title, body, created_at, read_at
                        FROM notifications
                        WHERE user_id = ?
-                       ORDER BY COALESCE(read_at, '9999-12-31') IS NOT NULL, created_at DESC
+                       ORDER BY read_at IS NULL DESC, COALESCE(read_at, '9999-12-31'), created_at DESC
                        LIMIT ? OFFSET ?""",
                 (user_id, limit, offset),
             )

--- a/tests/test_notifications_service.py
+++ b/tests/test_notifications_service.py
@@ -1,0 +1,49 @@
+import sqlite3
+from backend.services.notifications_service import NotificationsService
+
+
+def _setup_db(path):
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE notifications (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                type TEXT NOT NULL,
+                title TEXT NOT NULL,
+                body TEXT,
+                created_at TEXT DEFAULT (datetime('now')),
+                read_at TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO notifications (user_id, type, title, body, created_at, read_at)
+            VALUES (1, 'system', 'read', '', '2023-01-01', '2023-01-05')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO notifications (user_id, type, title, body, created_at)
+            VALUES (1, 'system', 'unread1', '', '2023-01-02')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO notifications (user_id, type, title, body, created_at)
+            VALUES (1, 'system', 'unread2', '', '2023-01-03')
+            """
+        )
+        conn.commit()
+
+
+def test_unread_first(tmp_path):
+    db_path = tmp_path / 'db.sqlite'
+    _setup_db(db_path)
+    svc = NotificationsService(str(db_path))
+    items = svc.list(1)
+    titles = [i['title'] for i in items]
+    assert titles == ['unread2', 'unread1', 'read']
+    assert items[0]['read_at'] is None
+    assert items[-1]['read_at'] is not None


### PR DESCRIPTION
## Summary
- Sort unread notifications first then by read/read-at dates
- Test that unread notifications are ordered before read ones

## Testing
- `pytest -q` *(fails: A parameter-less dependency must have a callable dependency, import errors)*
- `PYTHONPATH=. pytest tests/test_notifications_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0980f465c8325aecdeb8b59d3174e