### PR TITLE
feat(frontend): prefix API base URL for requests

### DIFF
--- a/frontend/utils/api.js
+++ b/frontend/utils/api.js
@@ -4,11 +4,28 @@ export async function apiFetch(input, init = {}) {
   if (token && !headers.has('Authorization')) {
     headers.set('Authorization', `Bearer ${token}`);
   }
-  if (init.body && !(init.body instanceof FormData) && !(init.body instanceof URLSearchParams) && typeof init.body !== 'string') {
+
+  if (
+    init.body &&
+    !(init.body instanceof FormData) &&
+    !(init.body instanceof URLSearchParams) &&
+    typeof init.body !== 'string'
+  ) {
     headers.set('Content-Type', 'application/json');
     init.body = JSON.stringify(init.body);
   }
-  const response = await fetch(input, { ...init, headers });
+
+  const API_BASE =
+    (typeof process !== 'undefined' && process.env && process.env.REACT_APP_API_BASE) ||
+    (typeof window !== 'undefined' && window.API_BASE) ||
+    '';
+
+  let url = typeof input === 'string' ? input : input.url;
+  if (!/^https?:\/\//i.test(url)) {
+    url = API_BASE + url;
+  }
+
+  const response = await fetch(url, { ...init, headers });
   if (!response.ok) {
     const text = await response.text();
     throw new Error(text || response.statusText);
@@ -19,3 +36,4 @@ export async function apiFetch(input, init = {}) {
 if (typeof window !== 'undefined') {
   window.apiFetch = apiFetch;
 }
+


### PR DESCRIPTION
## Summary
- prepend REACT_APP_API_BASE or window.API_BASE to all frontend API requests

## Testing
- `npm test` *(fails: Invalid package.json: JSONParseError)*
- `npm run build` *(fails: Invalid package.json: JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e38653a88325908e0ded39f6215a