### PR TITLE
Add regional royalty processing with monitoring

### DIFF
--- a/backend/services/jobs_royalties.py
+++ b/backend/services/jobs_royalties.py
@@ -17,18 +17,25 @@ All tables are optional; if missing, that channel is skipped gracefully.
 import json
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from backend.config.revenue import (
-    STREAM_RATE_MICROCENTS,
     DAILY_STREAM_CAP_PER_USER_PER_SONG,
     SPONSOR_IMPRESSION_RATE_CENTS,
     SPONSOR_PAYOUT_SPLIT,
+    STREAM_RATE_MICROCENTS,
 )
+from backend.utils.metrics import Counter
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
+
+ROYALTY_JOB_FAILURES = Counter(
+    "royalty_job_failures_total", "Total failed royalty job runs", labelnames=("region",)
+)
+ROYALTY_JOB_SUCCESS = Counter(
+    "royalty_job_success_total", "Total successful royalty job runs", labelnames=("region",)
+)
 
 class RoyaltyJobError(Exception):
     pass
@@ -55,6 +62,7 @@ class RoyaltyJobsService:
               id INTEGER PRIMARY KEY AUTOINCREMENT,
               period_start TEXT NOT NULL,
               period_end TEXT NOT NULL,
+              region TEXT NOT NULL DEFAULT 'global',
               status TEXT NOT NULL DEFAULT 'pending',
               notes TEXT,
               created_at TEXT DEFAULT (datetime('now')),
