### PR TITLE
Add gig booking validations and results page

### DIFF
--- a/backend/models/gig.py
+++ b/backend/models/gig.py
@@ -1,17 +1,27 @@
-from sqlalchemy import Column, Integer, Float, Boolean, String, Date, ForeignKey
+from sqlalchemy import Column, Integer, Float, Boolean, String, Date, Time
+
 from database import Base
 
+
 class Gig(Base):
+    """Database model representing a booked gig."""
+
     __tablename__ = "gigs"
 
     id = Column(Integer, primary_key=True)
     band_id = Column(Integer, nullable=False)
     venue_id = Column(Integer, nullable=False)
     date = Column(Date, nullable=False)
+    start_time = Column(Time, nullable=False)
+    end_time = Column(Time, nullable=False)
     ticket_price = Column(Float, nullable=False)
+    guarantee = Column(Float, default=0.0)
+    ticket_split = Column(Float, default=0.0)
     support_band_id = Column(Integer, nullable=True)
     promoted = Column(Boolean, default=False)
     acoustic = Column(Boolean, default=False)
     audience_size = Column(Integer, default=0)
     total_earned = Column(Float, default=0.0)
+    xp_gained = Column(Integer, default=0)
+    fans_gained = Column(Integer, default=0)
     review = Column(String)

--- a/backend/routes/gig.py
+++ b/backend/routes/gig.py
@@ -2,19 +2,80 @@ from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from models.gig import Gig
+from models.venues import Venue
 from schemas.gig import GigCreate, GigOut
 from database import get_db
 from utils.i18n import _
 
-# Simulated fame and skill lookup (to be replaced with real logic or DB queries)
+from services.band_service import BandService
+from services.skill_service import skill_service as skill_service_instance
+from backend.models.skill import Skill
+from seeds.skill_seed import SKILL_NAME_TO_ID
+
+band_service = BandService()
+skill_service = skill_service_instance
+ACOUSTIC_SKILL = Skill(
+    id=SKILL_NAME_TO_ID.get("studio_acoustics", 0),
+    name="studio_acoustics",
+    category="creative",
+)
+
+
 def get_band_fame(band_id: int, db: Session) -> int:
-    return 350  # Simulated fame
+    info = band_service.get_band_info(band_id)
+    return info.get("fame", 0) if info else 0
+
 
 def get_band_acoustic_skill_score(band_id: int, db: Session) -> int:
-    return 80  # Simulated skill
+    info = band_service.get_band_info(band_id)
+    members = info.get("members", []) if info else []
+    if not members:
+        return 0
+    total = 0
+    for m in members:
+        total += skill_service.train(m["user_id"], ACOUSTIC_SKILL, 0).level
+    return total // len(members)
+
 
 def is_band_solo(band_id: int, db: Session) -> bool:
-    return False  # Simulated solo check
+    info = band_service.get_band_info(band_id)
+    members = info.get("members", []) if info else []
+    return len(members) <= 1
+
+
+def band_has_conflict(band_id: int, date, start, end, db: Session) -> bool:
+    return (
+        db.query(Gig)
+        .filter(
+            Gig.band_id == band_id,
+            Gig.date == date,
+            Gig.start_time < end,
+            Gig.end_time > start,
+        )
+        .first()
+        is not None
+    )
+
+
+def venue_has_conflict(venue_id: int, date, start, end, db: Session) -> bool:
+    return (
+        db.query(Gig)
+        .filter(
+            Gig.venue_id == venue_id,
+            Gig.date == date,
+            Gig.start_time < end,
+            Gig.end_time > start,
+        )
+        .first()
+        is not None
+    )
+
+
+def get_venue_capacity(venue_id: int, db: Session) -> int:
+    venue = db.query(Venue).filter(Venue.id == venue_id).first()
+    if not venue:
+        raise HTTPException(status_code=404, detail=_("Venue not found"))
+    return venue.capacity
 
 router = APIRouter()
 
@@ -28,7 +89,9 @@ def book_gig(
     db: Session = Depends(get_db),
     user_id: int = Depends(get_current_user_id),
 ):
