### PR TITLE
fix: use absolute auth service import

### DIFF
--- a/backend/utils/auth_utils.py
+++ b/backend/utils/auth_utils.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
 
 from core.config import settings
-from services.auth_service import get_user_by_username, verify_password
 
 from backend.auth.jwt import encode
+from backend.services.auth_service import get_user_by_username, verify_password
 
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.auth.access_token_ttl_min
 


### PR DESCRIPTION
## Summary
- use absolute import for auth service

## Testing
- `ruff check backend/utils/auth_utils.py`
- `pytest tests/test_auth_service_refresh.py tests/test_jwt_module.py` *(fails: It is required that you pass in a value for the "algorithms" argument when calling decode())*

------
https://chatgpt.com/codex/tasks/task_e_68c2e025a974832593b396d8a93e15dd