@@ -65,6 +73,7 @@ class RoyaltyJobsService:
             CREATE TABLE IF NOT EXISTS royalty_run_lines (
               id INTEGER PRIMARY KEY AUTOINCREMENT,
               run_id INTEGER NOT NULL,
+              region TEXT NOT NULL DEFAULT 'global',
               work_type TEXT NOT NULL,
               work_id INTEGER,
               band_id INTEGER,
@@ -78,13 +87,37 @@ class RoyaltyJobsService:
             cur.execute("CREATE INDEX IF NOT EXISTS ix_royalty_lines_run ON royalty_run_lines(run_id)")
             cur.execute("CREATE INDEX IF NOT EXISTS ix_royalty_lines_band ON royalty_run_lines(band_id)")
             cur.execute("CREATE INDEX IF NOT EXISTS ix_royalty_lines_work ON royalty_run_lines(work_type, work_id)")
+            cur.execute("CREATE INDEX IF NOT EXISTS ix_royalty_runs_region ON royalty_runs(region)")
+            cur.execute("CREATE INDEX IF NOT EXISTS ix_royalty_lines_region ON royalty_run_lines(region)")
+            # Backfill region column if upgrading from older schema
+            for table in ("royalty_runs", "royalty_run_lines"):
+                cur.execute(f"PRAGMA table_info({table})")
+                cols = {row[1] for row in cur.fetchall()}
+                if "region" not in cols:
+                    cur.execute(f"ALTER TABLE {table} ADD COLUMN region TEXT DEFAULT 'global'")
             conn.commit()
 
-    def _create_run(self, cur, window: RunWindow) -> int:
-        cur.execute("""
-            INSERT INTO royalty_runs (period_start, period_end, status)
-            VALUES (?, ?, 'running')
-        """, (window.start, window.end))
+    def _has_column(self, cur, table: str, column: str) -> bool:
+        cur.execute(f"PRAGMA table_info({table})")
+        return any(row[1].lower() == column.lower() for row in cur.fetchall())
+
+    def _region_filter(self, cur, table: str, region: str, alias: str = "") -> Tuple[str, List[str]]:
+        if region == "global":
+            return "", []
+        for col in ("region", "country_code", "country"):
+            if self._has_column(cur, table, col):
+                prefix = f"{alias}." if alias else ""
+                return f" AND {prefix}{col} = ?", [region]
+        return "", []
+
+    def _create_run(self, cur, window: RunWindow, region: str) -> int:
+        cur.execute(
+            """
+            INSERT INTO royalty_runs (period_start, period_end, region, status)
+            VALUES (?, ?, ?, 'running')
+        """,
+            (window.start, window.end, region),
+        )
         return cur.lastrowid
 
     def _complete_run(self, cur, run_id: int, notes: Optional[str] = None) -> None:
@@ -142,14 +175,16 @@ class RoyaltyJobsService:
         source: str,
         amount_cents: int,
         meta: Optional[Dict[str, Any]] = None,
+        region: str = "global",
     ) -> None:
         cur.execute(
             """
-            INSERT INTO royalty_run_lines (run_id, work_type, work_id, band_id, collaborator_band_id, source, amount_cents, meta_json)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO royalty_run_lines (run_id, region, work_type, work_id, band_id, collaborator_band_id, source, amount_cents, meta_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 run_id,
+                region,
                 work_type,
                 work_id,
                 band_id,
@@ -161,16 +196,16 @@ class RoyaltyJobsService:
         )
 
     # -------- channels --------
-    def _process_streams(self, cur, run_id: int, window: RunWindow) -> None:
+    def _process_streams(self, cur, run_id: int, window: RunWindow, region: str) -> None:
         if not self._table_exists(cur, "streams"):
             return
-        # Aggregate plays per song with anti-fraud cap per user/day
-        # Expect streams(created_at TEXT, song_id INTEGER, user_id INTEGER)
-        cur.execute(f"""
+        region_sql, params = self._region_filter(cur, "streams", region)
+        cur.execute(
+            f"""
             WITH capped AS (
               SELECT song_id, date(created_at) AS d, user_id, MIN(COUNT(*), {DAILY_STREAM_CAP_PER_USER_PER_SONG}) AS capped_plays
               FROM streams
-              WHERE datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?) 
+              WHERE datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?) {region_sql}
               GROUP BY song_id, d, user_id
             ),
             sum_by_song AS (
@@ -179,36 +214,73 @@ class RoyaltyJobsService:
               GROUP BY song_id
             )
             SELECT song_id, total_plays FROM sum_by_song
-        """, (f"{window.start} 00:00:00", f"{window.end} 23:59:59"))
+        """,
+            (f"{window.start} 00:00:00", f"{window.end} 23:59:59", *params),
+        )
         rows = cur.fetchall()
         for song_id, plays in rows:
             plays = int(plays or 0)
             microcents = plays * STREAM_RATE_MICROCENTS
-            cents = microcents // 100  # convert microcents -> cents (floor)
+            cents = microcents // 100
             if cents <= 0:
                 continue
-            # Collab split?
             split = self._collab_split(cur, "song", song_id)
             if split:
                 a_id, b_id, a_pct, b_pct = split
                 a_amt = cents * a_pct // 100
                 b_amt = cents - a_amt
-                self._emit_line(cur, run_id, "song", song_id, a_id, b_id, "streams", a_amt, {"plays": plays, "split": f"{a_pct}/{b_pct}"})
-                self._emit_line(cur, run_id, "song", song_id, b_id, a_id, "streams", b_amt, {"plays": plays, "split": f"{a_pct}/{b_pct}"})
+                self._emit_line(
+                    cur,
+                    run_id,
+                    "song",
+                    song_id,
+                    a_id,
+                    b_id,
+                    "streams",
+                    a_amt,
+                    {"plays": plays, "split": f"{a_pct}/{b_pct}"},
+                    region=region,
+                )
+                self._emit_line(
+                    cur,
+                    run_id,
+                    "song",
+                    song_id,
+                    b_id,
+                    a_id,
+                    "streams",
+                    b_amt,
+                    {"plays": plays, "split": f"{a_pct}/{b_pct}"},
+                    region=region,
+                )
             else:
                 band_id = self._owner_band_for_work(cur, "song", song_id)
-                self._emit_line(cur, run_id, "song", song_id, band_id, None, "streams", cents, {"plays": plays})
+                self._emit_line(
+                    cur,
+                    run_id,
+                    "song",
+                    song_id,
+                    band_id,
+                    None,
+                    "streams",
+                    cents,
+                    {"plays": plays},
+                    region=region,
+                )
 
-    def _process_digital(self, cur, run_id: int, window: RunWindow) -> None:
+    def _process_digital(self, cur, run_id: int, window: RunWindow, region: str) -> None:
         if not self._table_exists(cur, "digital_sales"):
             return
-        # Sum per work
-        cur.execute("""
+        region_sql, params = self._region_filter(cur, "digital_sales", region)
+        cur.execute(
+            """
             SELECT work_type, work_id, SUM(price_cents) as revenue_cents, COUNT(*) as cnt
             FROM digital_sales
-            WHERE datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?)
+            WHERE datetime(created_at) >= datetime(?) AND datetime(created_at) <= datetime(?){} 
             GROUP BY work_type, work_id
-        """, (f"{window.start} 00:00:00", f"{window.end} 23:59:59"))
+        """.format(region_sql),
+            (f"{window.start} 00:00:00", f"{window.end} 23:59:59", *params),
+        )
         for work_type, work_id, revenue_cents, cnt in cur.fetchall():
             work_type = (work_type or "").lower()
             revenue_cents = int(revenue_cents or 0)
@@ -222,18 +294,52 @@ class RoyaltyJobsService:
                 a_id, b_id, a_pct, b_pct = split
                 a_amt = revenue_cents * a_pct // 100
                 b_amt = revenue_cents - a_amt
-                self._emit_line(cur, run_id, work_type, int(work_id), a_id, b_id, "digital", a_amt, {**meta, "split": f"{a_pct}/{b_pct}"})
-                self._emit_line(cur, run_id, work_type, int(work_id), b_id, a_id, "digital", b_amt, {**meta, "split": f"{a_pct}/{b_pct}"})
+                self._emit_line(
+                    cur,
+                    run_id,
+                    work_type,
+                    int(work_id),
+                    a_id,
+                    b_id,
+                    "digital",
+                    a_amt,
+                    {**meta, "split": f"{a_pct}/{b_pct}"},
+                    region=region,
+                )
+                self._emit_line(
+                    cur,
+                    run_id,
+                    work_type,
+                    int(work_id),
+                    b_id,
+                    a_id,
+                    "digital",
+                    b_amt,
+                    {**meta, "split": f"{a_pct}/{b_pct}"},
+                    region=region,
+                )
             else:
                 band_id = self._owner_band_for_work(cur, work_type, int(work_id)) if work_type in ("song","album") else None
-                self._emit_line(cur, run_id, work_type, int(work_id), band_id, None, "digital", revenue_cents, meta)
+                self._emit_line(
+                    cur,
+                    run_id,
+                    work_type,
+                    int(work_id),
+                    band_id,
+                    None,
+                    "digital",
+                    revenue_cents,
+                    meta,
+                    region=region,
+                )
 
-    def _process_vinyl(self, cur, run_id: int, window: RunWindow) -> None:
-        # Requires vinyl_order_items, vinyl_orders, vinyl_skus (for album_id)
-        needed = ["vinyl_order_items","vinyl_orders","vinyl_skus"]
+    def _process_vinyl(self, cur, run_id: int, window: RunWindow, region: str) -> None:
+        needed = ["vinyl_order_items", "vinyl_orders", "vinyl_skus"]
         if not all(self._table_exists(cur, t) for t in needed):
             return
-        cur.execute("""
+        region_sql, params = self._region_filter(cur, "vinyl_orders", region, alias="o")
+        cur.execute(
+            """
             SELECT s.album_id, SUM(oi.unit_price_cents * (oi.qty - oi.refunded_qty)) AS revenue_cents,
                    SUM(oi.qty - oi.refunded_qty) as units
             FROM vinyl_order_items oi
@@ -241,9 +347,11 @@ class RoyaltyJobsService:
             JOIN vinyl_skus s ON s.id = oi.sku_id
             WHERE o.status = 'confirmed'
               AND datetime(o.created_at) >= datetime(?)
-              AND datetime(o.created_at) <= datetime(?)
+              AND datetime(o.created_at) <= datetime(?){}
             GROUP BY s.album_id
-        """, (f"{window.start} 00:00:00", f"{window.end} 23:59:59"))
+        """.format(region_sql),
+            (f"{window.start} 00:00:00", f"{window.end} 23:59:59", *params),
+        )
         for album_id, revenue_cents, units in cur.fetchall():
             revenue_cents = int(revenue_cents or 0)
             if revenue_cents <= 0:
@@ -254,17 +362,53 @@ class RoyaltyJobsService:
                 a_id, b_id, a_pct, b_pct = split
                 a_amt = revenue_cents * a_pct // 100
                 b_amt = revenue_cents - a_amt
-                self._emit_line(cur, run_id, "album", int(album_id), a_id, b_id, "vinyl", a_amt, {**meta, "split": f"{a_pct}/{b_pct}"})
-                self._emit_line(cur, run_id, "album", int(album_id), b_id, a_id, "vinyl", b_amt, {**meta, "split": f"{a_pct}/{b_pct}"})
+                self._emit_line(
+                    cur,
+                    run_id,
+                    "album",
+                    int(album_id),
+                    a_id,
+                    b_id,
+                    "vinyl",
+                    a_amt,
+                    {**meta, "split": f"{a_pct}/{b_pct}"},
+                    region=region,
+                )
+                self._emit_line(
+                    cur,
+                    run_id,
+                    "album",
+                    int(album_id),
+                    b_id,
+                    a_id,
+                    "vinyl",
+                    b_amt,
+                    {**meta, "split": f"{a_pct}/{b_pct}"},
+                    region=region,
+                )
             else:
                 band_id = self._owner_band_for_work(cur, "album", int(album_id))
-                self._emit_line(cur, run_id, "album", int(album_id), band_id, None, "vinyl", revenue_cents, meta)
+                self._emit_line(
+                    cur,
+                    run_id,
+                    "album",
+                    int(album_id),
+                    band_id,
+                    None,
+                    "vinyl",
+                    revenue_cents,
+                    meta,
+                    region=region,
+                )
 
-    def _process_sponsorships(self, cur, run_id: int, window: RunWindow) -> None:
+    def _process_sponsorships(self, cur, run_id: int, window: RunWindow, region: str) -> None:
         """Aggregate sponsorship ad events into royalty lines."""
         needed = ["sponsorship_ad_events", "venue_sponsorships"]
         if not all(self._table_exists(cur, t) for t in needed):
             return
+        region_sql, params = self._region_filter(cur, "sponsorship_ad_events", region, alias="e")
+        if not region_sql:
+            region_sql, params = self._region_filter(cur, "venue_sponsorships", region, alias="vs")
         cur.execute(
             """
             SELECT vs.venue_id, COUNT(*) as impressions
@@ -273,10 +417,10 @@ class RoyaltyJobsService:
             WHERE e.event_type = 'impression'
               AND datetime(e.occurred_at) >= datetime(?)
               AND datetime(e.occurred_at) <= datetime(?)
-              AND vs.is_active = 1
+              AND vs.is_active = 1{}
             GROUP BY vs.venue_id
-            """,
-            (f"{window.start} 00:00:00", f"{window.end} 23:59:59"),
+            """.format(region_sql),
+            (f"{window.start} 00:00:00", f"{window.end} 23:59:59", *params),
         )
         for venue_id, impressions in cur.fetchall():
             impressions = int(impressions or 0)
