### PR TITLE
Update Netlify config for SPA routing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "frontend"
-  publish = "frontend/build"
+  publish = "build"
   command = "npm ci && npm run build"
 
 [build.environment]
@@ -8,7 +8,6 @@
   REACT_APP_API_BASE = "https://backend.example.com"
 
 [[redirects]]
-  from = "/api/*"
-  to = "http://localhost:8000/api/:splat"
+  from = "/*"
+  to = "/index.html"
   status = 200
-  force = true


### PR DESCRIPTION
## Summary
- simplify Netlify build path now that base points to frontend
- remove legacy API redirect and add SPA catch-all redirect

## Testing
- `pytest -q 2>&1 | tail -n 20` *(fails: ModuleNotFoundError: No module named 'tests.realtime')*


------
https://chatgpt.com/codex/tasks/task_e_68c2e7cbf34483259904e83dd9b9bfae