### PR TITLE
Add auth utility re-exports

### DIFF
--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -1,0 +1,12 @@
+"""Convenience re-exports for authentication utilities.
+
+This module exposes helper functions for creating access tokens and verifying
+user credentials by importing them from ``backend.utils.auth_utils``.
+"""
+
+from backend.utils.auth_utils import (
+    create_access_token,
+    verify_user_credentials,
+)
+
+__all__ = ["create_access_token", "verify_user_credentials"]


### PR DESCRIPTION
## Summary
- add `utils/auth_utils` to re-export auth token helpers

## Testing
- `pytest backend/tests -q` *(fails: ModuleNotFoundError: No module named 'backend')*
- `pytest tests/test_jwt_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7364c0c408325af521aaace6263d6