### PR TITLE
Use active Python interpreter for migrations

### DIFF
--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -3,5 +3,5 @@
 # Alembic's upgrade command is idempotent and will only run new migrations.
 set -e
 cd "$(dirname "$0")/.."
-# Apply migrations
-./venv/bin/python3.11 -m alembic upgrade head
+# Apply migrations using the active Python interpreter
+python -m alembic upgrade head


### PR DESCRIPTION
## Summary
- run Alembic migrations with the active Python interpreter

## Testing
- `./scripts/migrate.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c45f3e086483258f6e577935668728