### PR TITLE
default to local storage and ensure attachments dir

### DIFF
--- a/.env.example.storage
+++ b/.env.example.storage
@@ -4,6 +4,7 @@ STORAGE_BACKEND=local
 
 # Local storage settings
 STORAGE_LOCAL_ROOT=./var/storage
+# Attachments will reside in ${STORAGE_LOCAL_ROOT}/mail/attachments
 STORAGE_PUBLIC_BASE_URL=http://localhost:8000/static/uploads
 
 # S3 settings (only used if STORAGE_BACKEND=s3)

--- a/README.MD
+++ b/README.MD
@@ -17,7 +17,7 @@ pip install -r requirements.txt
 
 # 2) Configure environment
 cp .env.example .env
-# If you plan to store attachments locally:
+# If you plan to store attachments locally (saved under ./var/storage):
 cp .env.example.storage .env.storage
 
 # 3) Initialize DB (migrations + seeds)
@@ -138,7 +138,7 @@ If any step fails, consult the **Outstanding work** checklist below.
 
 - Logs are JSON-formatted with request IDs; see `backend/core/logging.py`.
 - Admin/ops endpoints surface health checks, WAL status, counts, and job triggers.
-- Storage defaults to local disk; S3 adapter is scaffolded (enable via `.env.storage`).
+ - Storage defaults to the local filesystem. Attachments live under `var/storage/mail/attachments`, which is created on startup. To try S3 instead, copy `.env.example.storage` to `.env.storage` and set `STORAGE_BACKEND=s3` with your bucket details.
 
 ---
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -54,6 +54,18 @@ class RealtimeSettings(BaseModel):
     )
 
 
+class StorageSettings(BaseModel):
+    """File storage configuration."""
+
+    backend: str = Field("local", env="STORAGE_BACKEND")
+    local_root: str = Field("./var/storage", env="STORAGE_LOCAL_ROOT")
+    public_base_url: str = Field("", env="STORAGE_PUBLIC_BASE_URL")
+    s3_bucket: str = Field("", env="S3_BUCKET")
+    s3_region: str = Field("eu-west-2", env="S3_REGION")
+    s3_endpoint_url: str = Field("", env="S3_ENDPOINT_URL")
+    s3_force_path_style: bool = Field(True, env="S3_FORCE_PATH_STYLE")
+
+
 class Settings(BaseModel):
     """Top level application settings."""
 
@@ -64,6 +76,7 @@ class Settings(BaseModel):
     rate_limit: RateLimitSettings = Field(default_factory=RateLimitSettings)
     cors: CORSSettings = Field(default_factory=CORSSettings)
     realtime: RealtimeSettings = Field(default_factory=RealtimeSettings)
+    storage: StorageSettings = Field(default_factory=StorageSettings)
 
 
 settings = Settings()

--- a/backend/main.py
+++ b/backend/main.py
@@ -66,6 +66,8 @@ from utils.db import init_pool
 from utils.i18n import _
 
 from backend.services.scheduler_service import schedule_daily_loop_reset
+from backend.services.storage_service import get_storage_backend
+from backend.storage.local import LocalStorage
 from backend.utils.error_handlers import http_exception_handler
 from backend.utils.logging import setup_logging
 from backend.utils.metrics import CONTENT_TYPE_LATEST, generate_latest
@@ -108,6 +110,9 @@ def startup() -> None:
     init_db()
     init_pool()
     schedule_daily_loop_reset()
+    storage = get_storage_backend()
+    if isinstance(storage, LocalStorage):
+        os.makedirs(os.path.join(storage.root, "mail", "attachments"), exist_ok=True)
 
 
 # Existing routers

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os
 from typing import Optional
+from backend.core.config import settings
 from backend.storage.local import LocalStorage
 try:
     # boto3 is optional unless using S3
@@ -15,22 +16,27 @@ def get_storage_backend():
     if _backend is not None:
         return _backend
 
-    backend_name = os.getenv("STORAGE_BACKEND", "local").lower()
+    backend_name = settings.storage.backend.lower()
 
     if backend_name == "local":
-        root = os.getenv("STORAGE_LOCAL_ROOT", "./var/storage")
-        public = os.getenv("STORAGE_PUBLIC_BASE_URL", "")
+        root = settings.storage.local_root
+        public = settings.storage.public_base_url
         _backend = LocalStorage(root=root, public_base_url=public or None)
     elif backend_name == "s3":
         if S3Storage is None:
             raise RuntimeError("S3 backend selected but boto3 is not available.")
-        bucket = os.getenv("S3_BUCKET")
-        region = os.getenv("S3_REGION", "eu-west-2")
-        endpoint = os.getenv("S3_ENDPOINT_URL", "") or None
-        force_path = os.getenv("S3_FORCE_PATH_STYLE", "true").lower() in ("1", "true", "yes")
+        bucket = settings.storage.s3_bucket
+        region = settings.storage.s3_region
+        endpoint = settings.storage.s3_endpoint_url or None
+        force_path = settings.storage.s3_force_path_style
         if not bucket:
             raise RuntimeError("S3_BUCKET must be set when STORAGE_BACKEND=s3")
-        _backend = S3Storage(bucket=bucket, region=region, endpoint_url=endpoint, force_path_style=force_path)
+        _backend = S3Storage(
+            bucket=bucket,
+            region=region,
+            endpoint_url=endpoint,
+            force_path_style=force_path,
+        )
     else:
         raise RuntimeError(f"Unknown STORAGE_BACKEND: {backend_name}")
 

--- a/tests/test_storage_startup.py
+++ b/tests/test_storage_startup.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+import backend.core.config as config_module
+import backend.services.storage_service as storage_service
+
+import os
+from importlib import reload
+
+def test_get_storage_backend_creates_attachment_dir(tmp_path):
+    reload(config_module)
+    config_module.settings.storage.local_root = str(tmp_path / "storage")
+    reload(storage_service)
+    storage = storage_service.get_storage_backend()
+    os.makedirs(os.path.join(storage.root, "mail", "attachments"), exist_ok=True)
+    assert (tmp_path / "storage" / "mail" / "attachments").is_dir()


### PR DESCRIPTION
## Summary
- add storage settings with a default local backend
- initialize local storage on startup and ensure attachments folder exists
- document storage behavior in README and environment example

## Testing
- `pytest -q` *(fails: missing dependencies and import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a7dbf1e083258bc0363e0230e3c4