### PR TITLE
Add startup migrations script and DB reset make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: migrate db-reset
+
+# Run database migrations
+migrate:
+	backend/scripts/migrate.sh
+
+# Drop the SQLite database, recreate it, and apply migrations
+# Useful during development to start with a clean schema
+# Uses migrate.sh which skips already-applied revisions.
+db-reset:
+	rm -f rockmundo.db
+	backend/scripts/migrate.sh

--- a/README.MD
+++ b/README.MD
@@ -21,7 +21,7 @@ cp .env.example .env
 cp .env.example.storage .env.storage
 
 # 3) Initialize DB (migrations + seeds)
-# Migrations are SQL files in backend/migrations/sql/*.sql
+./backend/scripts/migrate.sh        # apply Alembic migrations (skips ones already run)
 python -m backend.scripts.seed_demo  # creates demo data: users, skills, genres, etc.
 
 # 4) Run the API
@@ -99,7 +99,8 @@ assets/ images/                   # branding & UI assets
 
 ## 🗄️ Data, Migrations & Seeds
 
-- Migrations live in `backend/migrations/sql`. They are applied in-order by the startup DB initializer.
+- Run migrations with `backend/scripts/migrate.sh` – it skips revisions already applied.
+- `make db-reset` removes `rockmundo.db` and re-applies migrations for a clean slate.
 - Full-text search (FTS5) and **World Pulse** (daily/weekly charts) are included.
 - `backend/scripts/seed_demo.py` seeds minimum data (skills, genres, equipment, etc.) and creates test users and bands for smoke tests.
 

--- a/backend/scripts/migrate.sh
+++ b/backend/scripts/migrate.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Apply database migrations, skipping already-applied revisions.
+# Alembic's upgrade command is idempotent and will only run new migrations.
+set -e
+cd "$(dirname "$0")/.."
+# Apply migrations
+alembic upgrade head

--- a/backend/scripts/start.sh
+++ b/backend/scripts/start.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -e
 cd "$(dirname "$0")/.."
-alembic upgrade head
+# Apply database migrations before starting the server.  The migration script
+# skips revisions that have already been applied, so startup remains fast after
+# the initial run.
+./scripts/migrate.sh
 exec uvicorn backend.api:app --host 0.0.0.0 --port 8000

--- a/docs/migration_notes.md
+++ b/docs/migration_notes.md
@@ -1,5 +1,9 @@
 # Migration Notes
 
+Run `backend/scripts/migrate.sh` to apply migrations; it only executes new
+revisions that haven't been run yet.  To wipe the SQLite database and reapply
+all migrations from scratch use `make db-reset`.
+
 ## Irreversible Migrations
 
 - **0022_100_song_licensing**: Adds `license_fee` and `royalty_rate` columns to the `songs` table. SQLite lacks straightforward support for dropping columns prior to v3.35 and doing so would require recreating the table and migrating data, which is unsafe for production. The migration therefore only drops the `cover_royalties` table during downgrade and leaves the added columns in place.


### PR DESCRIPTION
## Summary
- add `scripts/migrate.sh` to apply Alembic migrations and update start script
- provide `db-reset` make target for wiping and re-running migrations
- document migration and reset commands in README and docs

## Testing
- `make db-reset` *(fails: sqlite3.ProgrammingError: You can only execute one statement at a time)*
- `pytest -q` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a7dad134832582fb294426a3781d