### PR TITLE
Add top-level tracing re-export

### DIFF
--- a/utils/tracing.py
+++ b/utils/tracing.py
@@ -1,0 +1,3 @@
+from backend.utils.tracing import get_tracer, setup_tracing
+
+__all__ = ["setup_tracing", "get_tracer"]


### PR DESCRIPTION
## Summary
- Add `utils.tracing` module re-exporting `setup_tracing` and `get_tracer` from `backend.utils.tracing`

## Testing
- `ruff check utils/tracing.py`
- `pytest tests/test_jwt_module.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7364f62d08325a8072730615d358b