### PR TITLE
feat: add i18n utility re-exports

### DIFF
--- a/utils/i18n.py
+++ b/utils/i18n.py
@@ -1,0 +1,3 @@
+from backend.utils.i18n import _, DEFAULT_LOCALE, SUPPORTED_LOCALES, set_locale  # noqa: I001
+
+__all__ = ["_", "DEFAULT_LOCALE", "SUPPORTED_LOCALES", "set_locale"]


### PR DESCRIPTION
## Summary
- expose i18n helpers at top-level utils package

## Testing
- `ruff check utils/i18n.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68c7364b52e88325a1e416d418c9a4ea