### PR TITLE
Add JWT decode validations

### DIFF
--- a/jwt.py
+++ b/jwt.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import hmac
 import json
+import time
 from typing import Any, Dict, List, Optional
 
 DEFAULT_ALG = "HS256"
@@ -29,10 +30,65 @@ def decode(
     leeway: int = 0,
     options: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    header_b64, payload_b64, signature_b64 = token.split(".")
+    algorithms = algorithms or [DEFAULT_ALG]
+    opts = {
+        "verify_exp": True,
+        "verify_nbf": True,
+        "verify_iat": True,
+        "verify_iss": True,
+        "verify_aud": True,
+    }
+    if options:
+        opts.update(options)
+
+    try:
+        header_b64, payload_b64, signature_b64 = token.split(".")
+    except ValueError as exc:  # not enough values to unpack
+        raise ValueError("Invalid token") from exc
+
+    header = json.loads(base64.urlsafe_b64decode(header_b64 + "=="))
+    alg = header.get("alg", DEFAULT_ALG)
+    if alg not in algorithms:
+        raise ValueError("Algorithm not allowed")
+    if alg != DEFAULT_ALG:
+        raise ValueError("Unsupported algorithm")
+
     signing_input = f"{header_b64}.{payload_b64}".encode()
     sig = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
     if _b64(sig) != signature_b64:
         raise ValueError("Invalid signature")
+
     payload = json.loads(base64.urlsafe_b64decode(payload_b64 + "=="))
+
+    now = int(time.time())
+    if opts["verify_exp"]:
+        exp = payload.get("exp")
+        if exp is None:
+            raise ValueError("Missing exp claim")
+        if now > int(exp) + leeway:
+            raise ValueError("Token expired")
+
+    if opts["verify_nbf"] and "nbf" in payload:
+        if now < int(payload["nbf"]) - leeway:
+            raise ValueError("Token not yet valid")
+
+    if opts["verify_iat"] and "iat" in payload:
+        if now + leeway < int(payload["iat"]):
+            raise ValueError("Token used before issued")
+
+    if issuer is not None and opts["verify_iss"]:
+        if payload.get("iss") != issuer:
+            raise ValueError("Invalid issuer")
+
+    if audience is not None and opts["verify_aud"]:
+        aud = payload.get("aud")
+        if aud is None:
+            raise ValueError("Missing audience")
+        if isinstance(audience, (list, tuple, set)):
+            if aud not in audience:
+                raise ValueError("Invalid audience")
+        else:
+            if aud != audience:
+                raise ValueError("Invalid audience")
+
     return payload


### PR DESCRIPTION
## Summary
- Validate header algorithm against allowed algorithms when decoding
- Enforce issuer and audience claims with optional leeway and claim verification options
- Check standard time-based claims (exp, nbf, iat) before returning payload

## Testing
- `ruff check jwt.py`
- `pytest tests/test_consume_drug.py -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c097f3ec4c83259dd243b1a2cce260