### PR TITLE
Add frontend API base env example and Netlify config

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE=https://backend.example.com

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,6 +8,13 @@ Install dependencies with [npm](https://www.npmjs.com/):
 npm install
 ```
 
+Copy the example environment file and update the backend URL:
+
+```bash
+cp .env.example .env
+# edit REACT_APP_API_BASE to point at your backend
+```
+
 ## Development
 
 Start a development server that proxies API requests to the FastAPI backend:

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,9 @@
   publish = "frontend/build"
   command = "npm ci && npm run build"
 
+[build.environment]
+  REACT_APP_API_BASE = "https://backend.example.com"
+
 [[redirects]]
   from = "/api/*"
   to = "http://localhost:8000/api/:splat"


### PR DESCRIPTION
## Summary
- provide `.env.example` for frontend with `REACT_APP_API_BASE`
- document copying the example env file in the frontend README
- configure Netlify build to define `REACT_APP_API_BASE`

## Testing
- `npm install` *(fails: Expected ',' or '}' after property value in JSON at position 400)*
- `pytest -q` *(fails: Interrupted: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e4f64f7883259c56c91fcf4900bb