### PR TITLE
test: import app from backend.api

### DIFF
--- a/backend/tests/test_metrics_smoke.py
+++ b/backend/tests/test_metrics_smoke.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from backend.main import app
+from backend.api import app
 from backend.realtime.gateway import hub
 from backend.services.economy_service import EconomyService
 


### PR DESCRIPTION
## Summary
- use `backend.api` in metrics smoke test

## Testing
- `pytest backend/tests/test_metrics_smoke.py` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c44ac1fc9c8325abbd15d8999d0952