### PR TITLE
feat: add dockerfile for backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Run the application
+CMD ["uvicorn", "backend.api:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- containerize backend with a Python 3.11 base image and uvicorn entrypoint

## Testing
- `pytest` *(fails: A parameter-less dependency must have a callable dependency, ImportError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e389b0c8832596a19b427c30a355