### PR TITLE
Add World Pulse snapshot endpoint and dashboard hook

### DIFF
--- a/docs/world_pulse_demo.md
+++ b/docs/world_pulse_demo.md
@@ -1,0 +1,25 @@
+# World Pulse Snapshot Demo
+
+This project includes a lightweight World Pulse dashboard that can display the
+current top genres. The snapshot data is generated on demand and stored in the
+`genre_pulse_snapshots` table.
+
+## Triggering a Snapshot
+
+Use the admin endpoint to compute today's snapshot and store the top ten
+results:
+
+```bash
+curl -X POST http://localhost:8000/api/world-pulse/snapshot
+```
+
+The response contains the snapshot date and the ten highest scoring genres.
+
+## Viewing the Snapshot
+
+Open `frontend/pages/popularity_dashboard.html` in a browser and click
+**Refresh Snapshot**. The page requests `/api/world-pulse/ranked` with today's
+date and renders the top ten genres along with a simple trend indicator.
+
+This flow is suitable for demos or manual testing and avoids the need for a
+background scheduler.

--- a/frontend/pages/popularity_dashboard.html
+++ b/frontend/pages/popularity_dashboard.html
@@ -29,6 +29,10 @@
 <h3>Forecast</h3>
 <ul id="forecast"></ul>
 
+<h3>World Pulse Top Genres</h3>
+<button onclick="loadWorldPulse()">Refresh Snapshot</button>
+<ul id="worldPulse"></ul>
+
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 async function loadPopularity() {
@@ -77,6 +81,19 @@ async function loadPopularity() {
   if (window.renderSentimentChart) {
     window.renderSentimentChart(sData.history);
   }
+}
+
+async function loadWorldPulse() {
+  const today = new Date().toISOString().slice(0, 10);
+  const res = await fetch(`/api/world-pulse/ranked?date=${today}&limit=10`);
+  const data = await res.json();
+  const list = document.getElementById('worldPulse');
+  list.innerHTML = '';
+  data.forEach(row => {
+    const li = document.createElement('li');
+    li.innerText = `${row.rank}. ${row.genre} (${row.score}) ${row.trend_emoji}`;
+    list.appendChild(li);
+  });
 }
 
 let trendChart = null;


### PR DESCRIPTION
## Summary
- add service helper to persist daily World Pulse top 10 snapshot
- expose POST /world-pulse/snapshot endpoint to trigger snapshot
- show top genres snapshot on popularity dashboard and document usage

## Testing
- `pytest backend/tests/test_world_pulse_jobs.py`
- `pytest backend/tests/test_dashboard_summary_smoke.py` *(fails: assert pulse list non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a732431c8325ad88018681366847