@@ -296,14 +440,11 @@ class RoyaltyJobsService:
                 "sponsorship",
                 venue_share,
                 {"impressions": impressions},
+                region=region,
             )
 
     # -------- public API --------
-    def run_royalties(self, period_start: str, period_end: str) -> Dict[str, Any]:
-        """
-        Execute a royalty run for [period_start, period_end] inclusive.
-        Returns a summary with run_id and counts by channel.
-        """
+    def _run_single_region(self, period_start: str, period_end: str, region: str) -> Dict[str, Any]:
         window = RunWindow(period_start, period_end)
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
@@ -311,41 +452,74 @@ class RoyaltyJobsService:
             self.ensure_schema()
             try:
                 cur.execute("BEGIN IMMEDIATE")
-                run_id = self._create_run(cur, window)
+                run_id = self._create_run(cur, window, region)
                 conn.commit()
-            except Exception as e:
+            except Exception:
                 conn.rollback()
                 raise
 
-            # Process channels
-            stats = {"streams": 0, "digital": 0, "vinyl": 0, "sponsorship": 0, "run_id": run_id}
+            stats = {
+                "streams": 0,
+                "digital": 0,
+                "vinyl": 0,
+                "sponsorship": 0,
+                "run_id": run_id,
+                "region": region,
+            }
             try:
                 cur.execute("BEGIN IMMEDIATE")
                 before = self._count_lines(cur, run_id)
