### PR TITLE
fix: update db and frontend paths

### DIFF
--- a/database.py
+++ b/database.py
@@ -3,7 +3,7 @@
 import sqlite3
 from pathlib import Path
 
-DB_PATH = Path(__file__).resolve().parent.parent / "rockmundo.db"
+DB_PATH = Path(__file__).resolve().parent / "rockmundo.db"
 
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:

--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ app.add_middleware(AdminMFAMiddleware)
 
 # Serve the frontend HTML pages from ``frontend/pages`` for local development.
 frontend_pages = (
-    Path(__file__).resolve().parent.parent / "frontend" / "pages"
+    Path(__file__).resolve().parent / "frontend" / "pages"
 )
 if frontend_pages.exists():
     app.mount("/frontend", StaticFiles(directory=str(frontend_pages), html=True), name="frontend")


### PR DESCRIPTION
## Summary
- locate SQLite database in project root
- mount existing frontend pages directory

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c7396fd4c88325a6d4dd75b15fb264