### PR TITLE
Support mail attachments across backend and frontend

### DIFF
--- a/backend/routes/mail_routes.py
+++ b/backend/routes/mail_routes.py
@@ -5,29 +5,28 @@ Endpoints for sending, listing, and deleting mail messages.
 
 import sqlite3
 
-from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, File, Form, UploadFile
 
 from auth.dependencies import get_current_user_id
 from services.mailbox_service import delete_message, get_inbox, send_message
+from services.storage_service import save_attachment
 from utils.db import aget_conn
 
 
 router = APIRouter(prefix="/mail", tags=["Mail"])
 
 
-class MailSendIn(BaseModel):
-    """Payload for sending a new mail message."""
-
-    recipient_id: int
-    subject: str
-    body: str
-
-
 @router.post("/")
-async def send_mail(payload: MailSendIn, user_id: int = Depends(get_current_user_id)):
+async def send_mail(
+    recipient_id: int = Form(...),
+    subject: str = Form(...),
+    body: str = Form(...),
+    files: list[UploadFile] = File([]),
+    user_id: int = Depends(get_current_user_id),
+):
     """Send a mail message from the authenticated user."""
-    return await send_message(user_id, payload.recipient_id, payload.subject, payload.body)
+    attachments = [await save_attachment(f) for f in files]
+    return await send_message(user_id, recipient_id, subject, body, attachments)
 
 
 @router.get("/")

--- a/backend/routes/mailbox_routes.py
+++ b/backend/routes/mailbox_routes.py
@@ -1,16 +1,22 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, Form, UploadFile
 from auth.dependencies import get_current_user_id, require_permission
 from services.mailbox_service import delete_message, get_inbox, send_message
+from services.storage_service import save_attachment
 
 router = APIRouter()
 
 
 @router.post("/mail/send", dependencies=[Depends(require_permission(["admin", "moderator"]))])
-async def send_message_route(payload: dict, user_id: int = Depends(get_current_user_id)):
+async def send_message_route(
+    recipient_id: int = Form(...),
+    subject: str = Form(...),
+    body: str = Form(...),
+    files: list[UploadFile] = File([]),
+    user_id: int = Depends(get_current_user_id),
+):
     """Send a mail message on behalf of an admin or moderator."""
-    return await send_message(
-        user_id, payload["recipient_id"], payload["subject"], payload["body"]
-    )
+    attachments = [await save_attachment(f) for f in files]
+    return await send_message(user_id, recipient_id, subject, body, attachments)
 
 
 @router.get("/mail/inbox")

--- a/frontend/pages/mail_compose.html
+++ b/frontend/pages/mail_compose.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Compose Mail</title>
+</head>
+<body>
+  <h1>Compose Mail</h1>
+  <form id="mail-form">
+    <input type="number" id="recipient" placeholder="Recipient ID" required />
+    <input type="text" id="subject" placeholder="Subject" required />
+    <textarea id="body" placeholder="Message" required></textarea>
+    <input type="file" id="files" multiple />
+    <button type="submit">Send</button>
+  </form>
+  <script type="module">
+    import { authFetch } from '../utils/auth.js';
+
+    document.getElementById('mail-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const form = new FormData();
+      form.append('recipient_id', document.getElementById('recipient').value);
+      form.append('subject', document.getElementById('subject').value);
+      form.append('body', document.getElementById('body').value);
+      const files = document.getElementById('files').files;
+      for (const f of files) form.append('files', f);
+      await authFetch('/mail', { method: 'POST', body: form });
+      window.location.href = '/mailbox.html';
+    });
+  </script>
+</body>
+</html>
+

--- a/frontend/pages/mailbox.html
+++ b/frontend/pages/mailbox.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Mailbox</title>
+</head>
+<body>
+  <h1>Mailbox</h1>
+  <div id="messages"></div>
+  <script type="module">
+    import { authFetch } from '../utils/auth.js';
+
+    async function load() {
+      const res = await authFetch('/mail');
+      if (!res.ok) return;
+      const data = await res.json();
+      const container = document.getElementById('messages');
+      data.forEach(m => {
+        const div = document.createElement('div');
+        div.innerHTML = `<h3>${m.subject}</h3><p>${m.body}</p>`;
+        if (m.attachments && m.attachments.length) {
+          const list = document.createElement('ul');
+          m.attachments.forEach(a => {
+            const li = document.createElement('li');
+            const link = document.createElement('a');
+            link.href = a.url;
+            link.textContent = a.filename;
+            link.download = '';
+            li.appendChild(link);
+            list.appendChild(li);
+          });
+          div.appendChild(list);
+        }
+        container.appendChild(div);
+      });
+    }
+    load();
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Save uploaded mail attachments via storage service and include metadata in mailbox entries
- Accept multipart mail submissions with attachments in user and admin routes
- Add compose and inbox pages that support file uploads and download links

## Testing
- `pytest` *(fails: A parameter-less dependency must have a callable dependency and numerous import errors)*


------
https://chatgpt.com/codex/tasks/task_e_68c0aae54ac4832594f6d11994062a8f