### PR TITLE
feat: re-export metrics utilities

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,0 +1,5 @@
+"""Convenience re-exports for metrics utilities."""
+
+from backend.utils.metrics import CONTENT_TYPE_LATEST, generate_latest
+
+__all__ = ["CONTENT_TYPE_LATEST", "generate_latest"]


### PR DESCRIPTION
## Summary
- expose CONTENT_TYPE_LATEST and generate_latest via utils.metrics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c7364e5ca883258ed05576b9b7df2e