### PR TITLE
Improve tour service error handling and add comprehensive tests

### DIFF
--- a/tests/test_auth_service_refresh.py
+++ b/tests/test_auth_service_refresh.py
@@ -1,0 +1,74 @@
+import asyncio
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+import backend.auth as backend_auth
+import backend.core as backend_core
+sys.modules.setdefault("auth", backend_auth)
+sys.modules.setdefault("core", backend_core)
+
+from backend.auth.service import AuthService
+
+
+def test_refresh_handles_timezone(tmp_path, monkeypatch):
+    db = tmp_path / "auth.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """
+        CREATE TABLE refresh_tokens (
+            user_id INTEGER,
+            token_hash TEXT PRIMARY KEY,
+            expires_at TEXT,
+            revoked_at TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE audit_log (
+            user_id INTEGER,
+            action TEXT,
+            meta TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    svc = AuthService(str(db))
+    token = "refresh-token"
+    token_hash = svc._hash_refresh(token)
+    expires_at = "2023-09-30T00:00:00-05:00"  # 5 hours behind UTC
+
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO refresh_tokens (user_id, token_hash, expires_at) VALUES (1, ?, ?)",
+        (token_hash, expires_at),
+    )
+    conn.commit()
+    conn.close()
+
+    async def fake_make_access_token(user_id: int) -> str:
+        return "access"
+
+    async def fake_new_refresh_token(user_id: int, user_agent: str = "", ip: str = ""):
+        return {"refresh_token": "new", "expires_at": "2030-01-01T00:00:00+00:00"}
+
+    svc._make_access_token = fake_make_access_token
+    svc._new_refresh_token = fake_new_refresh_token
+
+    monkeypatch.setattr(
+        "backend.auth.service._now", lambda: datetime(2023, 9, 30, 2, tzinfo=timezone.utc)
+    )
+
+    result = asyncio.run(svc.refresh(token))
+    assert result["access_token"] == "access"
+

--- a/tests/test_jwt_module.py
+++ b/tests/test_jwt_module.py
@@ -1,0 +1,57 @@
+import time
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import jwt
+
+
+def _base_payload():
+    now = int(time.time())
+    return {"iss": "me", "aud": "you", "exp": now + 10}
+
+
+def test_decode_valid_claims():
+    token = jwt.encode(_base_payload(), "secret")
+    data = jwt.decode(token, "secret", issuer="me", audience="you")
+    assert data["aud"] == "you"
+
+
+def test_decode_rejects_algorithm():
+    token = jwt.encode(_base_payload(), "secret")
+    with pytest.raises(ValueError, match="Algorithm not allowed"):
+        jwt.decode(token, "secret", algorithms=["HS512"], issuer="me", audience="you")
+
+
+def test_decode_validates_issuer_and_audience():
+    token = jwt.encode(_base_payload(), "secret")
+    with pytest.raises(ValueError, match="Invalid issuer"):
+        jwt.decode(token, "secret", issuer="other", audience="you")
+    with pytest.raises(ValueError, match="Invalid audience"):
+        jwt.decode(token, "secret", issuer="me", audience="them")
+
+
+def test_leeway_and_options_control_expiry():
+    now = int(time.time())
+    payload = {"iss": "me", "aud": "you", "exp": now - 2}
+    token = jwt.encode(payload, "secret")
+
+    with pytest.raises(ValueError, match="Token expired"):
+        jwt.decode(token, "secret", issuer="me", audience="you")
+
+    # Leeway allows short expiry drift
+    jwt.decode(token, "secret", issuer="me", audience="you", leeway=5)
+
+    # options can disable expiration verification entirely
+    jwt.decode(
+        token,
+        "secret",
+        issuer="me",
+        audience="you",
+        options={"verify_exp": False},
+    )
+

--- a/tests/test_metrics_generate_latest.py
+++ b/tests/test_metrics_generate_latest.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from backend.utils.metrics import Counter, _REGISTRY, generate_latest
+
+
+def test_generate_latest_has_trailing_newline():
+    _REGISTRY.clear()
+    Counter("requests_total", "Number of requests").labels()
+    data = generate_latest()
+    assert data.endswith(b"\n")
+

--- a/tests/test_notifications_service.py
+++ b/tests/test_notifications_service.py
@@ -1,4 +1,10 @@
 import sqlite3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
 from backend.services.notifications_service import NotificationsService
 
 

--- a/tests/test_s3_exists.py
+++ b/tests/test_s3_exists.py
@@ -1,0 +1,77 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+
+def make_storage(monkeypatch):
+    dummy_client = types.SimpleNamespace()
+    monkeypatch.setitem(
+        sys.modules,
+        "boto3",
+        types.SimpleNamespace(client=lambda *a, **k: dummy_client),
+    )
+
+    class DummyConfig:
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        "botocore.client",
+        types.SimpleNamespace(Config=DummyConfig),
+    )
+
+    class DummyClientError(Exception):
+        def __init__(self, response, operation_name):
+            self.response = response
+            self.operation_name = operation_name
+
+    monkeypatch.setitem(
+        sys.modules,
+        "botocore.exceptions",
+        types.SimpleNamespace(ClientError=DummyClientError),
+    )
+
+    s3_module = importlib.import_module("backend.storage.s3")
+    importlib.reload(s3_module)
+    storage = s3_module.S3Storage("bucket", "region")
+    return storage, dummy_client, DummyClientError
+
+
+def test_exists_returns_false_for_missing_key(monkeypatch):
+    storage, client, ClientError = make_storage(monkeypatch)
+
+    def head_object(**kwargs):
+        raise ClientError({"Error": {"Code": "404"}}, "head_object")
+
+    client.head_object = head_object
+    assert storage.exists("missing") is False
+
+
+def test_exists_raises_unexpected_client_error(monkeypatch):
+    storage, client, ClientError = make_storage(monkeypatch)
+
+    def head_object(**kwargs):
+        raise ClientError({"Error": {"Code": "500"}}, "head_object")
+
+    client.head_object = head_object
+    with pytest.raises(ClientError):
+        storage.exists("other")
+
+
+def test_exists_raises_other_exceptions(monkeypatch):
+    storage, client, _ = make_storage(monkeypatch)
+
+    def head_object(**kwargs):
+        raise RuntimeError("boom")
+
+    client.head_object = head_object
+    with pytest.raises(RuntimeError):
+        storage.exists("key")
+

