### PR TITLE
feat: add mail FTS search endpoint and UI

### DIFF
--- a/backend/routes/mail_routes.py
+++ b/backend/routes/mail_routes.py
@@ -3,11 +3,14 @@
 Endpoints for sending, listing, and deleting mail messages.
 """
 
+import sqlite3
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from auth.dependencies import get_current_user_id
 from services.mailbox_service import delete_message, get_inbox, send_message
+from utils.db import aget_conn
 
 
 router = APIRouter(prefix="/mail", tags=["Mail"])
@@ -37,4 +40,59 @@ async def list_mail(user_id: int = Depends(get_current_user_id)):
 async def delete_mail(message_id: int, user_id: int = Depends(get_current_user_id)):
     """Delete a mail message owned by the authenticated user."""
     return await delete_message(message_id, user_id)
+
+
+@router.get("/search")
+async def search_mail(
+    q: str = "",
+    user_id: int = Depends(get_current_user_id),
+):
+    """Search mail messages using full-text search.
+
+    Falls back to a simple LIKE query if the FTS virtual table is
+    unavailable.  An empty query returns an empty list immediately.
+    """
+
+    query = q.strip()
+    if not query:
+        return []
+
+    async with aget_conn() as conn:
+        try:
+            cur = await conn.execute(
+                """
+                SELECT mm.id, mm.thread_id, mm.body
+                FROM mail_fts mf
+                JOIN mail_messages mm ON mm.id = mf.rowid
+                JOIN mail_participants mp ON mp.thread_id = mm.thread_id
+                WHERE mp.user_id = ? AND mail_fts MATCH ?
+                ORDER BY mm.created_at DESC
+                LIMIT 20
+                """,
+                (user_id, f"{query}*"),
+            )
+            rows = await cur.fetchall()
+        except sqlite3.OperationalError:
+            like = f"%{query}%"
+            cur = await conn.execute(
+                """
+                SELECT mm.id, mm.thread_id, mm.body
+                FROM mail_messages mm
+                JOIN mail_participants mp ON mp.thread_id = mm.thread_id
+                WHERE mp.user_id = ? AND mm.body LIKE ?
+                ORDER BY mm.created_at DESC
+                LIMIT 20
+                """,
+                (user_id, like),
+            )
+            rows = await cur.fetchall()
+
+    return [
+        {
+            "message_id": row["id"],
+            "thread_id": row["thread_id"],
+            "body": row["body"],
+        }
+        for row in rows
+    ]
 

--- a/frontend/pages/music_library.html
+++ b/frontend/pages/music_library.html
@@ -17,6 +17,10 @@
     </select>
     <select id="playlistSelect"></select>
   </div>
+  <div>
+    <input type="text" id="mailSearch" placeholder="Search mail..." />
+    <ul id="mailResults"></ul>
+  </div>
   <div id="tabs">
     <button onclick="showTab('songs')">Songs</button>
     <button onclick="showTab('albums')">Albums</button>
@@ -164,9 +168,40 @@
     }
   }
 
+  async function searchMail() {
+    const q = document.getElementById('mailSearch').value.trim();
+    const list = document.getElementById('mailResults');
+    if (!q) {
+      list.innerHTML = '';
+      return;
+    }
+    try {
+      const res = await fetch(`/api/mail/search?q=${encodeURIComponent(q)}`);
+      if (!res.ok) {
+        list.innerHTML = '<li>Error searching mail</li>';
+        return;
+      }
+      const data = await res.json();
+      list.innerHTML = '';
+      if (data.length === 0) {
+        list.innerHTML = '<li>No results</li>';
+        return;
+      }
+      data.forEach(msg => {
+        const li = document.createElement('li');
+        li.textContent = msg.body;
+        list.appendChild(li);
+      });
+    } catch (err) {
+      console.error('Error searching mail', err);
+      list.innerHTML = '<li>Error searching mail</li>';
+    }
+  }
+
   window.addEventListener('DOMContentLoaded', () => {
     document.getElementById('searchInput').addEventListener('input', handleInput);
     document.getElementById('sortSelect').addEventListener('change', handleInput);
+    document.getElementById('mailSearch').addEventListener('input', searchMail);
     loadPlaylists();
     handleInput();
   });


### PR DESCRIPTION
## Summary
- implement FTS-powered mail search endpoint with graceful fallback
- wire new search box in music library page to fetch from backend and show results

## Testing
- `pytest backend/tests/test_mail_smoke.py -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a73319d883258f5dd52d55eae292