### PR TITLE
chore: specify Node 18 in CI and docs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -9,6 +9,7 @@ This README gives you a **1‑file quickstart** for running a *testable* local b
 ## ⚡ Quick Start (Backend)
 
 **Prereqs**: Python 3.11+, SQLite 3.39+, Node.js 18+, Git. (Static frontend pages can be served directly without Node.)
+If you work on the frontend, ensure Node 18 is active, e.g. with `nvm use 18`.
 
 ```bash
 # 1) Create venv + install deps

--- a/UPDATED_README.md
+++ b/UPDATED_README.md
@@ -8,7 +8,8 @@ This README gives you a **1‑file quickstart** for running a *testable* local b
 
 ## ⚡ Quick Start (Backend)
 
-**Prereqs**: Python 3.11+, SQLite 3.39+, Git. (Node is optional for frontend dev; HTML pages can be served directly.)
+**Prereqs**: Python 3.11+, SQLite 3.39+, Git. (Frontend dev uses Node.js 18; HTML pages can be served directly without Node.)
+If you plan to work on the frontend, run `nvm use 18` to match the required Node version.
 
 ```bash
 # 1) Create venv + install deps

--- a/workflows/ci.yml
+++ b/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
       - name: Cache pip
         uses: actions/cache@v4
         with:

--- a/workflows/lint.yml
+++ b/workflows/lint.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
       - name: Install tools
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- pin Node.js 18 in legacy CI workflows
- note Node 18 requirement for frontend development

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ajv)*
- `npm test` *(fails: sh: 1: vitest: not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c450d23d1c83259c12821b299a6d5c