-    """Create a gig with acoustic eligibility checks."""
+    """Create a gig with eligibility, conflict and payout checks."""
+
+    # Acoustic eligibility using real services
     if gig.acoustic:
         if is_band_solo(gig.band_id, db):
             skill = get_band_acoustic_skill_score(gig.band_id, db)
@@ -46,7 +109,31 @@ def book_gig(
                     detail=_("Band not eligible for acoustic performance (min fame: 300, skill: 70)."),
                 )
 
-    new_gig = Gig(**gig.dict())
+    # Date/time conflict checks
+    if band_has_conflict(gig.band_id, gig.date, gig.start_time, gig.end_time, db):
+        raise HTTPException(status_code=400, detail=_("Band already has a gig at that time."))
+    if venue_has_conflict(gig.venue_id, gig.date, gig.start_time, gig.end_time, db):
+        raise HTTPException(status_code=400, detail=_("Venue is not available at that time."))
+
+    # Capacity and payout calculations
+    capacity = get_venue_capacity(gig.venue_id, db)
+    expected = gig.expected_audience or capacity
+    if expected > capacity:
+        raise HTTPException(status_code=400, detail=_("Expected audience exceeds venue capacity."))
+
+    payout = gig.guarantee + expected * gig.ticket_price * gig.ticket_split
+    xp_gain = expected // 10
+    fans_gain = expected // 5
+
+    data = gig.dict()
+    data.pop("expected_audience", None)
+    new_gig = Gig(
+        **data,
+        audience_size=expected,
+        total_earned=payout,
+        xp_gained=xp_gain,
+        fans_gained=fans_gain,
+    )
     db.add(new_gig)
     db.commit()
     db.refresh(new_gig)

--- a/backend/schemas/gig.py
+++ b/backend/schemas/gig.py
@@ -1,12 +1,17 @@
 from pydantic import BaseModel
-from datetime import date
+from datetime import date, time
 from typing import Optional
 
 class GigCreate(BaseModel):
     band_id: int
     venue_id: int
     date: date
+    start_time: time
+    end_time: time
     ticket_price: float
+    guarantee: float = 0.0
+    ticket_split: float = 0.0
+    expected_audience: int = 0
     support_band_id: Optional[int] = None
     promoted: Optional[bool] = False
     acoustic: Optional[bool] = False
@@ -16,12 +21,18 @@ class GigOut(BaseModel):
     band_id: int
     venue_id: int
     date: date
+    start_time: time
+    end_time: time
     ticket_price: float
+    guarantee: float
+    ticket_split: float
     support_band_id: Optional[int]
     promoted: bool
     acoustic: bool
     audience_size: int
     total_earned: float
+    xp_gained: int
+    fans_gained: int
     review: Optional[str]
 
     class Config:

--- a/frontend/pages/gig_result.html
+++ b/frontend/pages/gig_result.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Gig Result</title>
+</head>
+<body>
+  <h2>Gig Performance Results</h2>
+  <div id="results">Loading...</div>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const bandId = params.get('band_id');
+    async function load() {
+      if (!bandId) {
+        document.getElementById('results').innerText = 'Band ID required';
+        return;
+      }
+      try {
+        const res = await fetch(`/gigs/${bandId}`);
+        const gigs = await res.json();
+        if (!Array.isArray(gigs) || gigs.length === 0) {
+          document.getElementById('results').innerText = 'No gigs found';
+          return;
+        }
+        const gig = gigs[gigs.length - 1];
+        document.getElementById('results').innerText = `XP: ${gig.xp_gained}\nFans: ${gig.fans_gained}\nCash: ${gig.total_earned}`;
+      } catch (err) {
+        document.getElementById('results').innerText = 'Error loading results';
+      }
+    }
+    load();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- connect gig booking to band and skill services
- enforce venue capacity and schedule conflicts while calculating payouts
- record XP, fans and cash and display on new gig results page

## Testing
- `pytest backend/tests/routes/test_gig_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0a59e43488325a39e6e11c4c8e2c6