### PR TITLE
chore(ci): use Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '18'
 
       - name: Install frontend deps
         if: hashFiles('frontend/package.json') != ''


### PR DESCRIPTION
## Summary
- align CI Node.js version with Netlify deployment by setting node-version to 18

## Testing
- `pytest` (fails: A parameter-less dependency must have a callable dependency; multiple import errors)
- `npm test` (fails: vitest not found)
- `npm install` (fails: 403 Forbidden fetching @testing-library/jest-dom)


------
https://chatgpt.com/codex/tasks/task_e_68c2e7cd67f88325b9de2b8b6ac37a79