### PR TITLE
feat: add jam and notification WebSockets with polling fallback

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -109,6 +109,10 @@ assets/ images/                   # branding & UI assets
 
 - WebSocket hub for jam sessions and notifications (`tests/realtime/*` cover gateway basics).
 - SSE/WS are optional for the MVP vertical slice; the static pages fall back to polling where applicable.
+- The realtime routers mount only when `ROCKMUNDO_REALTIME_BACKEND` is *not* set to `disabled`.
+  - `ROCKMUNDO_REALTIME_BACKEND=memory` (default) keeps an in-process hub for local dev.
+  - `ROCKMUNDO_REALTIME_BACKEND=redis` enables Redis pub/sub.
+  - `ROCKMUNDO_REALTIME_BACKEND=disabled` skips the WebSocket routes so the frontend's polling fallback is used.
 
 ---
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -61,6 +61,8 @@ from routes import (
     world_pulse_routes,
     skin_marketplace,
     festival_proposals_routes,
+    jam_ws,
+    notifications_ws,
 )
 from utils.db import init_pool
 from utils.i18n import _
@@ -196,6 +198,11 @@ app.include_router(
     prefix="/api",
     tags=["Festival Proposals"],
 )
+
+# Optional realtime features
+if settings.realtime.backend != "disabled":
+    app.include_router(jam_ws.router)
+    app.include_router(notifications_ws.router)
 
 
 

--- a/backend/routes/jam_ws.py
+++ b/backend/routes/jam_ws.py
@@ -1,0 +1,8 @@
+"""Expose WebSocket endpoints for jam sessions.
+
+This module simply re-exports the realtime jam gateway router so it can be
+mounted alongside other route modules.
+"""
+from backend.realtime.jam_gateway import router
+
+__all__ = ["router"]

--- a/backend/routes/notifications_ws.py
+++ b/backend/routes/notifications_ws.py
@@ -1,0 +1,53 @@
+"""WebSocket endpoint for user notifications."""
+from __future__ import annotations
+
+import asyncio
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
+
+from backend.realtime.gateway import (
+    _Subscriber,
+    get_current_user_id_dep,
+    hub,
+    topic_for_user,
+)
+from backend.monitoring.websocket import track_connect, track_disconnect, track_message
+
+router = APIRouter(prefix="/notifications", tags=["realtime"])
+
+
+@router.websocket("/ws")
+async def notifications_ws(
+    ws: WebSocket, user_id: int = Depends(get_current_user_id_dep)
+) -> None:
+    """Stream notification events for the current user.
+
+    The handler subscribes to the realtime hub using the caller's user topic and
+    forwards any published messages. Incoming messages are ignored except for
+    optional ping frames.
+    """
+
+    await ws.accept()
+    await track_connect()
+
+    sub = _Subscriber()
+    topic = topic_for_user(user_id)
+    await hub.subscribe(topic, sub)
+
+    async def pump() -> None:
+        async for msg in sub.stream():
+            await ws.send_text(msg)
+
+    outbound = asyncio.create_task(pump())
+    try:
+        while True:
+            try:
+                raw = await ws.receive_text()
+            except WebSocketDisconnect:
+                break
+            await track_message()
+            if raw == "ping":
+                await ws.send_text("pong")
+    finally:
+        outbound.cancel()
+        await hub.unsubscribe(topic, sub)
+        await track_disconnect()

--- a/frontend/utils/ws.js
+++ b/frontend/utils/ws.js
@@ -1,0 +1,64 @@
+// Simple helper for WebSocket connections with polling fallback.
+//
+// Usage:
+//   import { connect } from './utils/ws.js';
+//   const conn = connect('ws://localhost:8000/notifications/ws', {
+//     onMessage: (msg) => console.log(msg),
+//     pollUrl: '/api/notifications', // fallback endpoint returning JSON list
+//   });
+//
+// The returned object exposes `send` and `close` regardless of whether a
+// WebSocket or polling is used.
+
+import { authFetch } from './auth.js';
+
+export function connect(url, { onMessage, onError, onOpen, pollUrl, pollInterval = 5000 } = {}) {
+  // If WebSocket is supported and available, prefer it.
+  if ('WebSocket' in window) {
+    try {
+      const ws = new WebSocket(url);
+      ws.onmessage = (ev) => onMessage && onMessage(ev.data);
+      ws.onerror = (err) => onError && onError(err);
+      ws.onopen = () => onOpen && onOpen(ws);
+      ws.onclose = () => {
+        onError && onError(new Error('ws_closed'));
+        if (pollUrl) startPolling();
+      };
+      return {
+        send: (data) => ws.readyState === WebSocket.OPEN && ws.send(data),
+        close: () => ws.close(),
+      };
+    } catch (err) {
+      onError && onError(err);
+      if (!pollUrl) throw err;
+      return startPolling();
+    }
+  }
+  // Fallback to polling when WS unsupported or fails
+  return startPolling();
+
+  function startPolling() {
+    let timer;
+    const controller = {
+      send() {},
+      close() {
+        if (timer) clearInterval(timer);
+      },
+    };
+    async function poll() {
+      try {
+        const res = await authFetch(pollUrl);
+        if (res.ok) {
+          const data = await res.json();
+          onMessage && onMessage(data);
+        }
+      } catch (err) {
+        onError && onError(err);
+      }
+    }
+    timer = setInterval(poll, pollInterval);
+    poll();
+    onOpen && onOpen(controller);
+    return controller;
+  }
+}


### PR DESCRIPTION
## Summary
- expose jam session WebSocket router
- add notifications WebSocket endpoint and client utility with polling fallback
- document enabling/disabling realtime via ROCKMUNDO_REALTIME_BACKEND

## Testing
- `pytest -q` *(fails: ImportError and dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a733c780832586aa71ae3db6b50f