### PR TITLE
refactor: simplify auth dependency imports

### DIFF
--- a/backend/tests/analytics/test_analytics.py
+++ b/backend/tests/analytics/test_analytics.py
@@ -6,7 +6,7 @@ from backend.auth.service import AuthService
 from fastapi import HTTPException, Request
 from utils.db import get_conn
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.services.analytics_service import SERVICE_LATENCY_MS, AnalyticsService
 from backend.utils.metrics import generate_latest
 

--- a/backend/tests/auth/test_permissions.py
+++ b/backend/tests/auth/test_permissions.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-from backend.auth.dependencies import require_permission
+from auth.dependencies import require_permission
 from backend.auth.permissions import Permissions
 
 

--- a/backend/tests/auth/test_rbac_integration.py
+++ b/backend/tests/auth/test_rbac_integration.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.testclient import TestClient
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.auth import rbac
 
 

--- a/realtime/admin_gateway.py
+++ b/realtime/admin_gateway.py
@@ -11,7 +11,7 @@ from .gateway import hub, get_current_user_id_dep
 from backend.monitoring.websocket import track_connect, track_disconnect, track_message
 
 try:  # pragma: no cover - fallback during tests
-    from backend.auth.dependencies import require_permission
+    from auth.dependencies import require_permission
 except Exception:  # pragma: no cover
     async def require_permission(roles, user_id):  # type: ignore
         if user_id != 1:

--- a/routes/admin_business_routes.py
+++ b/routes/admin_business_routes.py
@@ -1,7 +1,7 @@
 """Administrative CRUD routes for businesses."""
 from fastapi import APIRouter, HTTPException, Request, Depends
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.business_service import BusinessService
 from services.admin_audit_service import audit_dependency
 

--- a/routes/admin_city_shop_routes.py
+++ b/routes/admin_city_shop_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.admin_audit_service import audit_dependency
 from services.city_shop_service import CityShopService
 from services.shop_restock_service import schedule_restock

--- a/routes/admin_course_routes.py
+++ b/routes/admin_course_routes.py
@@ -1,7 +1,7 @@
 """Admin routes for managing courses."""
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.models.course import Course
 from services.admin_audit_service import audit_dependency
 from services.course_admin_service import course_admin_service, CourseAdminService

--- a/routes/admin_drug_routes.py
+++ b/routes/admin_drug_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import require_admin
+from auth.dependencies import require_admin
 from backend.models.item import Item, ItemCategory
 from backend.models.drug import Drug
 from services.admin_audit_service import audit_dependency

--- a/routes/admin_economy_routes.py
+++ b/routes/admin_economy_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.economy_admin_service import EconomyAdminService
 from backend.models.economy_config import EconomyConfig
 from services.admin_audit_service import audit_dependency

--- a/routes/admin_events_routes.py
+++ b/routes/admin_events_routes.py
@@ -5,7 +5,7 @@ from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends
 
