### PR TITLE
Add gig ledger entries and band dashboard

### DIFF
--- a/backend/services/gig_service.py
+++ b/backend/services/gig_service.py
@@ -7,6 +7,7 @@ from backend.services import fan_service
 from backend.services.skill_service import skill_service
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
+from backend.services.economy_service import EconomyService
 
 
 class AvatarService:  # minimal stub for testing
@@ -16,6 +17,8 @@ class AvatarService:  # minimal stub for testing
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
 avatar_service = AvatarService()
+economy_service = EconomyService()
+economy_service.ensure_schema()
 
 
 def create_gig(band_id: int, city: str, venue_size: int, date: str, ticket_price: int) -> dict:
@@ -138,6 +141,8 @@ def simulate_gig_result(gig_id: int):
 
     conn.commit()
     conn.close()
+
+    economy_service.record_gig_payout(band_id, earnings)
 
     # Boost fans after gig
     fan_service.boost_fans_after_gig(band_id, city, attendance)

--- a/backend/tests/economy/test_gig_ledger.py
+++ b/backend/tests/economy/test_gig_ledger.py
@@ -1,0 +1,80 @@
+import sqlite3
+import types
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from backend.economy.models import Account, LedgerEntry, Transaction as TransactionModel
+from backend.services.economy_service import EconomyService
+import backend.services.gig_service as gig_service
+
+
+class DummyFanService:
+    def get_band_fan_stats(self, band_id):
+        return {"total_fans": 100, "average_loyalty": 50}
+
+    def boost_fans_after_gig(self, band_id, city, attendance):
+        pass
+
+
+class DummySkillService:
+    def train(self, uid, skill, amount):
+        return types.SimpleNamespace(level=50)
+
+    def get_category_multiplier(self, band_id, category):
+        return 1.0
+
+    def train_with_method(self, band_id, skill, method, difficulty):
+        pass
+
+
+def test_gig_completion_creates_ledger_entry(tmp_path):
+    db_file = tmp_path / "gig.db"
+
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE gigs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            band_id INTEGER,
+            city TEXT,
+            venue_size INTEGER,
+            date TEXT,
+            ticket_price INTEGER,
+            status TEXT,
+            attendance INTEGER,
+            revenue INTEGER,
+            fame_gain INTEGER
+        )
+        """
+    )
+    cur.execute(
+        "INSERT INTO gigs (band_id, city, venue_size, date, ticket_price, status) VALUES (1, 'NY', 100, '2025-01-01', 10, 'scheduled')"
+    )
+    conn.commit()
+    conn.close()
+
+    gig_service.DB_PATH = db_file
+    gig_service.economy_service = EconomyService(db_path=db_file)
+    gig_service.economy_service.ensure_schema()
+    gig_service.fan_service = DummyFanService()
+    gig_service.skill_service = DummySkillService()
+
+    result = gig_service.simulate_gig_result(1)
+
+    engine = create_engine(f"sqlite:///{db_file}")
+    with Session(engine) as session:
+        acct_id = session.execute(
+            select(Account.id).where(Account.user_id == 1)
+        ).scalar_one()
+        entry = session.execute(
+            select(LedgerEntry)
+            .where(LedgerEntry.account_id == acct_id)
+            .order_by(LedgerEntry.id.desc())
+        ).scalar_one()
+        tx = session.execute(
+            select(TransactionModel).where(TransactionModel.id == entry.transaction_id)
+        ).scalar_one()
+        assert entry.delta_cents == result["earnings"]
+        assert tx.type == "gig"

--- a/backend/tests/economy/test_recording_cost.py
+++ b/backend/tests/economy/test_recording_cost.py
@@ -58,6 +58,13 @@ def setup_services():
     os.close(fd)
     econ = EconomyService(db_path=path)
     econ.ensure_schema()
+    with sqlite3.connect(path) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS bands (id INTEGER PRIMARY KEY, recorded_shows_year INTEGER DEFAULT 0)"
+        )
+        cur.execute("INSERT INTO bands (id, recorded_shows_year) VALUES (1,0)")
+        conn.commit()
     tour = TourService(
         db_path=path,
         achievements=DummyAchievements(),

--- a/frontend/pages/band_dashboard.html
+++ b/frontend/pages/band_dashboard.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Band Dashboard</title>
+</head>
+<body>
+<h2>Band Dashboard</h2>
+
+<div>
+  <label for="bandIdInput">Enter Band ID:</label>
+  <input type="text" id="bandIdInput" />
+  <button onclick="loadEconomy()">Load</button>
+</div>
+
+<h3 id="balance"></h3>
+<ul id="transactions"></ul>
+
+<script>
+async function loadEconomy() {
+  const id = document.getElementById('bandIdInput').value;
+  const balRes = await fetch(`/economy/accounts/${id}`);
+  const balData = await balRes.json();
+  document.getElementById('balance').innerText = `Balance: ${balData.balance_cents}¢`;
+
+  const txRes = await fetch(`/economy/accounts/${id}/transactions?limit=5`);
+  const txData = await txRes.json();
+  const list = txData.map(t => `<li>${t.type}: ${t.amount_cents} ${t.currency}</li>`).join('');
+  document.getElementById('transactions').innerHTML = list;
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- credit gigs using new `record_gig_payout` and log ledger entries
- call payout routine when a gig completes
- show balance and recent transactions on band dashboard with new test coverage

## Testing
- `pytest backend/tests/economy -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0a5a444a08325af25d0ffe23c68ed