### PR TITLE
docs: restrict CORS origins in example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,8 @@ ROCKMUNDO_RATE_LIMIT_REDIS_URL=redis://localhost:6379/0
 # CORS
 ###############################
 # Comma-separated list of allowed origins
-ROCKMUNDO_CORS_ALLOWED_ORIGINS="*"
+# Set to https://your-netlify-site.netlify.app
+ROCKMUNDO_CORS_ALLOWED_ORIGINS=""
 
 ###############################
 # Realtime backend


### PR DESCRIPTION
## Summary
- limit default CORS origins in `.env.example`

## Testing
- `pytest` *(fails: A parameter-less dependency must have a callable dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e4f4cd588325938473c2cccc3a22