### PR TITLE
Refactor scheduler service imports

### DIFF
--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -2,23 +2,23 @@ import json
 import sqlite3
 from datetime import date, datetime, timedelta
 
-from backend.database import DB_PATH
-from backend.models import daily_loop
-from backend.models.notification_models import (
+from database import DB_PATH
+from models import daily_loop
+from models.notification_models import (
     alert_no_plan,
     alert_pending_outcomes,
 )
-from backend.services import chart_service, fan_service, song_popularity_service
-from backend.services.activity_processor import process_previous_day
-from backend.services.books_service import books_service
-from backend.services.event_service import end_shop_event, start_shop_event
-from backend.services.npc_service import npc_service
-from backend.services.peer_learning_service import run_scheduled_session
-from backend.services.schedule_service import schedule_service
-from backend.services.shop_restock_service import restock_handler
-from backend.services.skill_service import skill_service
-from backend.services.social_sentiment_service import social_sentiment_service
-from backend.services.song_popularity_forecast import forecast_service
+from services import chart_service, fan_service, song_popularity_service
+from services.activity_processor import process_previous_day
+from services.books_service import books_service
+from services.event_service import end_shop_event, start_shop_event
+from services.npc_service import npc_service
+from services.peer_learning_service import run_scheduled_session
+from services.schedule_service import schedule_service
+from services.shop_restock_service import restock_handler
+from services.skill_service import skill_service
+from services.social_sentiment_service import social_sentiment_service
+from services.song_popularity_forecast import forecast_service
 
 
 def _plan_reminder(user_id: int, day: str) -> dict:


### PR DESCRIPTION
## Summary
- update scheduler service imports to use top-level database, models, and services modules

## Testing
- `rg 'backend\.models|backend\.services|backend\.database' services/scheduler_service.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68c73c373b54832598e29da8bf907529