-from backend.auth.dependencies import require_permission
+from auth.dependencies import require_permission
 from backend.schemas.events_schemas import (
     EndEventSchema,
     EventResponse,

--- a/routes/admin_item_routes.py
+++ b/routes/admin_item_routes.py
@@ -1,7 +1,7 @@
 """Admin routes for managing generic items."""
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.models.item import Item
 from services.admin_audit_service import audit_dependency
 from services.item_service import ItemService

--- a/routes/admin_job_routes.py
+++ b/routes/admin_job_routes.py
@@ -1,6 +1,6 @@
 # File: backend/routes/admin_job_routes.py
 from fastapi import APIRouter, HTTPException, Request, Depends
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from utils.i18n import _
 from services.admin_audit_service import audit_dependency
 
@@ -11,7 +11,7 @@ except Exception:
     run_weekly_rollup = None
 
 try:
-    from backend.auth.dependencies import require_permission
+    from auth.dependencies import require_permission
 except Exception:
     def require_permission(_roles):
         async def _ok():

--- a/routes/admin_lifestyle_routes.py
+++ b/routes/admin_lifestyle_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.admin_audit_service import audit_dependency
 from backend.config import lifestyle as lifestyle_config
 

--- a/routes/admin_loyalty_routes.py
+++ b/routes/admin_loyalty_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.loyalty_service import loyalty_service
 from services.admin_audit_service import audit_dependency
 

--- a/routes/admin_monitoring_routes.py
+++ b/routes/admin_monitoring_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 try:  # pragma: no cover - optional auth dependency
-    from backend.auth.dependencies import get_current_user_id, require_permission
+    from auth.dependencies import get_current_user_id, require_permission
 except Exception:  # pragma: no cover
     async def get_current_user_id(req: Request) -> int:  # type: ignore
         header = req.headers.get("X-User-Id")

--- a/routes/admin_music_routes.py
+++ b/routes/admin_music_routes.py
@@ -4,7 +4,7 @@ import backend.seeds.genre_seed as genre_seed
 import backend.seeds.skill_seed as skill_seed
 from backend.models.skill_seed_store import load_skills, save_skills
 import backend.seeds.stage_equipment_seed as equipment_seed
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.models.genre import Genre
 from backend.models.skill import Skill
 from backend.models.stage_equipment import StageEquipment

--- a/routes/admin_name_routes.py
+++ b/routes/admin_name_routes.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services import name_dataset_service as dataset_service
 from services.admin_audit_service import audit_dependency
 from pydantic import BaseModel

--- a/routes/admin_notifications_routes.py
+++ b/routes/admin_notifications_routes.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.admin_notifications_service import AdminNotificationsService
 
 router = APIRouter(prefix="/notifications", tags=["AdminNotifications"])

--- a/routes/admin_npc_dialogue_routes.py
+++ b/routes/admin_npc_dialogue_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.routes.admin_npc_routes import svc
 from services.admin_audit_service import audit_dependency
 

--- a/routes/admin_npc_routes.py
+++ b/routes/admin_npc_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.npc_service import NPCService
 from services.admin_audit_service import audit_dependency
 

--- a/routes/admin_online_tutorial_routes.py
+++ b/routes/admin_online_tutorial_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.models.online_tutorial import OnlineTutorial
 from services.admin_audit_service import audit_dependency
 from services.online_tutorial_admin_service import (

--- a/routes/admin_player_shop_routes.py
+++ b/routes/admin_player_shop_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.admin_audit_service import audit_dependency
 from services.city_shop_service import CityShopService
 

--- a/routes/admin_quest_routes.py
+++ b/routes/admin_quest_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.quest_admin_service import QuestAdminService
 from services.admin_audit_service import audit_dependency
 

--- a/routes/admin_schema_routes.py
+++ b/routes/admin_schema_routes.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Literal
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field, field_validator
 

--- a/routes/admin_season_routes.py
+++ b/routes/admin_season_routes.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend.auth.dependencies import require_permission
+from auth.dependencies import require_permission
 from backend.database import get_conn
 from services.season_service import activate_season, deactivate_season
 

--- a/routes/admin_shop_event_routes.py
+++ b/routes/admin_shop_event_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.admin_audit_service import audit_dependency
 from services.event_service import list_shop_events, schedule_shop_event
 

--- a/routes/admin_song_popularity_routes.py
+++ b/routes/admin_song_popularity_routes.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from backend.auth.dependencies import require_permission
+from auth.dependencies import require_permission
 from fastapi import APIRouter, Depends
 from services.media_event_service import media_event_service
 from services.media_monitor_service import media_monitor_service

--- a/routes/admin_tutor_routes.py
+++ b/routes/admin_tutor_routes.py
@@ -2,7 +2,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.models.tutor import Tutor
 from services.admin_audit_service import audit_dependency
 from services.tutor_admin_service import (

--- a/routes/admin_venue_routes.py
+++ b/routes/admin_venue_routes.py
@@ -1,7 +1,7 @@
 """Administrative CRUD routes for venues."""
 from fastapi import APIRouter, HTTPException, Request, Depends
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.venue_service import VenueService
 from services.admin_audit_service import audit_dependency
 from models.economy_config import set_config, EconomyConfig

--- a/routes/admin_workshop_routes.py
+++ b/routes/admin_workshop_routes.py
@@ -2,7 +2,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.models.workshop import Workshop
 from services.admin_audit_service import audit_dependency
 from services.workshop_admin_service import (

--- a/routes/admin_xp_event_routes.py
+++ b/routes/admin_xp_event_routes.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.models.xp_event import XPEvent
 from services.admin_audit_service import audit_dependency
 from services.xp_event_service import XPEventService

--- a/routes/admin_xp_item_routes.py
+++ b/routes/admin_xp_item_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.models.xp_item import XPItem
 from services.admin_audit_service import audit_dependency
 from services.xp_item_service import XPItemService

--- a/routes/admin_xp_routes.py
+++ b/routes/admin_xp_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.xp_admin_service import XPAdminService
 from backend.models.xp_config import XPConfig
 from services.admin_audit_service import audit_dependency

--- a/routes/ai_manager_routes.py
+++ b/routes/ai_manager_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from services.ai_manager_service import *
 

--- a/routes/ai_tour_manager_routes.py
+++ b/routes/ai_tour_manager_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.ai_tour_manager_service import AITourManagerService

--- a/routes/ai_tour_scheduler_routes.py
+++ b/routes/ai_tour_scheduler_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from core.ai_tour_scheduler import run_ai_scheduler, scheduled_tours
 

--- a/routes/ai_transport_routes.py
+++ b/routes/ai_transport_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from core.ai_transport_optimizer import optimize_transport_for_tour, get_transport_bookings
 

--- a/routes/analytics_routes.py
+++ b/routes/analytics_routes.py
@@ -6,7 +6,7 @@ except Exception:  # pragma: no cover - fallback for stubs
     def Depends(dependency):  # type: ignore
         return dependency
 
-from backend.auth.dependencies import require_permission
+from auth.dependencies import require_permission
 from backend.models.analytics import (
     AggregatedMetrics,
     FanSegmentSummary,

--- a/routes/avatar.py
+++ b/routes/avatar.py
@@ -5,7 +5,7 @@ from services.avatar_service import AvatarService
 from services.lifestyle_service import calculate_lifestyle_score, evaluate_lifestyle_risks
 
 try:  # pragma: no cover - fallback for environments without auth module
-    from backend.auth.dependencies import require_permission
+    from auth.dependencies import require_permission
 except Exception:  # pragma: no cover
     def require_permission(roles):
         async def _noop():

--- a/routes/avatar_routes.py
+++ b/routes/avatar_routes.py
@@ -3,7 +3,7 @@ from schemas.avatar import AvatarResponse
 from services.avatar_service import AvatarService
 
 try:  # pragma: no cover - fallback when auth module absent
-    from backend.auth.dependencies import require_permission
+    from auth.dependencies import require_permission
 except Exception:  # pragma: no cover
     def require_permission(roles):
         async def _noop():

--- a/routes/awards.py
+++ b/routes/awards.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from models.awards import SongAward

--- a/routes/band.py
+++ b/routes/band.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 
 from schemas.band import (

--- a/routes/band_relationship_routes.py
+++ b/routes/band_relationship_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.band_relationship_service import BandRelationshipService

--- a/routes/band_social_routes.py
+++ b/routes/band_social_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 
 router = APIRouter()

--- a/routes/character.py
+++ b/routes/character.py
@@ -1,6 +1,6 @@
 """Character API routes."""
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from schemas.character import CharacterCreate, CharacterResponse

--- a/routes/chart_routes.py
+++ b/routes/chart_routes.py
@@ -2,7 +2,7 @@ import sqlite3
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.auth.dependencies import get_current_user_id
+from auth.dependencies import get_current_user_id
 from backend.database import DB_PATH
 from services.chart_service import calculate_weekly_chart, get_chart
 

--- a/routes/charts.py
+++ b/routes/charts.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from models.charts import ChartEntry

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 from schemas.chat_schemas import GroupMembershipSchema, GroupMessageSchema, MessageSchema
 
-from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
+from auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from services.chat_service import (
     add_user_to_group,
     get_user_chat_history,

--- a/routes/chemistry_routes.py
+++ b/routes/chemistry_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.chemistry_service import ChemistryService
 
 router = APIRouter(prefix="/chemistry", tags=["chemistry"])

--- a/routes/construction_routes.py
+++ b/routes/construction_routes.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from models.construction import Blueprint, BuildPhase
 from services.construction_service import ConstructionService
 from services.economy_service import EconomyService

--- a/routes/crafting_routes.py
+++ b/routes/crafting_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from typing import Dict

--- a/routes/dashboard_routes.py
+++ b/routes/dashboard_routes.py
@@ -1,7 +1,7 @@
 # File: backend/routes/dashboard_routes.py
 from typing import Optional
 
-from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
+from auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from services.dashboard_service import DashboardService
 from fastapi import APIRouter, Depends, HTTPException, Query, Request  # noqa: F401
 

--- a/routes/distribution.py
+++ b/routes/distribution.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from database import get_db

--- a/routes/education_routes.py
+++ b/routes/education_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.education_schema import EducationSessionCreate, EducationSessionResponse
 from datetime import date

--- a/routes/elections_routes.py
+++ b/routes/elections_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from services.election_service import *
 

--- a/routes/emotes_routes.py
+++ b/routes/emotes_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from services.emotes_service import *
 from schemas.emotes_schemas import EmoteTriggerSchema

--- a/routes/endorsement_routes.py
+++ b/routes/endorsement_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.endorsement_schema import EndorsementCreate, EndorsementResponse
 from datetime import date

--- a/routes/events_routes.py
+++ b/routes/events_routes.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends
 
-from backend.auth.dependencies import require_permission
+from auth.dependencies import require_permission
 from services.events_service import (
     cancel_scheduled_event,
     create_seasonal_event,

--- a/routes/fame_routes.py
+++ b/routes/fame_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.fame_service import FameService

--- a/routes/fan_club_routes.py
+++ b/routes/fan_club_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, HTTPException
 from models.fan_club_models import *
 from schemas.fan_club_schemas import *

--- a/routes/fan_interaction_routes.py
+++ b/routes/fan_interaction_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.fan_interaction_service import FanInteractionService

--- a/routes/fan_logistics_routes.py
+++ b/routes/fan_logistics_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from core.fan_logistics_engine import cast_vote, get_votes_for_band, get_top_petitions, trigger_engagement_bonus
 

--- a/routes/fanclub_routes.py
+++ b/routes/fanclub_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.fanclub_schema import FanClubCreate, FanClubResponse
 from datetime import date

--- a/routes/festival.py
+++ b/routes/festival.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from pydantic import BaseModel
 from typing import List, Optional
 from datetime import date

--- a/routes/festival_builder_routes.py
+++ b/routes/festival_builder_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.models.festival_builder import FestivalBuilder
 from services.festival_builder_service import (
     BookingConflictError,

--- a/routes/festival_history.py
+++ b/routes/festival_history.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from pydantic import BaseModel
 from typing import List, Dict
 

--- a/routes/festival_proposals_routes.py
+++ b/routes/festival_proposals_routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 try:
-    from backend.auth.dependencies import get_current_user_id, require_permission
+    from auth.dependencies import get_current_user_id, require_permission
 except Exception:  # pragma: no cover
     def require_permission(_: list[str]):
         async def _noop() -> None:  # type: ignore[return-value]

--- a/routes/gifting_routes.py
+++ b/routes/gifting_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, conint
 from typing import List, Optional

--- a/routes/gig.py
+++ b/routes/gig.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from services.notifications_service import NotificationsService
 from sqlalchemy.orm import Session

--- a/routes/health_routes.py
+++ b/routes/health_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 # File: backend/routes/health_routes.py
 from fastapi import APIRouter, Depends
 from utils.db import get_conn

--- a/routes/item_routes.py
+++ b/routes/item_routes.py
@@ -1,7 +1,7 @@
 """Routes for item interactions such as consuming drugs."""
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.item_service import item_service
 
 router = APIRouter(prefix="/items", tags=["Items"])

--- a/routes/jobs_charts_routes.py
+++ b/routes/jobs_charts_routes.py
@@ -1,11 +1,11 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 # File: backend/routes/jobs_charts_routes.py
 from fastapi import APIRouter, HTTPException, Depends
 from services.jobs_charts import ChartsJobsService
 
 # Auth dep
 try:
-    from backend.auth.dependencies import require_permission
+    from auth.dependencies import require_permission
 except Exception:
     def require_permission(roles):
         async def _noop():

--- a/routes/karma_admin_routes.py
+++ b/routes/karma_admin_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from backend.karma_extras import add_karma_vote, get_karma_leaderboard, get_karma_score
 from fastapi import APIRouter, Depends, HTTPException, Request
 

--- a/routes/karma_mentorship_routes.py
+++ b/routes/karma_mentorship_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.karma_mentorship_service import KarmaMentorshipService

--- a/routes/karma_routes.py
+++ b/routes/karma_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.karma_db import KarmaDB

--- a/routes/label_management_routes.py
+++ b/routes/label_management_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 
 router = APIRouter()

--- a/routes/labels_routes.py
+++ b/routes/labels_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 
-from backend.auth.dependencies import require_permission
+from auth.dependencies import require_permission
 from backend.schemas.labels_schemas import (
     LabelCreateSchema,
     OfferRequestSchema,

--- a/routes/live_performance.py
+++ b/routes/live_performance.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services import live_performance_service

--- a/routes/mail_routes.py
+++ b/routes/mail_routes.py
@@ -7,7 +7,7 @@ import sqlite3
 
 from fastapi import APIRouter, Depends, File, Form, UploadFile
 
-from backend.auth.dependencies import get_current_user_id
+from auth.dependencies import get_current_user_id
 from services.mailbox_service import delete_message, get_inbox, send_message
 from services.storage_service import save_attachment
 from utils.db import aget_conn

--- a/routes/mailbox_routes.py
+++ b/routes/mailbox_routes.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, File, Form, UploadFile
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.mailbox_service import delete_message, get_inbox, send_message
 from services.storage_service import save_attachment
 

--- a/routes/major_role_routes.py
+++ b/routes/major_role_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.major_role_schema import MajorCreate, RoleAssignmentCreate
 from models.major_role import Major, RoleAssignment

--- a/routes/management_routes.py
+++ b/routes/management_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.management_schema import ManagerCreate, ManagerResponse
 from datetime import date

--- a/routes/marketplace_routes.py
+++ b/routes/marketplace_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.economy_service import EconomyService, EconomyError
 from services.marketplace_service import MarketplaceService, MarketplaceError
 

--- a/routes/media_exposure_routes.py
+++ b/routes/media_exposure_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, HTTPException
 from models.media_exposure_models import *
 from schemas.media_exposure_schemas import *

--- a/routes/media_publicity_routes.py
+++ b/routes/media_publicity_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, HTTPException
 from models import media_publicity_models
 from schemas import media_publicity_schemas

--- a/routes/media_routes.py
+++ b/routes/media_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from typing import List, Optional
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from services.media_event_service import media_event_service
 from services.media_moderation_service import media_moderation_service

--- a/routes/membership_routes.py
+++ b/routes/membership_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.economy_service import EconomyError, EconomyService
 from services.membership_service import membership_service
 

--- a/routes/merch_routes.py
+++ b/routes/merch_routes.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
+from auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from services.economy_service import EconomyService
 from services.merch_service import MerchError, MerchService
 from backend.models.merch import ProductIn, SKUIn

--- a/routes/merchandise_routes.py
+++ b/routes/merchandise_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.merchandise_schema import MerchandiseCreate, MerchandiseResponse
 from typing import List

--- a/routes/metrics_routes.py
+++ b/routes/metrics_routes.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - fallback for stubs
     def Depends(dependency: Any) -> Any:  # type: ignore[misc]
         return dependency
 
-from backend.auth.dependencies import require_permission
+from auth.dependencies import require_permission
 from utils.db import get_conn
 
 router = APIRouter(prefix="/metrics", tags=["Metrics"])

--- a/routes/music.py
+++ b/routes/music.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import Depends
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from sqlalchemy.orm import Session
 
 from models.music import Song, Album, album_song_link

--- a/routes/music_metrics_routes.py
+++ b/routes/music_metrics_routes.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 
-from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
+from auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from services import song_popularity_service
 from services.song_popularity_service import (
     ALLOWED_REGION_CODES,

--- a/routes/music_routes.py
+++ b/routes/music_routes.py
@@ -1,7 +1,7 @@
 # File: backend/routes/music_routes.py
 from fastapi import APIRouter, HTTPException
 from fastapi import Depends
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from pydantic import BaseModel, Field
 from typing import Optional
 

--- a/routes/notification_routes.py
+++ b/routes/notification_routes.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends
-from backend.auth.dependencies import get_current_user_id
+from auth.dependencies import get_current_user_id
 from services.notifications_service import NotificationsService
 
 router = APIRouter(prefix="/notification", tags=["notification"])

--- a/routes/notifications_routes.py
+++ b/routes/notifications_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend.auth.dependencies import get_current_user_id
+from auth.dependencies import get_current_user_id
 from services.notifications_service import NotificationsService
 
 router = APIRouter(prefix="/notifications", tags=["Notifications"])

--- a/routes/promotion_routes.py
+++ b/routes/promotion_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from schemas.promotion_schema import PromotionCreate, PromotionResponse
 from typing import List

--- a/routes/property_routes.py
+++ b/routes/property_routes.py
@@ -2,7 +2,7 @@ from services.achievement_service import AchievementService
 from services.economy_service import EconomyService
 from services.property_service import PropertyError, PropertyService
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 

--- a/routes/public_reactions_routes.py
+++ b/routes/public_reactions_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 
 router = APIRouter()

--- a/routes/recording_routes.py
+++ b/routes/recording_routes.py
@@ -5,7 +5,7 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id
+from auth.dependencies import get_current_user_id
 from services.economy_service import EconomyService
 from services.recording_service import RecordingService
 

--- a/routes/replay_routes.py
+++ b/routes/replay_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from services.replay_service import *
 

--- a/routes/sales.py
+++ b/routes/sales.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 try:
-    from backend.auth.dependencies import require_permission
+    from auth.dependencies import require_permission
 except Exception:  # pragma: no cover
     def require_permission(_: List[str]):
         async def _noop() -> None:  # type: ignore[return-value]

--- a/routes/shipping_routes.py
+++ b/routes/shipping_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.shipping_service import ShippingService
 
 router = APIRouter(prefix="/shipping", tags=["Shipping"])

--- a/routes/shop_routes.py
+++ b/routes/shop_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.books_service import books_service
 from services.city_shop_service import city_shop_service
 from services.economy_service import EconomyError, EconomyService

--- a/routes/skin.py
+++ b/routes/skin.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session, joinedload
 from models.skin import Skin, SkinInventory

--- a/routes/skins_routes.py
+++ b/routes/skins_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from services.skins_service import *
 

--- a/routes/social_routes.py
+++ b/routes/social_routes.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from backend.utils.i18n import _
-from backend.auth.dependencies import get_current_user_id
+from auth.dependencies import get_current_user_id
 from services.social_service import social_service
 from services.fan_club_service import fan_club_service
 from datetime import datetime

--- a/routes/songwriting_routes.py
+++ b/routes/songwriting_routes.py
@@ -6,7 +6,7 @@ from typing import Dict, Set
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, validator
 
-from backend.auth.dependencies import get_current_user_id
+from auth.dependencies import get_current_user_id
 from backend.models.theme import THEMES
 from services.skill_service import skill_service
 from services.songwriting_service import songwriting_service

--- a/routes/sponsorship.py
+++ b/routes/sponsorship.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from utils.i18n import _
 
-from backend.auth.dependencies import get_current_user_id, require_permission  # noqa: F401
+from auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from services.sponsorship_service import SponsorshipService
 from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 from pydantic import BaseModel, Field

--- a/routes/stream_routes.py
+++ b/routes/stream_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.stream_service import StreamService

--- a/routes/streaming.py
+++ b/routes/streaming.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 

--- a/routes/support_slot_routes.py
+++ b/routes/support_slot_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 try:  # Authentication dependencies may not be available during tests
-    from backend.auth.dependencies import get_current_user_id, require_permission
+    from auth.dependencies import get_current_user_id, require_permission
 except Exception:  # pragma: no cover - fallback for docs builds
     def require_permission(_: List[str]):
         async def _noop() -> None:  # type: ignore[return-value]

--- a/routes/ticketing_routes.py
+++ b/routes/ticketing_routes.py
@@ -6,7 +6,7 @@ from services.economy_service import EconomyService
 from services.ticketing_service import TicketingError, TicketingService
 
 try:
-    from backend.auth.dependencies import require_permission
+    from auth.dependencies import require_permission
 except Exception:  # pragma: no cover - fallback for tests
     def require_permission(roles):
         async def _noop():

--- a/routes/tour_logistics_routes.py
+++ b/routes/tour_logistics_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.tour_logistics_service import TourLogisticsService

--- a/routes/tours.py
+++ b/routes/tours.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 from fastapi import Depends
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from sqlalchemy.orm import Session
 from database import get_db
 from models.tours import Tour, TourStop

--- a/routes/trade_routes.py
+++ b/routes/trade_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.trade_route_service import TradeRouteService
 
 router = APIRouter(prefix="/trade", tags=["Trade"])

--- a/routes/transport.py
+++ b/routes/transport.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from database import get_db

--- a/routes/transport_routes.py
+++ b/routes/transport_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 
 from flask import Blueprint, request, jsonify
 from services.transport_service import TransportService

--- a/routes/tutorial_routes.py
+++ b/routes/tutorial_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter
 from services.tutorial_service import *
 

--- a/routes/user_routes.py
+++ b/routes/user_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 
-from backend.auth.dependencies import get_current_user_id
+from auth.dependencies import get_current_user_id
 from services.notifications_service import NotificationsService
 
 

--- a/routes/venue_routes.py
+++ b/routes/venue_routes.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 # File: backend/routes/venue_routes.py
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field

--- a/routes/venue_sponsorships_routes.py
+++ b/routes/venue_sponsorships_routes.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, HttpUrl
 
 try:
-    from backend.auth.dependencies import get_current_user_id, require_permission
+    from auth.dependencies import get_current_user_id, require_permission
 except Exception:  # pragma: no cover
     def require_permission(_: List[str]):
         async def _noop() -> None:  # type: ignore[return-value]

--- a/routes/venues.py
+++ b/routes/venues.py
@@ -1,4 +1,4 @@
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from database import get_db

--- a/routes/video_routes.py
+++ b/routes/video_routes.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from backend.auth.dependencies import get_current_user_id, require_permission
+from auth.dependencies import get_current_user_id, require_permission
 from services.economy_service import EconomyService
 from services.video_service import VideoService
 from services.skill_service import SkillService


### PR DESCRIPTION
## Summary
- switch route and test imports from `backend.auth.dependencies` to `auth.dependencies`
- update conditional imports in realtime and route modules to use new path

## Testing
- `pytest backend/tests/auth/test_permissions.py backend/tests/auth/test_rbac_integration.py backend/tests/analytics/test_analytics.py tests/test_band_recording_slots.py tests/test_jobs_charts_multi_country.py tests/test_auth_service_refresh.py tests/test_jwt_module.py -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
- `pip install aiosqlite` *(fails: Could not find a version that satisfies the requirement aiosqlite)*

------
https://chatgpt.com/codex/tasks/task_e_68c439debbb88325822b3280f6924663