### PR TITLE
chore: add netlify deployment configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+  base = "frontend"
+  publish = "frontend/build"
+  command = "npm ci && npm run build"
+
+[[redirects]]
+  from = "/api/*"
+  to = "http://localhost:8000/api/:splat"
+  status = 200
+  force = true


### PR DESCRIPTION
## Summary
- add Netlify build config for frontend
- proxy /api requests to backend

## Testing
- `pytest` (fails: 32 errors during collection)
- `cd frontend && npm test` (fails: Invalid package.json JSON)

------
https://chatgpt.com/codex/tasks/task_e_68c2e30991e4832596158275b78a8554