### PR TITLE
chore: add utils error handler re-export

### DIFF
--- a/utils/error_handlers.py
+++ b/utils/error_handlers.py
@@ -1,0 +1,11 @@
+"""Convenience re-export for HTTP error handlers.
+
+This module exposes the :func:`http_exception_handler` from
+:mod:`backend.utils.error_handlers` so consumers can import it from
+``utils``.
+"""
+
+from backend.utils.error_handlers import http_exception_handler
+
+__all__ = ["http_exception_handler"]
+


### PR DESCRIPTION
## Summary
- add top-level `utils.error_handlers` re-export for `http_exception_handler`

## Testing
- `ruff check utils/error_handlers.py`
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c7364cf8ec83259f932593117fcb14