### PR TITLE
docs: streamline migration quick start

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -27,8 +27,6 @@ mkdir -p var/storage                      # create storage dir
 # ensure the runtime user can write to it
 chmod -R 775 var/storage                  # adjust UID/GID as needed
 # 4) Initialize DB (migrations + seeds)
-./backend/scripts/migrate.sh        # apply Alembic migrations (skips ones already run)
-# 3) Initialize DB (migrations + seeds)
 ./scripts/migrate.sh        # apply Alembic migrations (skips ones already run)
 python -m backend.scripts.seed_demo  # creates demo data: users, skills, genres, etc.
 


### PR DESCRIPTION
## Summary
- remove outdated `./backend/scripts/migrate.sh` reference in README and keep single `./scripts/migrate.sh` command
- renumber backend quick-start steps and confirm API entrypoint `uvicorn backend.api:app`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c45eb4158c8325bf08b2102b22f91a