### PR TITLE
refactor: update auth import paths

### DIFF
--- a/backend/tests/routes/test_merch_routes.py
+++ b/backend/tests/routes/test_merch_routes.py
@@ -4,7 +4,7 @@ from backend.services.economy_service import EconomyService
 from backend.services.merch_service import MerchService
 from backend.services.payment_service import MockGateway, PaymentService
 
-import backend.auth.dependencies as auth_dep
+import auth.dependencies as auth_dep
 from typing import List
 
 

--- a/tests/test_jobs_charts_multi_country.py
+++ b/tests/test_jobs_charts_multi_country.py
@@ -12,9 +12,9 @@ sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
 # Stub heavy dependencies before importing routes
-auth_deps = types.ModuleType("backend.auth.dependencies")
+auth_deps = types.ModuleType("auth.dependencies")
 auth_deps.get_current_user_id = lambda req=None: 1
-sys.modules["backend.auth.dependencies"] = auth_deps
+sys.modules["auth.dependencies"] = auth_deps
 
 chart_service_stub = types.ModuleType("backend.services.chart_service")
 chart_service_stub.calculate_weekly_chart = lambda *a, **k: {}


### PR DESCRIPTION
## Summary
- use top-level auth.dependencies for merch route tests
- stub auth.dependencies in chart jobs multi-country tests

## Testing
- `PYTHONPATH=/workspace pytest backend/backend/tests/routes/test_merch_routes.py backend/tests/test_jobs_charts_multi_country.py -q` *(fails: ImportError: cannot import name 'aget_conn' from partially initialized module 'backend.utils.db')*

------
https://chatgpt.com/codex/tasks/task_e_68c4491238c88325a760020d88f2f5ee