### PR TITLE
Add Docker entrypoint for migrations and demo seeding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy source code
 COPY . .
+COPY backend/scripts/docker-entrypoint.sh /app/
 
 # Expose the port the app runs on
 EXPOSE 8000
 
+ENTRYPOINT ["./docker-entrypoint.sh"]
 # Run the application
 CMD ["uvicorn", "backend.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+./backend/scripts/migrate.sh
+python -m backend.scripts.seed_demo
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add docker entrypoint script that migrates and seeds demo data before starting
- use entrypoint in Dockerfile

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'tests.realtime')
- `docker build -t rockmundo-test .` (fails: command not found)
- `docker push rockmundo-test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c2e7cf14c88325bc8245161fe0de04