### PR TITLE
fix: pin TypeScript version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "autoprefixer": "^10.4.0",
         "jsdom": "^23.0.1",
         "postcss": "^8.4.0",
-        "typescript": "^4.9.5",
+        "typescript": "4.9.5",
         "vitest": "^1.6.0"
       },
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "typescript": "^4.9.5",
+    "typescript": "4.9.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "vitest": "^1.6.0",


### PR DESCRIPTION
## Summary
- pin frontend TypeScript to 4.9.5

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ajv)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4582bd4e88325b9ee983a67f91eb1