### PR TITLE
chore: ignore compiled locale catalogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 frontend/node_modules/
 
 # Ignore compiled message catalogs
-backend/locales/**/LC_MESSAGES/*.mo
+locales/**/LC_MESSAGES/*.mo
 
 # Python caches
 __pycache__/


### PR DESCRIPTION
## Summary
- ignore compiled message catalogs under locales for any language

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68c45407ff548325a341bd9685bda276