### PR TITLE
Expose additional i18n helpers

### DIFF
--- a/utils/i18n.py
+++ b/utils/i18n.py
@@ -1,3 +1,19 @@
-from backend.utils.i18n import _, DEFAULT_LOCALE, SUPPORTED_LOCALES, set_locale  # noqa: I001
+from backend.utils.i18n import (  # noqa: I001
+    _,
+    DEFAULT_LOCALE,
+    SUPPORTED_LOCALES,
+    set_locale,
+    ngettext_,
+    pgettext_,
+    npgettext_,
+)
 
-__all__ = ["_", "DEFAULT_LOCALE", "SUPPORTED_LOCALES", "set_locale"]
+__all__ = [
+    "_",
+    "DEFAULT_LOCALE",
+    "SUPPORTED_LOCALES",
+    "set_locale",
+    "ngettext_",
+    "pgettext_",
+    "npgettext_",
+]


### PR DESCRIPTION
## Summary
- export plural and context-aware translation helpers via `utils.i18n`

## Testing
- `ruff check utils/i18n.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'backend.auth')*


------
https://chatgpt.com/codex/tasks/task_e_68c7396e9b8c8325adf17869e5ecd33b