### PR TITLE
docs: reference admin monitoring and realtime paths

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -3,6 +3,16 @@
 This directory contains sample configuration for deploying a Prometheus and Grafana
 stack to observe Rockmundo services.
 
+## Admin monitoring endpoints
+
+The HTTP API for basic system metrics and session management lives in
+`routes/admin_monitoring_routes.py`.
+
+## Realtime admin gateway
+
+WebSocket alerts for administrative dashboards are served from
+`realtime/admin_gateway.py` at `/admin/realtime/ws`.
+
 ## Prometheus
 
 Use `monitoring/prometheus.yml` as a starting point. It scrapes the FastAPI


### PR DESCRIPTION
## Summary
- document admin monitoring HTTP API in `routes/admin_monitoring_routes.py`
- note realtime admin gateway at `/admin/realtime/ws`

## Testing
- ⚠️ `npm install` *(403 Forbidden - GET https://registry.npmjs.org/ajv)*
- ⚠️ `npm test` *(sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c45f472094832590dfe9d6c60b9237