--- a/tests/test_tour_service_logging.py
+++ b/tests/test_tour_service_logging.py
@@ -1,0 +1,117 @@
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+import backend.services as backend_services
+sys.modules.setdefault("services", backend_services)
+
+import backend.core as backend_core
+sys.modules.setdefault("core", backend_core)
+
+import backend.core.errors as core_errors
+sys.modules.setdefault("core.errors", core_errors)
+
+
+
+class AppError(Exception):
+    pass
+
+
+class VenueConflictError(AppError):
+    pass
+
+
+class TourMinStopsError(AppError):
+    pass
+
+
+core_errors.AppError = AppError
+core_errors.VenueConflictError = VenueConflictError
+core_errors.TourMinStopsError = TourMinStopsError
+
+import backend.models as backend_models
+sys.modules.setdefault("models", backend_models)
+
+import backend.services.tour_service as tour_service_module
+from backend.services.tour_service import TourService
+
+
+class DummyEconomy:
+    def ensure_schema(self):
+        pass
+
+
+def setup_db(path):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE tours (id INTEGER PRIMARY KEY, band_id INTEGER, name TEXT, status TEXT DEFAULT 'draft', created_at TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE tour_stops (id INTEGER PRIMARY KEY, tour_id INTEGER, status TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO tours (id, band_id, name, status) VALUES (1, 1, 't', 'draft')"
+    )
+    conn.execute("INSERT INTO tour_stops (tour_id, status) VALUES (1, 'pending')")
+    conn.execute("INSERT INTO tour_stops (tour_id, status) VALUES (1, 'pending')")
+    conn.commit()
+    conn.close()
+
+
+def test_init_logs_and_raises(monkeypatch, caplog, tmp_path):
+    class BadEconomy(DummyEconomy):
+        def ensure_schema(self):
+            raise RuntimeError("boom")
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError):
+            TourService(db_path=None, economy=BadEconomy())
+
+    assert "Failed to ensure economy schema" in caplog.text
+
+
+def test_confirm_tour_logs_achievement_failure(monkeypatch, caplog, tmp_path):
+    db = tmp_path / "tour.db"
+    setup_db(db)
+    monkeypatch.setattr(tour_service_module, "get_conn", sqlite3.connect)
+
+    class BadAchievement:
+        def grant(self, *args, **kwargs):
+            raise AppError("nope")
+
+    svc = TourService(
+        db_path=str(db),
+        achievements=BadAchievement(),
+        economy=DummyEconomy(),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        tour = svc.confirm_tour(1)
+    assert tour["status"] == "confirmed"
+    assert "Failed to grant achievement" in caplog.text
+
+
+def test_confirm_tour_reraises_unexpected(monkeypatch, tmp_path):
+    db = tmp_path / "tour2.db"
+    setup_db(db)
+    monkeypatch.setattr(tour_service_module, "get_conn", sqlite3.connect)
+
+    class BoomAchievement:
+        def grant(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    svc = TourService(
+        db_path=str(db),
+        achievements=BoomAchievement(),
+        economy=DummyEconomy(),
+    )
+
+    with pytest.raises(RuntimeError):
+        svc.confirm_tour(1)
+


### PR DESCRIPTION
## Summary
- refine tour service initialization and achievement handling with explicit logging and re-raising
- add focused unit tests for JWT validation, auth refresh timing, Prometheus metrics, S3 existence checks, and tour service logging

## Testing
- `pytest tests/test_jwt_module.py tests/test_auth_service_refresh.py tests/test_notifications_service.py tests/test_notifications_logging.py tests/test_metrics_generate_latest.py tests/test_s3_exists.py tests/test_tour_service_logging.py tests/test_chemistry_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68c09a0121a88325b1e72893f38bb5c4