### PR TITLE
Clear npm cache before Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base = "frontend"
   publish = "build"
-  command = "npm ci && npm run build"
+  command = "npm cache clean --force && npm ci && npm run build"
 
 [build.environment]
   NODE_VERSION = "18"


### PR DESCRIPTION
## Summary
- ensure Netlify build clears npm cache before installing deps

## Testing
- `npm ci --prefix frontend` (fails: 403 Forbidden - GET https://registry.npmjs.org/ajv)
- `npm test --prefix frontend` (fails: vitest: not found)
- `pytest` (fails: 50 errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_68c4579e6a2c8325b680ec76587a8f69