### PR TITLE
Restrict CORS to localhost in development

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -73,12 +73,16 @@ from backend.utils.tracing import setup_tracing
 
 app = FastAPI(title="RockMundo API with Events, Lifestyle, and Sponsorships")
 app.add_exception_handler(HTTPException, http_exception_handler)
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=settings.cors.allowed_origins,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+cors_kwargs = {
+    "allow_methods": ["*"],
+    "allow_headers": ["*"],
+}
+if settings.env == "dev":
+    cors_kwargs["allow_origin_regex"] = r"http://localhost(:[0-9]+)?"
+else:
+    cors_kwargs["allow_origins"] = settings.cors.allowed_origins
+
+app.add_middleware(CORSMiddleware, **cors_kwargs)
 app.add_middleware(ObservabilityMiddleware)
 app.add_middleware(RateLimitMiddleware)
 app.add_middleware(LocaleMiddleware)


### PR DESCRIPTION
## Summary
- Add environment-aware CORS middleware configuration
- Permit http://localhost:* during development via regex, retain configured origins otherwise

## Testing
- `PYTHONPATH=backend python - <<'PY'
from fastapi import FastAPI
from fastapi.middleware.cors import CORSMiddleware
from fastapi.testclient import TestClient

app = FastAPI()
app.add_middleware(CORSMiddleware, allow_methods=['*'], allow_headers=['*'], allow_origin_regex=r'http://localhost(:[0-9]+)?')

@app.get('/')
async def root():
    return {'hello':'world'}

with TestClient(app) as client:
    r = client.get('/', headers={'Origin': 'http://localhost:3000'})
    print('localhost header:', r.headers.get('access-control-allow-origin'))
    r2 = client.get('/', headers={'Origin': 'http://example.com'})
    print('example.com header:', r2.headers.get('access-control-allow-origin'))
PY`
- `pytest` (fails: A parameter-less dependency must have a callable dependency)

------
https://chatgpt.com/codex/tasks/task_e_68c0a7db6ae88325b7fdf18f2af88ccb