### PR TITLE
Log Discord notification failures

### DIFF
--- a/backend/services/notifications_service.py
+++ b/backend/services/notifications_service.py
@@ -1,6 +1,7 @@
 # File: backend/services/notifications_service.py
 
 import asyncio
+import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -16,8 +17,10 @@ except Exception:  # pragma: no cover - fallback or noop if unavailable
 
         def send_message(*args, **kwargs):  # type: ignore
             return None
-from utils.db import get_conn
 from backend.realtime.social_gateway import publish_notification
+from utils.db import get_conn
+
+logger = logging.getLogger(__name__)
 
 
 class NotificationsError(Exception):
@@ -50,7 +53,7 @@ class NotificationsService:
                 content = f"{title}\n{body}".strip()
                 send_message(content)
             except DiscordServiceError as exc:
-                print(f"Discord notification failed: {exc}")
+                logger.warning("Discord notification failed: %s", exc)
 
         # Fire-and-forget realtime event
         try:

--- a/tests/test_notifications_logging.py
+++ b/tests/test_notifications_logging.py
@@ -1,0 +1,47 @@
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from backend.services import notifications_service as ns
+
+
+@pytest.fixture
+def temp_db(tmp_path):
+    db = tmp_path / "notif.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """
+        CREATE TABLE notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            type TEXT NOT NULL,
+            title TEXT NOT NULL,
+            body TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            read_at TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    return str(db)
+
+
+def test_discord_warning_logged(monkeypatch, caplog, temp_db):
+    service = ns.NotificationsService(db_path=temp_db)
+
+    def mock_send_message(content):
+        raise ns.DiscordServiceError("boom")
+
+    monkeypatch.setattr(ns, "send_message", mock_send_message)
+    monkeypatch.setattr(ns, "publish_notification", lambda *a, **k: None)
+    monkeypatch.setattr(ns.asyncio, "create_task", lambda *a, **k: None)
+
+    with caplog.at_level(logging.WARNING):
+        service.create(1, "title", "body", send_to_discord=True)
+
+    assert "Discord notification failed: boom" in caplog.text


### PR DESCRIPTION
## Summary
- add module logger to `notifications_service`
- log Discord send failures as warnings
- cover Discord logging via pytest

## Testing
- `ruff check backend/services/notifications_service.py tests/test_notifications_logging.py`
- `pytest tests/test_notifications_logging.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'tests.realtime' and other module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0981657cc832591a86fe7d8988ad8