### PR TITLE
Expose DB pool init and cached query helpers

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -3,9 +3,23 @@
 This module exposes the synchronous and asynchronous connection
 helpers from :mod:`backend.utils.db`.  The synchronous ``get_conn``
 wrapper uses the underlying asynchronous driver but remains available
-for legacy callers.  New code should prefer :func:`aget_conn`.
+for legacy callers.  New code should prefer :func:`aget_conn`.  Additional
+utilities such as :func:`cached_query`, :func:`init_pool`, and
+:func:`_init_pool_async` are also re-exported for convenience.
 """
 
-from backend.utils.db import aget_conn, get_conn
+from backend.utils.db import (
+    _init_pool_async,
+    aget_conn,
+    cached_query,
+    get_conn,
+    init_pool,
+)
 
-__all__ = ["get_conn", "aget_conn"]
+__all__ = [
+    "get_conn",
+    "aget_conn",
+    "cached_query",
+    "init_pool",
+    "_init_pool_async",
+]


### PR DESCRIPTION
## Summary
- re-export cached_query, init_pool, and _init_pool_async in utils.db for easier access to backend database helpers

## Testing
- `ruff check utils/db.py`
- `pytest tests/test_jwt_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7396dc9d48325a8a240f17bde8266