### PR TITLE
Add trailing comma for date-fns dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "react-big-calendar": "^1.8.5",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
-    "date-fns": "^3.6.0"
+    "date-fns": "^3.6.0",
     "react-router-dom": "^6.22.3"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- add missing comma after date-fns dependency in frontend package.json

## Testing
- `npm install` (fails: 403 Forbidden for @testing-library/jest-dom)
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c2e3809dac8325a0cf163f610f0b07