-                self._process_streams(cur, run_id, window)
-                after = self._count_lines(cur, run_id); stats["streams"] = after - before
+                self._process_streams(cur, run_id, window, region)
+                after = self._count_lines(cur, run_id)
+                stats["streams"] = after - before
 
                 before = self._count_lines(cur, run_id)
-                self._process_digital(cur, run_id, window)
-                after = self._count_lines(cur, run_id); stats["digital"] = after - before
+                self._process_digital(cur, run_id, window, region)
+                after = self._count_lines(cur, run_id)
+                stats["digital"] = after - before
 
                 before = self._count_lines(cur, run_id)
-                self._process_vinyl(cur, run_id, window)
-                after = self._count_lines(cur, run_id); stats["vinyl"] = after - before
+                self._process_vinyl(cur, run_id, window, region)
+                after = self._count_lines(cur, run_id)
+                stats["vinyl"] = after - before
 
                 before = self._count_lines(cur, run_id)
-                self._process_sponsorships(cur, run_id, window)
-                after = self._count_lines(cur, run_id); stats["sponsorship"] = after - before
+                self._process_sponsorships(cur, run_id, window, region)
+                after = self._count_lines(cur, run_id)
+                stats["sponsorship"] = after - before
 
                 self._complete_run(cur, run_id, notes=None)
                 conn.commit()
