### PR TITLE
feat(frontend): copy pages to build output

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && cp -R pages build/",
     "test": "vitest --run --config tests/vitest.config.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- copy static pages into the build directory after bundling

## Testing
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org)*
- `npm run build` *(fails: react-scripts: not found)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e7ccb9e083258d3db3c0cb0281fb