### PR TITLE
Ensure migrations and demo seeds run before server startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 
 # Run database migrations
 migrate:
-	backend/scripts/migrate.sh
+	scripts/migrate.sh
 
 # Drop the SQLite database, recreate it, and apply migrations
 # Useful during development to start with a clean schema
 # Uses migrate.sh which skips already-applied revisions.
 db-reset:
 	rm -f rockmundo.db
-	backend/scripts/migrate.sh
+	scripts/migrate.sh

--- a/README.MD
+++ b/README.MD
@@ -21,7 +21,7 @@ cp .env.example .env
 cp .env.example.storage .env.storage
 
 # 3) Initialize DB (migrations + seeds)
-./backend/scripts/migrate.sh        # apply Alembic migrations (skips ones already run)
+./scripts/migrate.sh        # apply Alembic migrations (skips ones already run)
 python -m backend.scripts.seed_demo  # creates demo data: users, skills, genres, etc.
 
 # 4) Run the API
@@ -100,7 +100,7 @@ assets/ images/                   # branding & UI assets
 
 ## 🗄️ Data, Migrations & Seeds
 
-- Run migrations with `backend/scripts/migrate.sh` – it skips revisions already applied.
+- Run migrations with `scripts/migrate.sh` – it skips revisions already applied.
 - `make db-reset` removes `rockmundo.db` and re-applies migrations for a clean slate.
 - Full-text search (FTS5) and **World Pulse** (daily/weekly charts) are included.
 - `backend/scripts/seed_demo.py` seeds minimum data (skills, genres, equipment, etc.) and creates test users and bands for smoke tests.

--- a/UPDATED_README.md
+++ b/UPDATED_README.md
@@ -22,6 +22,7 @@ cp .env.example.storage .env.storage
 
 # 3) Initialize DB (migrations + seeds)
 # Migrations are SQL files in backend/migrations/sql/*.sql
+./scripts/migrate.sh                 # apply Alembic migrations (skips ones already run)
 python -m backend.scripts.seed_demo  # creates demo data: users, skills, genres, etc.
 
 # 4) Run the API

--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-./backend/scripts/migrate.sh
+./scripts/migrate.sh
 python -m backend.scripts.seed_demo
 
 exec "$@"

--- a/docs/migration_notes.md
+++ b/docs/migration_notes.md
@@ -1,6 +1,6 @@
 # Migration Notes
 
-Run `backend/scripts/migrate.sh` to apply migrations; it only executes new
+Run `scripts/migrate.sh` to apply migrations; it only executes new
 revisions that haven't been run yet.  To wipe the SQLite database and reapply
 all migrations from scratch use `make db-reset`.
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -17,4 +17,5 @@ fi
 # skips revisions that have already been applied, so startup remains fast after
 # the initial run.
 ./scripts/migrate.sh
+./venv/bin/python3.11 -m backend.scripts.seed_demo
 exec env PYTHONPATH=.:backend ./venv/bin/python3.11 -m uvicorn main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- run migrations and seed demo data in local `scripts/start.sh`
- fix Docker entrypoint to run migrations from the correct path
- document running `scripts/migrate.sh` and `python -m backend.scripts.seed_demo`

## Testing
- `pytest -q` *(fails: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c44df4a8d88325a2386c84dac48858