### PR TITLE
Use services for gig eligibility

### DIFF
--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -277,6 +277,11 @@ class SkillService:
         avg_level = sum(levels) / len(levels)
         return 1 + (avg_level / 200)
 
+    def get_skill_level(self, user_id: int, skill: Skill) -> int:
+        """Return the current level for ``skill`` without awarding XP."""
+
+        return self._get_skill(user_id, skill).level
+
     def train(
         self, user_id: int, skill: Skill, base_xp: int, duration: int = 0
     ) -> Skill:


### PR DESCRIPTION
## Summary
- compute acoustic gig eligibility using FameService and SkillService
- expose SkillService.get_skill_level for non-mutating skill lookups
- expand gig route tests for solo/non-solo success and failure scenarios

## Testing
- `pytest backend/tests/routes/test_gig_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0a93794c08325b0301d8c69f47a2e