### PR TITLE
Add manual test plan for release candidates

### DIFF
--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -1,0 +1,28 @@
+# Manual Test Plan
+
+Run the following manual steps after each release candidate and log the results or any issues discovered. Update this document as features evolve.
+
+## Steps
+
+1. **Login**
+   - Ensure users can authenticate with valid credentials and are blocked with invalid ones.
+
+2. **Avatar/Band Creation**
+   - Verify new avatars or bands can be created, edited, and saved.
+
+3. **Booking**
+   - Confirm users can book venues or sessions and that bookings appear correctly.
+
+4. **Performing**
+   - Check the performance flow from start to completion.
+
+5. **Dashboard Checks**
+   - Review dashboard widgets for accurate metrics and recent activity.
+
+6. **World Pulse**
+   - Validate world pulse updates reflect current game events and user actions.
+
+7. **Notifications**
+   - Ensure notifications are sent, received, and displayed properly across channels.
+
+Document any outcomes or issues after executing these steps.


### PR DESCRIPTION
## Summary
- document manual test plan covering login, creation, booking, performance, dashboard, world pulse, and notifications checks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'tests.realtime'; 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a7eb81c083259c5c03d21f37b42f