+                ROYALTY_JOB_SUCCESS.labels(region).inc()
             except Exception as e:
                 conn.rollback()
                 cur.execute("BEGIN IMMEDIATE")
                 self._fail_run(cur, run_id, err=str(e))
                 conn.commit()
+                ROYALTY_JOB_FAILURES.labels(region).inc()
                 raise
             return stats
+
+    def run_royalties(
+        self,
+        period_start: str,
+        period_end: str,
+        regions: Optional[List[str]] = None,
+        max_retries: int = 3,
+    ) -> Dict[str, Any]:
+        regions = regions or ["global"]
+        results: Dict[str, Any] = {}
+        for region in regions:
+            attempt = 0
+            while attempt < max_retries:
+                attempt += 1
+                try:
+                    results[region] = self._run_single_region(period_start, period_end, region)
+                    break
+                except Exception:
+                    if attempt >= max_retries:
+                        results[region] = {"error": "failed"}
+        return results
 
     def _count_lines(self, cur, run_id: int) -> int:
         cur.execute("SELECT COUNT(*) FROM royalty_run_lines WHERE run_id = ?", (run_id,))

--- a/backend/tests/royalties/test_venue_sponsorship_payouts.py
+++ b/backend/tests/royalties/test_venue_sponsorship_payouts.py
@@ -1,7 +1,8 @@
 import sqlite3
+
 from backend.config import revenue
-from backend.services.venue_sponsorships_service import VenueSponsorshipsService, SponsorshipIn
 from backend.services.jobs_royalties import RoyaltyJobsService
+from backend.services.venue_sponsorships_service import SponsorshipIn, VenueSponsorshipsService
 
 
 def test_venue_sponsorship_payout(tmp_path):
@@ -28,6 +29,7 @@ def test_venue_sponsorship_payout(tmp_path):
 
     rsvc = RoyaltyJobsService(str(db_path))
     stats = rsvc.run_royalties("2000-01-01", "2030-01-01")
+    stats = stats["global"]
     assert stats["sponsorship"] == 1
 
     with sqlite3.connect(db_path) as conn:

--- a/backend/tests/test_dashboard_summary_smoke.py
+++ b/backend/tests/test_dashboard_summary_smoke.py
@@ -1,6 +1,7 @@
 # File: backend/tests/test_dashboard_summary_smoke.py
-from utils.db import get_conn
 from services.dashboard_service import DashboardService
+
+from utils.db import get_conn
 
 DDL = """
 CREATE TABLE IF NOT EXISTS venues (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, city TEXT, country TEXT, capacity INTEGER, created_at TEXT DEFAULT (datetime('now')));
@@ -35,3 +36,4 @@ def test_dashboard_summary(tmp_path):
     assert "badge" in summary and isinstance(summary["badge"], dict)
     assert "pulse" in summary and len(summary["pulse"]) >= 1
     assert "music" in summary and "last_7d" in summary["music"]
+    assert "chart_regions" in summary and isinstance(summary["chart_regions"], dict)


### PR DESCRIPTION
## Summary
- process royalty jobs per region with retry support and metrics
- expose chart region breakdown for dashboards
- track sponsor reconciliation and royalty job failures

## Testing
- `pytest backend/tests/royalties/test_venue_sponsorship_payouts.py backend/tests/royalties/test_sponsorship_reconciliation.py backend/tests/test_dashboard_summary_smoke.py tests/test_jobs_charts_multi_country.py`
- `ruff check backend/jobs/sponsor_reconciliation_job.py backend/routes/chart_routes.py backend/services/dashboard_service.py backend/services/jobs_royalties.py backend/tests/royalties/test_venue_sponsorship_payouts.py backend/tests/test_dashboard_summary_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0aae669d08325b213f25464b18554