### PR TITLE
feat(frontend): centralize API fetch and update routes

### DIFF
--- a/frontend/pages/Dashboard.jsx
+++ b/frontend/pages/Dashboard.jsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
+import { apiFetch } from '../utils/api.js';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
@@ -29,7 +30,7 @@ const Dashboard = () => {
       return;
     }
 
-    fetch('/dashboard/summary')
+    apiFetch('/api/dashboard/summary')
       .then((res) => {
         if (!res.ok) {
           throw new Error('Network response was not ok');

--- a/frontend/pages/admin/index.tsx
+++ b/frontend/pages/admin/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import AdminApp from '../../src/admin/App';
+import { apiFetch } from '../../utils/api.js';
 
 function isAuthenticated(): boolean {
   const jwt = localStorage.getItem('jwt');
@@ -21,8 +22,8 @@ const AdminPage: React.FC = () => {
     const jwt = localStorage.getItem('jwt');
 
     Promise.all([
-      fetch('/auth/permissions').then((r) => r.json()),
-      fetch('/auth/me', {
+      apiFetch('/auth/permissions').then((r) => r.json()),
+      apiFetch('/auth/me', {
         headers: jwt ? { Authorization: `Bearer ${jwt}` } : {},
       })
         .then((r) => (r.ok ? r.json() : { roles: [] }))

--- a/frontend/pages/album_form.html
+++ b/frontend/pages/album_form.html
@@ -7,6 +7,7 @@
   <title>Album Form</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <div id="react-root"></div>
 <h2>Create Release</h2>
 <form id="albumForm">
@@ -103,7 +104,7 @@
       };
 
       li.append(up, down, remove);
-      fetch(`/songs/${id}`)
+      apiFetch(`/api/songs/${id}`)
         .then(r => r.json())
         .then(data => {
           li.append(` ${data.title || 'Song ' + id}`);
@@ -146,7 +147,7 @@
       tracks
     };
     try {
-      const res = await fetch('/albums', {
+      const res = await apiFetch('/api/albums', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)

--- a/frontend/pages/avatar_editor.html
+++ b/frontend/pages/avatar_editor.html
@@ -5,6 +5,7 @@
     <title>Avatar Editor</title>
   </head>
   <body>
+<script src="../utils/api.js"></script>
     <h1>Avatar Editor</h1>
     <form id="avatarForm">
       <label>
@@ -31,7 +32,7 @@
           display_name: document.getElementById('nickname').value || undefined,
           body_type: document.getElementById('bodyType').value || undefined,
         };
-        await fetch(`/api/avatars/${id}`, {
+        await apiFetch(`/api/avatars/${id}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),

--- a/frontend/pages/band_dashboard.html
+++ b/frontend/pages/band_dashboard.html
@@ -6,6 +6,7 @@
   <title>Band Dashboard</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Band Dashboard</h2>
 
 <div>
@@ -20,11 +21,11 @@
 <script>
 async function loadEconomy() {
   const id = document.getElementById('bandIdInput').value;
-  const balRes = await fetch(`/economy/accounts/${id}`);
+  const balRes = await apiFetch(`/api/economy/accounts/${id}`);
   const balData = await balRes.json();
   document.getElementById('balance').innerText = `Balance: ${balData.balance_cents}¢`;
 
-  const txRes = await fetch(`/economy/accounts/${id}/transactions?limit=5`);
+  const txRes = await apiFetch(`/api/economy/accounts/${id}/transactions?limit=5`);
   const txData = await txRes.json();
   const list = txData.map(t => `<li>${t.type}: ${t.amount_cents} ${t.currency}</li>`).join('');
   document.getElementById('transactions').innerHTML = list;

--- a/frontend/pages/chart_page.html
+++ b/frontend/pages/chart_page.html
@@ -6,6 +6,7 @@
   <title>Chart Page</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Global Top 100 Chart</h2>
 
 <div>
@@ -19,7 +20,7 @@
 <script>
 async function loadChart() {
   const week = document.getElementById('weekInput').value;
-  const res = await fetch(`/charts/global/${week}`);
+  const res = await apiFetch(`/api/charts/global/${week}`);
   const data = await res.json();
   const list = document.getElementById('chartList');
   list.innerHTML = '';

--- a/frontend/pages/cover_licensing.html
+++ b/frontend/pages/cover_licensing.html
@@ -6,6 +6,7 @@
   <title>Cover Licensing</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Cover Licensing</h2>
 <table id="royalties">
   <thead>
@@ -23,7 +24,7 @@
   const BAND_ID = 1; // Placeholder for current band
 
   function loadRoyalties() {
-    fetch(`/cover_royalties/band/${BAND_ID}`)
+    apiFetch(`/api/cover_royalties/band/${BAND_ID}`)
       .then(r => r.json())
       .then(list => {
         const body = document.querySelector('#royalties tbody');
@@ -42,7 +43,7 @@
     e.preventDefault();
     const form = e.target;
     const data = new FormData(form);
-    await fetch(`/cover_royalties/band/${BAND_ID}`, { method: 'POST', body: data });
+    await apiFetch(`/api/cover_royalties/band/${BAND_ID}`, { method: 'POST', body: data });
     form.reset();
     loadRoyalties();
   });

--- a/frontend/pages/cover_marketplace.html
+++ b/frontend/pages/cover_marketplace.html
@@ -6,6 +6,7 @@
   <title>Cover Marketplace</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Cover Marketplace</h2>
 <div id="catalog"></div>
 
@@ -14,7 +15,7 @@
     // In a real application this would call an API endpoint which in turn
     // uses ``LicensingMarketplaceService``.  Here we just expect JSON of the
     // form [{song_id, title, license_fee}].
-    const resp = await fetch('/licensing_marketplace');
+    const resp = await apiFetch('/api/licensing_marketplace');
     const songs = await resp.json();
     const container = document.getElementById('catalog');
     container.innerHTML = '';

--- a/frontend/pages/fame_dashboard.html
+++ b/frontend/pages/fame_dashboard.html
@@ -6,6 +6,7 @@
   <title>Fame Dashboard</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Fame Dashboard</h2>
 
 <div>
@@ -20,11 +21,11 @@
 <script>
 async function loadFame() {
   const bandId = document.getElementById('bandId').value;
-  const fameRes = await fetch(`/fame/${bandId}/total`);
+  const fameRes = await apiFetch(`/api/fame/${bandId}/total`);
   const fameData = await fameRes.json();
   document.getElementById('fameTotal').innerText = fameData.fame;
 
-  const historyRes = await fetch(`/fame/${bandId}`);
+  const historyRes = await apiFetch(`/api/fame/${bandId}`);
   const historyData = await historyRes.json();
   const list = document.getElementById('fameHistory');
   list.innerHTML = '';

--- a/frontend/pages/genre_trends.html
+++ b/frontend/pages/genre_trends.html
@@ -6,11 +6,12 @@
   <title>Festival Genre Trends</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Festival Genre Trends</h2>
 <ul id="trendList"></ul>
 <script>
 async function loadTrends() {
-  const res = await fetch('/festival/proposals/trends/genres');
+  const res = await apiFetch('/api/festival/proposals/trends/genres');
   const data = await res.json();
   const list = document.getElementById('trendList');
   list.innerHTML = '';

--- a/frontend/pages/gig_booking.html
+++ b/frontend/pages/gig_booking.html
@@ -7,6 +7,7 @@
   <script type="module" src="../components/toast.js"></script>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Book a Gig</h2>
 <form id="bookingForm">
   <input type="number" name="band_id" placeholder="Band ID" required />
@@ -29,14 +30,14 @@ form.addEventListener('submit', async (e) => {
     ticket_price: parseFloat(data.get('ticket_price')),
     acoustic: data.get('acoustic') === 'on'
   };
-  const res = await fetch('/gigs/book', {
+  const res = await apiFetch('/api/gigs/book', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
   if (res.ok) {
     showToast('Booking confirmed');
-    await fetch('/notification', {
+    await apiFetch('/api/notification', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ title: 'Gig booked', body: `${payload.date}` })

--- a/frontend/pages/gig_result.html
+++ b/frontend/pages/gig_result.html
@@ -6,6 +6,7 @@
   <title>Gig Result</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
   <h2>Gig Performance Results</h2>
   <div id="results">Loading...</div>
   <script>
@@ -17,7 +18,7 @@
         return;
       }
       try {
-        const res = await fetch(`/gigs/${bandId}`);
+        const res = await apiFetch(`/api/gigs/${bandId}`);
         const gigs = await res.json();
         if (!Array.isArray(gigs) || gigs.length === 0) {
           document.getElementById('results').innerText = 'No gigs found';

--- a/frontend/pages/gig_simulator.html
+++ b/frontend/pages/gig_simulator.html
@@ -7,6 +7,7 @@
   <script type="module" src="../components/toast.js"></script>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Live Gig Simulator</h2>
 
 <form id="gigForm">
@@ -100,7 +101,7 @@ document.getElementById('gigForm').addEventListener('submit', async (e) => {
     setlist: actions.map((a, i) => ({ ...a, position: i + 1 }))
   };
 
-  const res = await fetch('/gigs/simulate', {
+  const res = await apiFetch('/api/gigs/simulate', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
@@ -110,7 +111,7 @@ document.getElementById('gigForm').addEventListener('submit', async (e) => {
   document.getElementById('resultBox').innerText = JSON.stringify(data, null, 2);
   if (res.ok) {
     showToast('Gig performed');
-    await fetch('/notification', {
+    await apiFetch('/api/notification', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ title: 'Gig performed', body: `${payload.city} - ${payload.venue}` })

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="../index.css">
 </head>
 <body>
+<script src="../utils/api.js"></script>
     <div id="react-root"></div>
     <h1>Welcome to RockMundo</h1>
     <div id="notification-root"></div>
@@ -23,7 +24,7 @@
     <script type="module" src="../components/NotificationCenter.jsx"></script>
     <script>
     async function loadDaily() {
-        const res = await fetch('/api/daily/status/1');
+        const res = await apiFetch('/api/daily/status/1');
         const data = await res.json();
         document.getElementById('streak').textContent = `Streak: ${data.login_streak}`;
         document.getElementById('challenge').textContent = `Today's challenge: ${data.current_challenge}`;
@@ -31,7 +32,7 @@
         document.getElementById('claim-btn').disabled = data.reward_claimed;
     }
     document.getElementById('claim-btn').addEventListener('click', async () => {
-        await fetch('/api/daily/claim', {
+        await apiFetch('/api/daily/claim', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ user_id: 1 })

--- a/frontend/pages/karma_dashboard.html
+++ b/frontend/pages/karma_dashboard.html
@@ -6,6 +6,7 @@
   <title>Karma Dashboard</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Karma Dashboard</h2>
 
 <div>
@@ -20,7 +21,7 @@
 <script>
 async function loadKarma() {
   const userId = document.getElementById('userId').value;
-  const res = await fetch(`/karma/${userId}`);
+  const res = await apiFetch(`/api/karma/${userId}`);
   const data = await res.json();
 
   document.getElementById('karmaTotal').innerText = data.total;

--- a/frontend/pages/login.html
+++ b/frontend/pages/login.html
@@ -6,6 +6,7 @@
   <title data-i18n="login.title">Login</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
   <label for="locale-select" data-i18n="language">Language</label>
   <select id="locale-select"></select>
 
@@ -25,7 +26,7 @@
       const username = document.getElementById('username').value;
       const password = document.getElementById('password').value;
       try {
-        const res = await fetch('/auth/token', {
+        const res = await apiFetch('/auth/login', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded',

--- a/frontend/pages/media_mentions.html
+++ b/frontend/pages/media_mentions.html
@@ -6,6 +6,7 @@
   <title>Media Mentions</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Media Mentions Monitor</h2>
 <button onclick="pollFeed()">Poll Media Feed</button>
 <ul id="mentions"></ul>
@@ -20,7 +21,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 async function loadMentions() {
-  const res = await fetch('/song-popularity/events?source=media');
+  const res = await apiFetch('/api/song-popularity/events?source=media');
   const data = await res.json();
   const list = document.getElementById('mentions');
   list.innerHTML = '';
@@ -32,11 +33,11 @@ async function loadMentions() {
   });
 }
 async function pollFeed() {
-  await fetch('/song-popularity/media/poll', {method: 'POST'});
+  await apiFetch('/api/song-popularity/media/poll', {method: 'POST'});
   loadMentions();
 }
 async function showImpact(songId) {
-  const res = await fetch(`/music/metrics/songs/${songId}/popularity`);
+  const res = await apiFetch(`/music/metrics/songs/${songId}/popularity`);
   const data = await res.json();
   const labels = data.history.map(h => h.updated_at);
   const scores = data.history.map(h => h.popularity_score);
@@ -51,7 +52,7 @@ async function sendAdjust() {
   const songId = parseInt(document.getElementById('adjSong').value);
   const amount = parseInt(document.getElementById('adjAmount').value);
   const details = document.getElementById('adjDetails').value;
-  await fetch('/song-popularity/media/adjust', {
+  await apiFetch('/api/song-popularity/media/adjust', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({song_id: songId, amount: amount, details: details})

--- a/frontend/pages/music_library.html
+++ b/frontend/pages/music_library.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="../index.css" />
 </head>
 <body>
+<script src="../utils/api.js"></script>
   <h2>Your Music Library</h2>
   <div>
     <input type="text" id="searchInput" placeholder="Search..." />
@@ -45,7 +46,7 @@
 
   async function loadPlaylists() {
     try {
-      const res = await fetch('/playlists');
+      const res = await apiFetch('/api/playlists');
       if (!res.ok) {
         console.error('Failed to load playlists', res.status);
         playlistSelect.innerHTML = '<option>Error loading playlists</option>';
@@ -67,7 +68,7 @@
 
   async function loadSongs(search = '', sort = 'title') {
     try {
-      const res = await fetch(`/songs/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
+      const res = await apiFetch(`/api/songs/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
       if (!res.ok) {
         console.error('Failed to load songs', res.status);
         document.getElementById('songList').innerHTML = '<li>Error loading songs</li>';
@@ -98,7 +99,7 @@
 
   async function loadAlbums(search = '', sort = 'title') {
     try {
-      const res = await fetch(`/albums/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
+      const res = await apiFetch(`/api/albums/band/${BAND_ID}?search=${encodeURIComponent(search)}&sort=${sort}`);
       if (!res.ok) {
         console.error('Failed to load albums', res.status);
         document.getElementById('albumList').innerHTML = '<li>Error loading albums</li>';
@@ -138,7 +139,7 @@
     const pid = playlistSelect.value;
     if (!pid) return;
     try {
-      const res = await fetch(`/playlists/${pid}/songs`, {
+      const res = await apiFetch(`/api/playlists/${pid}/songs`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ song_id: songId })
@@ -157,7 +158,7 @@
     const pid = playlistSelect.value;
     if (!pid) return;
     try {
-      const res = await fetch(`/playlists/${pid}/songs/${songId}`, { method: 'DELETE' });
+      const res = await apiFetch(`/api/playlists/${pid}/songs/${songId}`, { method: 'DELETE' });
       if (!res.ok) {
         console.error('Failed to remove song from playlist', res.status);
         alert('Failed to remove song from playlist.');
@@ -176,7 +177,7 @@
       return;
     }
     try {
-      const res = await fetch(`/api/mail/search?q=${encodeURIComponent(q)}`);
+      const res = await apiFetch(`/api/mail/search?q=${encodeURIComponent(q)}`);
       if (!res.ok) {
         list.innerHTML = '<li>Error searching mail</li>';
         return;

--- a/frontend/pages/notifications.html
+++ b/frontend/pages/notifications.html
@@ -6,12 +6,13 @@
   <title>Notifications</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Notifications</h2>
 <ul id="notifList"></ul>
 
 <script>
 async function loadNotifications() {
-  const res = await fetch('/notification');
+  const res = await apiFetch('/api/notification');
   const data = await res.json();
   const list = document.getElementById('notifList');
   list.innerHTML = '';

--- a/frontend/pages/npc_band_admin.html
+++ b/frontend/pages/npc_band_admin.html
@@ -6,6 +6,7 @@
   <title>Npc Band Admin</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>NPC Band Admin</h2>
 
 <button onclick="createBand()">Create NPC Band</button>
@@ -15,13 +16,13 @@
 
 <script>
 async function createBand() {
-  const res = await fetch('/npc_band/create', { method: 'POST' });
+  const res = await apiFetch('/api/npc_band/create', { method: 'POST' });
   const data = await res.json();
   log(`Created: ${data.name} (${data.genre})`);
 }
 
 async function simulate() {
-  await fetch('/npc_band/simulate', { method: 'POST' });
+  await apiFetch('/api/npc_band/simulate', { method: 'POST' });
   log("Simulated NPC band activity.");
 }
 

--- a/frontend/pages/playlist_manager.html
+++ b/frontend/pages/playlist_manager.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="../index.css" />
 </head>
 <body>
+<script src="../utils/api.js"></script>
   <h2>Playlist Manager</h2>
   <form id="newPlaylistForm">
     <input type="text" id="playlistName" placeholder="Playlist name" required />
@@ -17,7 +18,7 @@
 
   <script>
   async function loadPlaylists() {
-    const res = await fetch('/playlists');
+    const res = await apiFetch('/api/playlists');
     const data = await res.json();
     const list = document.getElementById('playlistList');
     list.innerHTML = '';
@@ -58,7 +59,7 @@
     e.preventDefault();
     const name = document.getElementById('playlistName').value;
     const is_public = document.getElementById('isPublic').checked;
-    await fetch('/playlists', {
+    await apiFetch('/api/playlists', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, is_public })
@@ -69,7 +70,7 @@
 
   async function addSong(playlistId, songId) {
     if (!songId) return;
-    await fetch(`/playlists/${playlistId}/songs`, {
+    await apiFetch(`/api/playlists/${playlistId}/songs`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ song_id: parseInt(songId) })
@@ -78,12 +79,12 @@
   }
 
   async function removeSong(playlistId, songId) {
-    await fetch(`/playlists/${playlistId}/songs/${songId}`, { method: 'DELETE' });
+    await apiFetch(`/api/playlists/${playlistId}/songs/${songId}`, { method: 'DELETE' });
     loadPlaylists();
   }
 
   async function deletePlaylist(id) {
-    await fetch(`/playlists/${id}`, { method: 'DELETE' });
+    await apiFetch(`/api/playlists/${id}`, { method: 'DELETE' });
     loadPlaylists();
   }
 

--- a/frontend/pages/playlist_view.html
+++ b/frontend/pages/playlist_view.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="../index.css" />
 </head>
 <body>
+<script src="../utils/api.js"></script>
   <h2 id="playlistName">Playlist</h2>
   <ul id="songList"></ul>
   <script>
@@ -14,7 +15,7 @@
     const params = new URLSearchParams(window.location.search);
     const id = params.get('id');
     if (!id) return;
-    const res = await fetch(`/playlists/public/${id}`);
+    const res = await apiFetch(`/api/playlists/public/${id}`);
     if (res.status !== 200) {
       document.getElementById('playlistName').textContent = 'Playlist unavailable';
       return;

--- a/frontend/pages/popularity_dashboard.html
+++ b/frontend/pages/popularity_dashboard.html
@@ -6,6 +6,7 @@
   <title>Popularity Dashboard</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Song Popularity Dashboard</h2>
 
 <div>
@@ -37,7 +38,7 @@
 <script>
 async function loadPopularity() {
   const id = document.getElementById('songId').value;
-  const res = await fetch(`/music/metrics/songs/${id}/popularity`);
+  const res = await apiFetch(`/music/metrics/songs/${id}/popularity`);
   const data = await res.json();
   document.getElementById('currentPopularity').innerText = data.current_popularity;
   document.getElementById('halfLife').innerText = data.half_life_days.toFixed(2);
@@ -50,7 +51,7 @@ async function loadPopularity() {
     list.appendChild(li);
   });
 
-  const sRes = await fetch(`/music/metrics/songs/${id}/sentiment`);
+  const sRes = await apiFetch(`/music/metrics/songs/${id}/sentiment`);
   const sData = await sRes.json();
   document.getElementById('currentSentiment').innerText = sData.current_sentiment.toFixed(2);
   const sList = document.getElementById('sentimentHistory');
@@ -63,7 +64,7 @@ async function loadPopularity() {
 
   renderTrendChart(data.history, sData.history);
 
-  const fRes = await fetch(`/music/metrics/songs/${id}/forecast`);
+  const fRes = await apiFetch(`/music/metrics/songs/${id}/forecast`);
 
   // Hooks for custom chart rendering if available
   const fData = await fRes.json();
@@ -85,7 +86,7 @@ async function loadPopularity() {
 
 async function loadWorldPulse() {
   const today = new Date().toISOString().slice(0, 10);
-  const res = await fetch(`/api/world-pulse/ranked?date=${today}&limit=10`);
+  const res = await apiFetch(`/api/world-pulse/ranked?date=${today}&limit=10`);
   const data = await res.json();
   const list = document.getElementById('worldPulse');
   list.innerHTML = '';

--- a/frontend/pages/revenue_dashboard.html
+++ b/frontend/pages/revenue_dashboard.html
@@ -6,6 +6,7 @@
   <title>Revenue Dashboard</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Revenue Dashboard</h2>
 
 <div>
@@ -19,7 +20,7 @@
 <script>
 async function fetchRevenue() {
   const bandId = document.getElementById('bandIdInput').value;
-  const res = await fetch(`/revenue/band/${bandId}`);
+  const res = await apiFetch(`/api/revenue/band/${bandId}`);
   const data = await res.json();
   const container = document.getElementById('revenueResults');
   container.innerHTML = "<pre>" + JSON.stringify(data, null, 2) + "</pre>";

--- a/frontend/pages/schedule.html
+++ b/frontend/pages/schedule.html
@@ -14,6 +14,7 @@
   </style>
 </head>
 <body>
+<script src="../utils/api.js"></script>
   <h2>Schedule Planner</h2>
   <div id="scheduleStats">
     <h3>Daily Stats</h3>
@@ -134,7 +135,7 @@
     document.getElementById('historyBtn').addEventListener('click', async () => {
       const date = document.getElementById('historyDate').value;
       if (!date) return;
-      const res = await fetch(`/schedule/history/${date}`);
+      const res = await apiFetch(`/api/schedule/history/${date}`);
       const data = await res.json();
       const list = document.getElementById('historyList');
       list.innerHTML = '';
@@ -148,7 +149,7 @@
       const userId = document.getElementById('exportUserId').value;
       const date = document.getElementById('exportDate').value;
       if (!userId || !date) return;
-      window.location = `/schedule/export/ics?user_id=${userId}&date=${date}`;
+      window.location = `/api/schedule/export/ics?user_id=${userId}&date=${date}`;
     });
 
     document.getElementById('copyBtn').addEventListener('click', async () => {
@@ -164,7 +165,7 @@
         dates.push(d.toISOString().slice(0,10));
         d.setDate(d.getDate() + 1);
       }
-      await fetch('/schedule/copy', {
+      await apiFetch('/api/schedule/copy', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({user_id: parseInt(uid), src_date: src, dest_dates: dates})
@@ -175,7 +176,7 @@
     async function loadTemplates() {
       const uid = document.getElementById('tmplUser').value;
       if (!uid) return;
-      const res = await fetch(`/schedule/templates/${uid}`);
+      const res = await apiFetch(`/api/schedule/templates/${uid}`);
       const data = await res.json();
       tmplSelect.innerHTML = '';
       for (const t of data.templates) {
@@ -192,9 +193,9 @@
       const day = document.getElementById('tmplDay').value;
       const name = document.getElementById('tmplName').value;
       if (!uid || !day || !name) return;
-      const res = await fetch(`/schedule/default-plan/${uid}/${day}`);
+      const res = await apiFetch(`/api/schedule/default-plan/${uid}/${day}`);
       const plan = await res.json();
-      await fetch(`/schedule/templates/${uid}`, {
+      await apiFetch(`/api/schedule/templates/${uid}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({name, entries: plan.plan})
@@ -207,7 +208,7 @@
       const date = document.getElementById('tmplDate').value;
       const tid = tmplSelect.value;
       if (!uid || !date || !tid) return;
-      await fetch(`/schedule/apply-template/${uid}/${date}/${tid}`, {method: 'POST'});
+      await apiFetch(`/api/schedule/apply-template/${uid}/${date}/${tid}`, {method: 'POST'});
     });
   </script>
   <script src="../components/themeToggle.js"></script>

--- a/frontend/pages/setlist_review.html
+++ b/frontend/pages/setlist_review.html
@@ -6,6 +6,7 @@
   <title>Setlist Review</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Setlist Review</h2>
 
 <input type="number" id="performanceId" placeholder="Performance ID" />
@@ -30,7 +31,7 @@
 document.getElementById('loadBtn').onclick = async () => {
   const id = document.getElementById('performanceId').value;
   if (!id) return;
-  const res = await fetch(`/analysis/setlist/${id}`);
+  const res = await apiFetch(`/analysis/setlist/${id}`);
   const data = await res.json();
   const body = document.getElementById('summaryBody');
   body.innerHTML = '';

--- a/frontend/pages/skin_marketplace.html
+++ b/frontend/pages/skin_marketplace.html
@@ -5,12 +5,13 @@
     <title>Skin Marketplace</title>
   </head>
   <body>
+<script src="../utils/api.js"></script>
     <h1>Skin Marketplace</h1>
     <ul id="skinList"></ul>
 
     <script>
       async function loadSkins() {
-        const res = await fetch('/api/skins');
+        const res = await apiFetch('/api/skins');
         const skins = await res.json();
         const list = document.getElementById('skinList');
         list.innerHTML = '';
@@ -20,7 +21,7 @@
           const btn = document.createElement('button');
           btn.textContent = 'Buy';
           btn.onclick = async () => {
-            await fetch(`/api/skins/${skin.id}/purchase`, { method: 'POST' });
+            await apiFetch(`/api/skins/${skin.id}/purchase`, { method: 'POST' });
             alert('Purchased ' + skin.name);
           };
           item.appendChild(btn);

--- a/frontend/pages/song_collab.html
+++ b/frontend/pages/song_collab.html
@@ -6,7 +6,7 @@
   <title>Song Collaboration</title>
   <script>
     async function loadVersions(draftId) {
-      const res = await fetch(`/songwriting/drafts/${draftId}/versions`);
+      const res = await apiFetch(`/api/songwriting/drafts/${draftId}/versions`);
       const versions = await res.json();
       const list = document.getElementById('versions');
       list.innerHTML = '';
@@ -30,6 +30,7 @@
   </script>
 </head>
 <body>
+<script src="../utils/api.js"></script>
   <h1>Collaborative Song Editor</h1>
   <textarea id="lyrics" rows="10" cols="60"></textarea>
   <h3>Version History</h3>

--- a/frontend/pages/song_form.html
+++ b/frontend/pages/song_form.html
@@ -7,6 +7,7 @@
   <title>Song Form</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <div id="react-root"></div>
 
 <h2>Create Song</h2>
@@ -61,7 +62,7 @@
   let lastCollaborators = [];
 
   function loadSkill() {
-    fetch('/songwriting/skill')
+    apiFetch('/api/songwriting/skill')
       .then(r => r.json())
       .then(s => {
         document.getElementById('skillLevel').textContent = s.level;
@@ -74,7 +75,7 @@
   function loadBandMembers() {
     const bandId = new URLSearchParams(window.location.search).get('band_id');
     if (!bandId) return;
-    fetch(`/bands/${bandId}`)
+    apiFetch(`/api/bands/${bandId}`)
       .then(r => r.json())
       .then(b => {
         const sel = document.getElementById('coWriters');
@@ -89,7 +90,7 @@
 
   loadBandMembers();
 
-  fetch('/songwriting/themes')
+  apiFetch('/api/songwriting/themes')
     .then(r => r.json())
     .then(list => {
       const sel = document.getElementById('themes');
@@ -113,7 +114,7 @@
     let list = lastCollaborators;
     for (const id of ids) {
       try {
-        const res = await fetch(`/songwriting/drafts/${draftId}/co_writers`, {
+        const res = await apiFetch(`/api/songwriting/drafts/${draftId}/co_writers`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ co_writer_id: id })
@@ -146,7 +147,7 @@
   function pollCollaborators(draftId) {
     setInterval(async () => {
       try {
-        const res = await fetch(`/songwriting/drafts/${draftId}/co_writers`);
+        const res = await apiFetch(`/api/songwriting/drafts/${draftId}/co_writers`);
         if (!res.ok) return;
         const data = await res.json();
         const list = data.co_writers || [];
@@ -174,7 +175,7 @@
       themes
     };
     try {
-      const res = await fetch('/songwriting/prompt', {
+      const res = await apiFetch('/api/songwriting/prompt', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
@@ -222,7 +223,7 @@
       distribution_channels: Array.from(form.distribution_channels.selectedOptions).map(o => o.value)
     };
     try {
-      const res = await fetch('/songs', {
+      const res = await apiFetch('/api/songs', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)

--- a/frontend/pages/tour_collab.html
+++ b/frontend/pages/tour_collab.html
@@ -6,6 +6,7 @@
   <title>Tour Collab</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Tour Collaboration Planner</h2>
 <form id="collabForm">
   <label>Band IDs (comma separated):</label>
@@ -71,7 +72,7 @@ document.getElementById('collabForm').addEventListener('submit', async (e) => {
   const setlist = JSON.parse(document.getElementById('setlist').value || '[]');
   const revenueSplit = document.getElementById('revenueSplit').value ? JSON.parse(document.getElementById('revenueSplit').value) : {};
   const payload = { band_ids: bandIds, setlist, revenue_split: revenueSplit, schedule, expenses };
-  const res = await fetch('/api/tour-collab', {
+  const res = await apiFetch('/api/tour-collab', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)

--- a/frontend/pages/tour_planner.html
+++ b/frontend/pages/tour_planner.html
@@ -6,6 +6,7 @@
   <title>Tour Planner</title>
 </head>
 <body>
+<script src="../utils/api.js"></script>
 <h2>Tour Planner</h2>
 
 <link
@@ -80,14 +81,14 @@ document.getElementById('tourForm').addEventListener('submit', async (e) => {
     route: route
   };
 
-  const res = await fetch('/api/tour-planner/optimize', {
+  const res = await apiFetch('/api/tour-planner/optimize', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
 
   const result = await res.json();
-  const quotaRes = await fetch(`/api/bands/${payload.band_id}/recording-slots`);
+  const quotaRes = await apiFetch(`/api/bands/${payload.band_id}/recording-slots`);
   const { remaining_slots } = await quotaRes.json();
   const itineraryDiv = document.getElementById('itinerary');
   let remainingSlots = remaining_slots;
@@ -135,7 +136,7 @@ document.getElementById('tourForm').addEventListener('submit', async (e) => {
     )
       .filter((cb) => cb.checked)
       .map((cb) => parseInt(cb.dataset.idx));
-    await fetch('/api/tour-planner/schedule/update', {
+    await apiFetch('/api/tour-planner/schedule/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ updates: recordStops.map((id) => ({ stop_id: id, is_recorded: true })) }),

--- a/frontend/utils/api.js
+++ b/frontend/utils/api.js
@@ -1,0 +1,21 @@
+export async function apiFetch(input, init = {}) {
+  const headers = new Headers(init.headers || {});
+  const token = typeof localStorage !== 'undefined' ? localStorage.getItem('jwt') : null;
+  if (token && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  if (init.body && !(init.body instanceof FormData) && !(init.body instanceof URLSearchParams) && typeof init.body !== 'string') {
+    headers.set('Content-Type', 'application/json');
+    init.body = JSON.stringify(init.body);
+  }
+  const response = await fetch(input, { ...init, headers });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || response.statusText);
+  }
+  return response;
+}
+
+if (typeof window !== 'undefined') {
+  window.apiFetch = apiFetch;
+}


### PR DESCRIPTION
## Summary
- add shared `apiFetch` helper to standardize requests and inject auth headers
- replace direct `fetch` calls across frontend pages with `apiFetch`
- align many page endpoints with `/api` backend routes

## Testing
- `npm test` *(fails: Invalid package.json)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'tests.realtime')*

------
https://chatgpt.com/codex/tasks/task_e_68c0a941050483258754388b1a39619b