### PR TITLE
Add live3d gig rendering prototype

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -81,6 +81,7 @@ backend/
 frontend/
   pages/*.html                    # static testable pages
   components/*.js / *.vue         # widgets (notifications, schedule, player, charts, etc.)
+live3d/                    # 3D performance rendering prototype
 tests/
   ...                             # ~50+ pytest suites (realtime, lifestyle, charts, etc.)
 docs/ TDD_with_diagrams.md        # high-level design notes/diagrams

--- a/docs/live3d_prototype.md
+++ b/docs/live3d_prototype.md
@@ -1,0 +1,25 @@
+# live3d Prototype
+
+The `live3d` module is a minimal experiment for visualising gig completion
+results in 3D. It uses `matplotlib` to render a single bar showing the
+crowd attendance for a gig.
+
+## Build
+
+Install the optional dependency:
+
+```bash
+pip install matplotlib
+```
+
+## Run
+
+Create some gig data and then render it:
+
+```bash
+# assuming an existing SQLite database with gigs
+python -m live3d --gig-id 1 --db path/to/gig.db
+```
+
+The command fetches the gig's completion data using
+`backend.services.gig_service` and displays the attendance as a 3D bar.

--- a/live3d/__init__.py
+++ b/live3d/__init__.py
@@ -1,0 +1,5 @@
+"""Prototype 3D live performance renderer."""
+
+from .engine import PerformanceRenderer, render_gig
+
+__all__ = ["PerformanceRenderer", "render_gig"]

--- a/live3d/__main__.py
+++ b/live3d/__main__.py
@@ -1,0 +1,21 @@
+"""Command line entry point for the live3d prototype."""
+
+from __future__ import annotations
+
+import argparse
+
+from .engine import render_gig
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render gig data in 3D")
+    parser.add_argument("--gig-id", type=int, required=True, help="Gig identifier")
+    parser.add_argument(
+        "--db", default="rockmundo.db", help="Path to gig SQLite database"
+    )
+    args = parser.parse_args()
+    render_gig(args.gig_id, args.db)
+
+
+if __name__ == "__main__":
+    main()

--- a/live3d/engine.py
+++ b/live3d/engine.py
@@ -1,0 +1,49 @@
+"""Simple 3D performance rendering prototype.
+
+This module demonstrates how gig completion data can drive visuals. It
+uses matplotlib's 3D plotting capabilities to render a bar representing
+the crowd attendance of a completed gig.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
+from backend.services import gig_service
+
+
+class PerformanceRenderer:
+    """Render gig data in a minimal 3D scene."""
+
+    def __init__(self) -> None:
+        self.fig = plt.figure()
+        self.ax = self.fig.add_subplot(111, projection="3d")
+
+    def render(self, attendance: int) -> None:
+        """Render a single bar representing crowd attendance."""
+        # Draw a bar whose height equals attendance
+        self.ax.bar3d([0], [0], [0], 1, 1, [attendance], color="mediumseagreen")
+        self.ax.set_zlim(0, max(100, attendance * 1.2))
+        self.ax.set_xlabel("X")
+        self.ax.set_ylabel("Y")
+        self.ax.set_zlabel("Attendance")
+        self.ax.set_title("Gig Attendance")
+        plt.show()
+
+
+def render_gig(gig_id: int, db_path: str) -> None:
+    """Fetch gig results and render them.
+
+    Parameters
+    ----------
+    gig_id: int
+        Identifier of the gig in the database.
+    db_path: str
+        Path to the SQLite database file containing gig records.
+    """
+    gig_service.DB_PATH = db_path
+    result = gig_service.simulate_gig_result(gig_id)
+    attendance = int(result.get("attendance", 0))
+    renderer = PerformanceRenderer()
+    renderer.render(attendance)


### PR DESCRIPTION
## Summary
- Scaffold `live3d` module with a minimal 3D renderer driven by gig completion data
- Document build and run steps for the live3d prototype
- Reference the new module in the repository layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aae45da08325a432ec3b09105d41