### PR TITLE
Add band and avatar creation with dashboard

### DIFF
--- a/frontend/components/profile.js
+++ b/frontend/components/profile.js
@@ -25,6 +25,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   const avatarInput = document.getElementById('avatar-input');
   const chemTbody = document.querySelector('#chemistry-table tbody');
 
+  const bandForm = document.getElementById('band-form');
+  const bandNameInput = document.getElementById('band-name');
+  const bandGenreInput = document.getElementById('band-genre');
+  const bandFounderInput = document.getElementById('band-founder');
+  const bandError = document.getElementById('band-error');
+
+  if (bandFounderInput && USER_ID) bandFounderInput.value = USER_ID;
+
+  const avatarForm = document.getElementById('avatar-form');
+  const avatarError = document.getElementById('avatar-error');
+
   try {
     const res = await authFetch(`/api/user-settings/profile/${USER_ID}`);
     if (res && res.ok) {
@@ -74,4 +85,78 @@ document.addEventListener('DOMContentLoaded', async () => {
       await authFetch('/api/avatars', { method: 'POST', body: fd });
     }
   });
+
+  if (bandForm) {
+    bandForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (bandError) bandError.textContent = '';
+      const payload = {
+        name: bandNameInput.value,
+        genre: bandGenreInput.value,
+        founder_id: parseInt(bandFounderInput.value, 10),
+      };
+      const res = await authFetch('/api/bands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        bandForm.reset();
+        if (bandFounderInput && USER_ID) bandFounderInput.value = USER_ID;
+      } else {
+        let errText = 'Failed to create band';
+        try {
+          const data = await res.json();
+          if (Array.isArray(data.detail)) {
+            errText = data.detail.map((d) => d.msg).join(', ');
+          } else if (data.detail) {
+            errText = data.detail;
+          }
+        } catch (err) {
+          // ignore parse errors
+        }
+        if (bandError) bandError.textContent = errText;
+      }
+    });
+  }
+
+  if (avatarForm) {
+    avatarForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (avatarError) avatarError.textContent = '';
+      const payload = {
+        character_id: parseInt(document.getElementById('avatar-character-id').value, 10),
+        nickname: document.getElementById('avatar-nickname').value,
+        body_type: document.getElementById('avatar-body').value,
+        skin_tone: document.getElementById('avatar-skin').value,
+        face_shape: document.getElementById('avatar-face').value,
+        hair_style: document.getElementById('avatar-hair-style').value,
+        hair_color: document.getElementById('avatar-hair-color').value,
+        top_clothing: document.getElementById('avatar-top').value,
+        bottom_clothing: document.getElementById('avatar-bottom').value,
+        shoes: document.getElementById('avatar-shoes').value,
+      };
+      const res = await authFetch('/api/avatars', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        avatarForm.reset();
+      } else {
+        let errText = 'Failed to create avatar';
+        try {
+          const data = await res.json();
+          if (Array.isArray(data.detail)) {
+            errText = data.detail.map((d) => d.msg).join(', ');
+          } else if (data.detail) {
+            errText = data.detail;
+          }
+        } catch (err) {
+          // ignore parse errors
+        }
+        if (avatarError) avatarError.textContent = errText;
+      }
+    });
+  }
 });

--- a/frontend/pages/band_dashboard.html
+++ b/frontend/pages/band_dashboard.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Band Dashboard</title>
+</head>
+<body>
+  <h1>Band & Avatar Dashboard</h1>
+
+  <section>
+    <h2>Bands</h2>
+    <ul id="band-list"></ul>
+  </section>
+
+  <section>
+    <h2>Avatars</h2>
+    <ul id="avatar-list"></ul>
+  </section>
+
+  <script src="../components/themeToggle.js"></script>
+  <script src="../components/globalSearch.js"></script>
+  <script type="module">
+    import { authFetch } from '../utils/auth.js';
+
+    async function load() {
+      const bandRes = await authFetch('/api/bands');
+      if (bandRes.ok) {
+        const bands = await bandRes.json();
+        const list = document.getElementById('band-list');
+        list.innerHTML = '';
+        bands.forEach(b => {
+          const li = document.createElement('li');
+          li.textContent = `${b.id}: ${b.name} (${b.genre})`;
+          list.appendChild(li);
+        });
+      }
+
+      const avatarRes = await authFetch('/api/avatars');
+      if (avatarRes.ok) {
+        const avatars = await avatarRes.json();
+        const list = document.getElementById('avatar-list');
+        list.innerHTML = '';
+        avatars.forEach(a => {
+          const li = document.createElement('li');
+          li.textContent = `${a.id}: ${a.nickname}`;
+          list.appendChild(li);
+        });
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', load);
+  </script>
+</body>
+</html>

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -24,6 +24,70 @@
     </div>
     <button type="submit">Save</button>
   </form>
+
+  <h2>Create Band</h2>
+  <form id="band-form">
+    <div>
+      <label for="band-name">Name</label>
+      <input type="text" id="band-name" required />
+    </div>
+    <div>
+      <label for="band-genre">Genre</label>
+      <input type="text" id="band-genre" required />
+    </div>
+    <div>
+      <label for="band-founder">Founder ID</label>
+      <input type="number" id="band-founder" required />
+    </div>
+    <button type="submit">Create Band</button>
+    <div class="error" id="band-error"></div>
+  </form>
+
+  <h2>Create Avatar</h2>
+  <form id="avatar-form">
+    <div>
+      <label for="avatar-character-id">Character ID</label>
+      <input type="number" id="avatar-character-id" required />
+    </div>
+    <div>
+      <label for="avatar-nickname">Nickname</label>
+      <input type="text" id="avatar-nickname" required />
+    </div>
+    <div>
+      <label for="avatar-body">Body Type</label>
+      <input type="text" id="avatar-body" required />
+    </div>
+    <div>
+      <label for="avatar-skin">Skin Tone</label>
+      <input type="text" id="avatar-skin" required />
+    </div>
+    <div>
+      <label for="avatar-face">Face Shape</label>
+      <input type="text" id="avatar-face" required />
+    </div>
+    <div>
+      <label for="avatar-hair-style">Hair Style</label>
+      <input type="text" id="avatar-hair-style" required />
+    </div>
+    <div>
+      <label for="avatar-hair-color">Hair Color</label>
+      <input type="text" id="avatar-hair-color" required />
+    </div>
+    <div>
+      <label for="avatar-top">Top Clothing</label>
+      <input type="text" id="avatar-top" required />
+    </div>
+    <div>
+      <label for="avatar-bottom">Bottom Clothing</label>
+      <input type="text" id="avatar-bottom" required />
+    </div>
+    <div>
+      <label for="avatar-shoes">Shoes</label>
+      <input type="text" id="avatar-shoes" required />
+    </div>
+    <button type="submit">Create Avatar</button>
+    <div class="error" id="avatar-error"></div>
+  </form>
   <h2>Chemistry</h2>
   <table id="chemistry-table">
     <thead>


### PR DESCRIPTION
## Summary
- Extend profile page with forms to create bands and avatars, posting to API endpoints and showing validation errors
- Introduce band dashboard to list bands and avatars for quick confirmation of new submissions
- Wire up client-side logic in profile.js to handle POST requests and inline error handling

## Testing
- `pytest` (fails: ModuleNotFoundError and other errors during collection)
- `npm --prefix frontend test` (fails: package.json parse error)


------
https://chatgpt.com/codex/tasks/task_e_68c0a4889bbc8325822fcd66c820afff