### PR TITLE
feat: add auth token handling across frontend

### DIFF
--- a/frontend/pages/login.html
+++ b/frontend/pages/login.html
@@ -18,20 +18,24 @@
   <p id="error" data-i18n="login.error" style="color:red; display:none;"></p>
   <script type="module">
     import { initI18n, t, getLocale } from '../utils/i18n.js';
+    import { setToken } from '../utils/auth.js';
     await initI18n();
     document.getElementById('login-form').addEventListener('submit', async (e) => {
       e.preventDefault();
       const username = document.getElementById('username').value;
       const password = document.getElementById('password').value;
       try {
-        const res = await fetch('/auth/login', {
+        const res = await fetch('/auth/token', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Accept-Language': getLocale() },
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept-Language': getLocale()
+          },
           body: new URLSearchParams({ username, password })
         });
         if (!res.ok) throw new Error('Login failed');
         const data = await res.json();
-        localStorage.setItem('jwt', data.access_token);
+        setToken(data.access_token);
         window.location.href = '/dashboard';
       } catch (err) {
         const errEl = document.getElementById('error');

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ThemeProvider } from '../context/ThemeContext';
 import ThemeToggle from './ThemeToggle';
+import { getToken } from '../../utils/auth.js';
 
 declare global {
   interface Window {
@@ -10,11 +11,21 @@ declare global {
 
 const Header: React.FC = () => {
   const [open, setOpen] = useState(false);
+  const [user, setUser] = useState<{ username?: string; sub?: string } | null>(null);
   const navRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     if (window.initGlobalSearch && navRef.current) {
       window.initGlobalSearch(navRef.current);
+    }
+    const token = getToken();
+    if (token) {
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1]));
+        setUser(payload);
+      } catch {
+        // ignore parse errors
+      }
     }
   }, []);
 
@@ -24,6 +35,7 @@ const Header: React.FC = () => {
         <button className="hamburger" onClick={() => setOpen((o) => !o)}>☰</button>
         <nav ref={navRef} className={open ? 'open' : ''}>
           <a href="index.html">Home</a>
+          {user ? <span className="user">{user.username || user.sub}</span> : <a href="login.html">Login</a>}
           <a href="profile.html">Profile</a>
           <ThemeToggle />
         </nav>

--- a/frontend/utils/auth.js
+++ b/frontend/utils/auth.js
@@ -1,0 +1,16 @@
+export function getToken() {
+  return localStorage.getItem('jwt');
+}
+
+export function setToken(token) {
+  localStorage.setItem('jwt', token);
+}
+
+export async function authFetch(input, init = {}) {
+  const token = getToken();
+  const headers = new Headers(init.headers || {});
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return fetch(input, { ...init, headers });
+}


### PR DESCRIPTION
## Summary
- add auth helper for managing JWTs and authenticated fetch calls
- wire login page to JWT token endpoint and persist tokens
- surface logged-in user in navbar and profile pages using token state

## Testing
- `npm test` *(fails: Invalid package.json)*
- `pytest -q` *(fails: ModuleNotFoundError and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a0d46de88325a6b5437288e1dc97