### PR TITLE
refactor: use services namespace

### DIFF
--- a/services/ai_art_service.py
+++ b/services/ai_art_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import List
 
-from backend.services.storage_service import get_storage_backend
+from services.storage_service import get_storage_backend
 
 
 class AIArtService:

--- a/services/album_service.py
+++ b/services/album_service.py
@@ -15,7 +15,7 @@ from typing import Callable, Iterable
 
 from models.music import Base as MusicBase  # noqa: F401
 from models.music import Release, Track
-from backend.services.band_service import (  # noqa: F401
+from services.band_service import (  # noqa: F401
     BandCollaboration,
     BandService,
 )

--- a/services/apprenticeship_service.py
+++ b/services/apprenticeship_service.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from backend.database import DB_PATH
 from backend.models.apprenticeship import Apprenticeship
-from backend.services.karma_service import KarmaService
+from services.karma_service import KarmaService
 
 
 class ApprenticeshipService:

--- a/services/arrangement_service.py
+++ b/services/arrangement_service.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 from backend.models.arrangement import ArrangementTrack
 from backend.models.song import Song
-from backend.services.recording_service import RecordingService, recording_service
+from services.recording_service import RecordingService, recording_service
 
 
 class ArrangementService:

--- a/services/attribute_service.py
+++ b/services/attribute_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Tuple
 
 from backend.models.attribute import Attribute
-from backend.services.perk_service import perk_service
+from services.perk_service import perk_service
 
 
 class AttributeService:

--- a/services/audio_mixing_service.py
+++ b/services/audio_mixing_service.py
@@ -4,7 +4,7 @@ from typing import List
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 
 
 def mix_tracks(performance_ids: List[int], user_id: int | None = None) -> List[int]:

--- a/services/band_service.py
+++ b/services/band_service.py
@@ -15,10 +15,10 @@ from typing import Callable, Optional
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, create_engine, func
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
-from backend.services.chemistry_service import ChemistryService
-from backend.services.band_relationship_service import BandRelationshipService
-from backend.services.avatar_service import AvatarService
-from backend.services.skill_service import SkillService
+from services.chemistry_service import ChemistryService
+from services.band_relationship_service import BandRelationshipService
+from services.avatar_service import AvatarService
+from services.skill_service import SkillService
 from backend.models.skill import Skill
 
 # ---------------------------------------------------------------------------

--- a/services/books_service.py
+++ b/services/books_service.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 from backend.models.book import Book
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 
 
 class BooksService:
@@ -69,7 +69,7 @@ class BooksService:
             "hours": hours,
         }
 
-        from backend.services.scheduler_service import schedule_task
+        from services.scheduler_service import schedule_task
 
         return schedule_task("complete_reading", params, run_at.isoformat())
 

--- a/services/business_service.py
+++ b/services/business_service.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 
 from .economy_service import EconomyError, EconomyService
 

--- a/services/business_training_service.py
+++ b/services/business_training_service.py
@@ -4,8 +4,8 @@ from typing import Dict
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import SkillService
-from backend.services.skill_service import skill_service as default_skill_service
+from services.skill_service import SkillService
+from services.skill_service import skill_service as default_skill_service
 
 
 class BusinessTrainingService:

--- a/services/calendar_export.py
+++ b/services/calendar_export.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-from backend.services.schedule_service import schedule_service
+from services.schedule_service import schedule_service
 
 
 def daily_schedule_to_ics(user_id: int, date: str) -> str:

--- a/services/chart_service.py
+++ b/services/chart_service.py
@@ -1,8 +1,8 @@
 import sqlite3
 from datetime import datetime, timedelta
 
-from backend.services.achievement_service import AchievementService
-from backend.services.legacy_service import LegacyService
+from services.achievement_service import AchievementService
+from services.legacy_service import LegacyService
 
 from backend.database import DB_PATH
 

--- a/services/city_shop_service.py
+++ b/services/city_shop_service.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from datetime import datetime
 
-from backend.services.item_service import item_service
-from backend.services.books_service import books_service
-from backend.services.economy_service import EconomyService
+from services.item_service import item_service
+from services.books_service import books_service
+from services.economy_service import EconomyService
 
 from .economy_service import EconomyService, EconomyError
 from .item_service import item_service

--- a/services/contract_negotiation_service.py
+++ b/services/contract_negotiation_service.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 from backend.models.label_management_models import NegotiationStage
 from backend.models.record_contract import RecordContract, RoyaltyTier
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 Base = declarative_base()
 

--- a/services/cover_service.py
+++ b/services/cover_service.py
@@ -1,7 +1,7 @@
 """Service for handling song covers by other artists."""
 
-from backend.services.song_popularity_service import add_event
-from backend.services.song_service import SongService
+from services.song_popularity_service import add_event
+from services.song_service import SongService
 
 song_service = SongService()
 

--- a/services/crafting_service.py
+++ b/services/crafting_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, asdict
 from typing import Dict, List
 
-from backend.services.item_service import item_service
+from services.item_service import item_service
 
 
 @dataclass

--- a/services/crowdfunding_service.py
+++ b/services/crowdfunding_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from pathlib import Path
 from typing import Optional
 
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/dialogue_service.py
+++ b/services/dialogue_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import List, Optional, Protocol
 
 from backend.models.dialogue import DialogueMessage
-from backend.services.moderation_service import moderate_content
+from services.moderation_service import moderate_content
 
 
 class LLMProvider(Protocol):

--- a/services/economy_admin_service.py
+++ b/services/economy_admin_service.py
@@ -11,7 +11,7 @@ from backend.models.economy_config import (
     set_config,
     save_config,
 )
-from backend.services.economy_service import EconomyService, TransactionRecord
+from services.economy_service import EconomyService, TransactionRecord
 
 
 class EconomyAdminService:

--- a/services/economy_service.py
+++ b/services/economy_service.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from backend.services.xp_reward_service import xp_reward_service
+from services.xp_reward_service import xp_reward_service
 
 from backend.models.banking import Loan
 from backend.models.economy_config import get_config

--- a/services/fan_club_service.py
+++ b/services/fan_club_service.py
@@ -8,7 +8,7 @@ from backend.realtime.publish import (
     publish_fan_club_event_invite,
     publish_fan_club_post,
 )
-from backend.services.avatar_service import AvatarService
+from services.avatar_service import AvatarService
 
 
 @dataclass

--- a/services/fan_interaction_service.py
+++ b/services/fan_interaction_service.py
@@ -1,8 +1,8 @@
 import sqlite3
 from datetime import datetime
 from backend.database import DB_PATH
-from backend.services import fan_service
-from backend.services.skill_service import skill_service
+from services import fan_service
+from services.skill_service import skill_service
 from backend.seeds.skill_seed import SEED_SKILLS
 
 FASHION_SKILL = next(s for s in SEED_SKILLS if s.name == "fashion")

--- a/services/fan_service.py
+++ b/services/fan_service.py
@@ -3,8 +3,8 @@ import sqlite3
 from backend.database import DB_PATH
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.avatar_service import AvatarService
-from backend.services.skill_service import skill_service
+from services.avatar_service import AvatarService
+from services.skill_service import skill_service
 
 avatar_service = AvatarService()
 

--- a/services/festival_builder_service.py
+++ b/services/festival_builder_service.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from backend.services.economy_service import EconomyService
-from backend.services.legacy_service import LegacyService
+from services.economy_service import EconomyService
+from services.legacy_service import LegacyService
 
 from backend.models.festival import FestivalProposal
 from backend.models.festival_builder import (

--- a/services/gifting_service.py
+++ b/services/gifting_service.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.services.xp_reward_service import xp_reward_service
+from services.xp_reward_service import xp_reward_service
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/gig_service.py
+++ b/services/gig_service.py
@@ -3,14 +3,14 @@ import random
 from datetime import datetime, timedelta
 
 from backend.database import DB_PATH
-from backend.services import fan_service
-from backend.services.skill_service import skill_service
+from services import fan_service
+from services.skill_service import skill_service
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 try:  # pragma: no cover - optional in minimal environments
-    from backend.services.band_service import BandService
+    from services.band_service import BandService
 except Exception:  # pragma: no cover
     class BandService:  # type: ignore
         def get_band_info(self, _band_id: int):
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover
             return None
 
 try:  # pragma: no cover - optional avatar dependency
-    from backend.services.avatar_service import AvatarService
+    from services.avatar_service import AvatarService
     from backend.schemas.avatar import AvatarUpdate
 except Exception:  # pragma: no cover
     class AvatarUpdate:  # type: ignore

--- a/services/image_training_service.py
+++ b/services/image_training_service.py
@@ -6,8 +6,8 @@ from typing import Dict
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import SkillService
-from backend.services.skill_service import skill_service as default_skill_service
+from services.skill_service import SkillService
+from services.skill_service import skill_service as default_skill_service
 
 
 class ImageTrainingService:

--- a/services/indie_release_service.py
+++ b/services/indie_release_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from backend.models.label_management_models import ClauseTemplate
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 
 @dataclass

--- a/services/jam_service.py
+++ b/services/jam_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Dict, Optional, Set
 
 from backend.models.jam_session import AudioStream, JamSession
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 STUDIO_RENTAL_CENTS = 100
 PREMIUM_STREAM_CENTS = 25

--- a/services/karma_service.py
+++ b/services/karma_service.py
@@ -2,8 +2,8 @@
 from datetime import datetime
 
 from models.karma_event import KarmaEvent
-from backend.services.karma_db import KarmaDB
-from backend.services.xp_reward_service import xp_reward_service
+from services.karma_db import KarmaDB
+from services.xp_reward_service import xp_reward_service
 
 
 class KarmaService:

--- a/services/legal_service.py
+++ b/services/legal_service.py
@@ -5,8 +5,8 @@ from typing import Dict, Optional, Protocol
 
 from datetime import datetime
 
-from backend.services.economy_service import EconomyService, EconomyError
-from backend.services.karma_service import KarmaService
+from services.economy_service import EconomyService, EconomyError
+from services.karma_service import KarmaService
 from models.legal import LegalCase, Filing, Verdict
 
 

--- a/services/live_album_service.py
+++ b/services/live_album_service.py
@@ -12,9 +12,9 @@ from typing import Dict, List
 from models.album import Album
 
 from backend.database import DB_PATH
-from backend.services import audio_mixing_service, chart_service
-from backend.services.ai_art_service import ai_art_service
-from backend.services.sales_service import SalesService
+from services import audio_mixing_service, chart_service
+from services.ai_art_service import ai_art_service
+from services.sales_service import SalesService
 
 
 class LiveAlbumService:

--- a/services/live_performance_service.py
+++ b/services/live_performance_service.py
@@ -5,13 +5,13 @@ from datetime import datetime
 from typing import Dict, Generator, Iterable, Optional
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 from backend.models.skill import Skill
 
 from backend.database import DB_PATH
-from backend.services import live_performance_analysis
+from services import live_performance_analysis
 try:
-    from backend.services.chemistry_service import ChemistryService
+    from services.chemistry_service import ChemistryService
 except Exception:  # pragma: no cover - fallback if DB unavailable
     class ChemistryService:  # type: ignore
         def initialize_pair(self, a, b):
@@ -19,10 +19,10 @@ except Exception:  # pragma: no cover - fallback if DB unavailable
 
         def adjust_pair(self, a, b, delta):  # noqa: D401 - simple stub
             return type("P", (), {"score": 50})()
-from backend.services.city_service import city_service
-from backend.services.event_service import is_skill_blocked
-from backend.services.gear_service import gear_service
-from backend.services.setlist_service import get_approved_setlist
+from services.city_service import city_service
+from services.event_service import is_skill_blocked
+from services.gear_service import gear_service
+from services.setlist_service import get_approved_setlist
 
 try:
     from backend.realtime.polling import poll_hub

--- a/services/mail_service.py
+++ b/services/mail_service.py
@@ -6,8 +6,8 @@ import time
 import uuid
 from typing import Dict, List, Optional
 
-from backend.services.notifications_service import NotificationsService
-from backend.services.storage_service import get_storage_backend
+from services.notifications_service import NotificationsService
+from services.storage_service import get_storage_backend
 from utils.db import get_conn
 
 

--- a/services/marketplace_service.py
+++ b/services/marketplace_service.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from backend.services.economy_service import EconomyService, EconomyError
+from services.economy_service import EconomyService, EconomyError
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/media_event_service.py
+++ b/services/media_event_service.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from backend.services.song_popularity_service import SongPopularityService, song_popularity_service
+from services.song_popularity_service import SongPopularityService, song_popularity_service
 
 
 class MediaEventService:

--- a/services/media_moderation_service.py
+++ b/services/media_moderation_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, List, Optional
 
-from backend.services.moderation_service import (
+from services.moderation_service import (
     BANNED_WORDS as TEXT_BANNED_WORDS,
     moderate_content,
 )

--- a/services/media_monitor_service.py
+++ b/services/media_monitor_service.py
@@ -1,7 +1,7 @@
 import re
 from typing import Callable, Dict, List
 
-from backend.services.song_popularity_service import song_popularity_service
+from services.song_popularity_service import song_popularity_service
 
 
 class MediaMonitorService:

--- a/services/media_service.py
+++ b/services/media_service.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 
 from models.influencer_models import Collaboration, CollaborationStatus
 
-from backend.services.song_popularity_service import add_event
+from services.song_popularity_service import add_event
 
 
 def record_media_placement(song_id: int, placement_type: str) -> None:

--- a/services/merch_service.py
+++ b/services/merch_service.py
@@ -4,9 +4,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from backend.models.merch import CartItem, ProductIn, SKUIn
-from backend.services.economy_service import EconomyError, EconomyService
-from backend.services.payment_service import PaymentError, PaymentService
-from backend.services.legacy_service import LegacyService
+from services.economy_service import EconomyError, EconomyService
+from services.payment_service import PaymentError, PaymentService
+from services.legacy_service import LegacyService
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/mod_marketplace_service.py
+++ b/services/mod_marketplace_service.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Dict, List, Optional
 from uuid import uuid4
 
-from backend.services.economy_service import EconomyService
-from backend.services.storage_service import get_storage_backend
+from services.economy_service import EconomyService
+from services.storage_service import get_storage_backend
 from backend.storage.base import StorageBackend
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"

--- a/services/music_production_service.py
+++ b/services/music_production_service.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.avatar_service import AvatarService
+from services.avatar_service import AvatarService
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 
 
 class MusicProductionService:

--- a/services/npc_band_service.py
+++ b/services/npc_band_service.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 import random
 
 try:  # pragma: no cover - import path shim
-    from backend.services.world_pulse_service import get_current_season
+    from services.world_pulse_service import get_current_season
 except Exception:  # pragma: no cover
-    from backend.services.world_pulse_service import get_current_season
+    from services.world_pulse_service import get_current_season
 
 class NPCBandService:
     def __init__(self, db):

--- a/services/payment_service.py
+++ b/services/payment_service.py
@@ -11,7 +11,7 @@ from typing import Dict, Optional
 from uuid import uuid4
 
 from backend.models.payment import PremiumCurrency, PurchaseRecord, SubscriptionPlan
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 
 class PaymentError(Exception):

--- a/services/peer_learning_service.py
+++ b/services/peer_learning_service.py
@@ -6,7 +6,7 @@ from typing import Iterable, List
 
 from backend.database import DB_PATH
 from backend.models.skill import Skill
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 PERFORMANCE_SKILL = Skill(
@@ -51,7 +51,7 @@ class PeerLearningService:
     # ------------------------------------------------------------------
     def schedule_session(self, band_id: int, members: Iterable[int], run_at: str) -> dict:
         """Schedule a peer learning session via the scheduler service."""
-        from backend.services.scheduler_service import schedule_task
+        from services.scheduler_service import schedule_task
 
         member_list = list(members)
         try:

--- a/services/plan_service.py
+++ b/services/plan_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List
 
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 
 # Default mapping of category -> list of activity names.
 CATEGORY_MAP: Dict[str, List[str]] = {

--- a/services/quest_service.py
+++ b/services/quest_service.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import Dict
 
 from backend.models.quest import Quest, QuestReward, QuestStage
-from backend.services.city_service import city_service
-from backend.services.quest_admin_service import QuestAdminService
-from backend.services.xp_event_service import XPEventService
+from services.city_service import city_service
+from services.quest_admin_service import QuestAdminService
+from services.xp_event_service import XPEventService
 
 
 class QuestService:

--- a/services/radio_service.py
+++ b/services/radio_service.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import Optional
 
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 AD_REVENUE_CENTS = 1  # revenue per listener

--- a/services/random_event_service.py
+++ b/services/random_event_service.py
@@ -5,9 +5,9 @@ from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.models.random_event import RandomEvent
 from backend.models.random_events import ADDICTION_EVENTS
 from backend.models.skill import Skill
-from backend.services.addiction_service import addiction_service
-from backend.services.notifications_service import NotificationsService
-from backend.services.skill_service import skill_service
+from services.addiction_service import addiction_service
+from services.notifications_service import NotificationsService
+from services.skill_service import skill_service
 
 
 class RandomEventService:

--- a/services/recording_service.py
+++ b/services/recording_service.py
@@ -6,9 +6,9 @@ from backend.models.learning_method import LearningMethod
 from backend.models.recording_session import RecordingSession
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.chemistry_service import ChemistryService
-from backend.services.economy_service import EconomyError, EconomyService
-from backend.services.skill_service import skill_service
+from services.chemistry_service import ChemistryService
+from services.economy_service import EconomyError, EconomyService
+from services.skill_service import skill_service
 
 
 class RecordingService:

--- a/services/rehearsal_service.py
+++ b/services/rehearsal_service.py
@@ -14,9 +14,9 @@ from typing import Iterable, List, Optional
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
-from backend.services.event_service import is_skill_blocked
-from backend.services.gear_service import gear_service
-from backend.services.peer_learning_service import peer_learning_service
+from services.event_service import is_skill_blocked
+from services.gear_service import gear_service
+from services.peer_learning_service import peer_learning_service
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -8,17 +8,17 @@ from backend.models.notification_models import (
     alert_no_plan,
     alert_pending_outcomes,
 )
-from backend.services import chart_service, fan_service, song_popularity_service
-from backend.services.activity_processor import process_previous_day
-from backend.services.books_service import books_service
-from backend.services.event_service import end_shop_event, start_shop_event
-from backend.services.npc_service import npc_service
-from backend.services.peer_learning_service import run_scheduled_session
-from backend.services.schedule_service import schedule_service
-from backend.services.shop_restock_service import restock_handler
-from backend.services.skill_service import skill_service
-from backend.services.social_sentiment_service import social_sentiment_service
-from backend.services.song_popularity_forecast import forecast_service
+from services import chart_service, fan_service, song_popularity_service
+from services.activity_processor import process_previous_day
+from services.books_service import books_service
+from services.event_service import end_shop_event, start_shop_event
+from services.npc_service import npc_service
+from services.peer_learning_service import run_scheduled_session
+from services.schedule_service import schedule_service
+from services.shop_restock_service import restock_handler
+from services.skill_service import skill_service
+from services.social_sentiment_service import social_sentiment_service
+from services.song_popularity_forecast import forecast_service
 
 
 def _plan_reminder(user_id: int, day: str) -> dict:

--- a/services/shop_npc_service.py
+++ b/services/shop_npc_service.py
@@ -4,9 +4,9 @@ from datetime import date
 from typing import Dict, List, Optional
 
 from backend.models.npc_dialogue import DialogueNode, DialogueResponse, DialogueTree
-from backend.services.npc_service import NPCService
-from backend.services.city_shop_service import CityShopService, city_shop_service
-from backend.services.item_service import item_service as default_item_service, ItemService
+from services.npc_service import NPCService
+from services.city_shop_service import CityShopService, city_shop_service
+from services.item_service import item_service as default_item_service, ItemService
 
 
 class ShopNPCService:

--- a/services/shop_restock_service.py
+++ b/services/shop_restock_service.py
@@ -34,7 +34,7 @@ def schedule_restock(
     shop_id: int, kind: str, item_id: int, interval: int, quantity: int
 ) -> Dict[str, int]:
     """Schedule recurring restocking for a shop item or book."""
-    from backend.services.scheduler_service import schedule_task
+    from services.scheduler_service import schedule_task
 
     run_at = (datetime.utcnow() + timedelta(days=interval)).isoformat()
     return schedule_task(

--- a/services/social_media_training_service.py
+++ b/services/social_media_training_service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import SkillService
-from backend.services.skill_service import skill_service as default_skill_service
+from services.skill_service import SkillService
+from services.skill_service import skill_service as default_skill_service
 
 
 class SocialMediaTrainingService:

--- a/services/social_sentiment_service.py
+++ b/services/social_sentiment_service.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Callable, Dict, List, Optional
 
 from backend.database import DB_PATH
-from backend.services.song_popularity_service import add_event
+from services.song_popularity_service import add_event
 
 
 def _ensure_schema(cur: sqlite3.Cursor) -> None:

--- a/services/song_popularity_forecast.py
+++ b/services/song_popularity_forecast.py
@@ -132,7 +132,7 @@ forecast_service = SongPopularityForecastService()
 def _schedule_forecast_recompute() -> None:
     """Schedule nightly recomputation of all song forecasts."""
     try:  # best effort; scheduler may not be set up in all environments
-        from backend.services.scheduler_service import schedule_task
+        from services.scheduler_service import schedule_task
 
         run_at = (datetime.utcnow() + timedelta(days=1)).isoformat()
         schedule_task(

--- a/services/song_popularity_service.py
+++ b/services/song_popularity_service.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from backend.database import DB_PATH
-from backend.services.song_popularity_forecast import forecast_service
+from services.song_popularity_forecast import forecast_service
 
 # Supported region codes and platforms
 ALLOWED_REGION_CODES = {"global", "US", "EU"}
@@ -457,7 +457,7 @@ def schedule_global_aggregation() -> None:
     try:
         from datetime import timedelta
 
-        from backend.services.scheduler_service import schedule_task
+        from services.scheduler_service import schedule_task
 
         run_at = (datetime.utcnow() + timedelta(days=1)).isoformat()
         schedule_task(

--- a/services/song_remaster_service.py
+++ b/services/song_remaster_service.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from typing import Dict, Optional
 
 from backend.database import DB_PATH
-from backend.services.song_service import SongService
-from backend.services.song_popularity_service import song_popularity_service
+from services.song_service import SongService
+from services.song_popularity_service import song_popularity_service
 
 
 class SongRemasterService:

--- a/services/songwriting_service.py
+++ b/services/songwriting_service.py
@@ -8,23 +8,23 @@ from backend.models.song import Song
 from backend.models.song_draft_version import SongDraftVersion
 from backend.models.songwriting import GenerationMetadata, LyricDraft
 from backend.models.theme import THEMES
-from backend.services.ai_art_service import AIArtService, ai_art_service
-from backend.services.band_service import BandService
-from backend.services.chemistry_service import ChemistryService
-from backend.services.avatar_service import AvatarService
-from backend.services.originality_service import (
+from services.ai_art_service import AIArtService, ai_art_service
+from services.band_service import BandService
+from services.chemistry_service import ChemistryService
+from services.avatar_service import AvatarService
+from services.originality_service import (
     OriginalityService,
     originality_service,
 )
-from backend.services.skill_service import (
+from services.skill_service import (
     SkillService,
 )
-from backend.services.skill_service import (
+from services.skill_service import (
     skill_service as skill_service_instance,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
-    from backend.services.legal_service import LegalService
+    from services.legal_service import LegalService
 
 
 class _Message:

--- a/services/stream_service.py
+++ b/services/stream_service.py
@@ -1,6 +1,6 @@
 
 from models.stream import Stream
-from backend.services.avatar_service import AvatarService
+from services.avatar_service import AvatarService
 
 PLATFORM_PAYOUTS = {
     "Spotify": 0.003,

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -8,8 +8,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback to package
 from backend.database import DB_PATH
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import skill_service
-from backend.services.song_popularity_service import add_event
+from services.skill_service import skill_service
+from services.song_popularity_service import add_event
 
 
 async def _stream_song(user_id: int, song_id: int) -> dict:

--- a/services/ticketing_service.py
+++ b/services/ticketing_service.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.services.economy_service import EconomyError, EconomyService
+from services.economy_service import EconomyError, EconomyService
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/tour_logistics_service.py
+++ b/services/tour_logistics_service.py
@@ -4,7 +4,7 @@ from models.tour_route import TourRoute
 from datetime import datetime, timedelta
 import random
 
-from backend.services.transport_service import TransportService
+from services.transport_service import TransportService
 
 class TourLogisticsService:
     def __init__(self, db, transport: TransportService | None = None):

--- a/services/tour_service.py
+++ b/services/tour_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Dict, List, Optional
 from utils.db import get_conn
-from backend.services.venue_availability import VenueAvailabilityService
+from services.venue_availability import VenueAvailabilityService
 from core.errors import AppError, TourMinStopsError, VenueConflictError
 import sqlite3
 from typing import Any, Dict, List, Optional
@@ -13,11 +13,11 @@ from core.errors import AppError, TourMinStopsError, VenueConflictError
 from models.economy_config import get_config
 from models.tour import Expense, TicketTier, TourLeg
 from models.tour import Tour as TourModel
-from backend.services.achievement_service import AchievementService
-from backend.services.economy_service import EconomyService
-from backend.services.fame_service import FameService
-from backend.services.venue_availability import VenueAvailabilityService
-from backend.services.weather_service import WeatherService
+from services.achievement_service import AchievementService
+from services.economy_service import EconomyService
+from services.fame_service import FameService
+from services.venue_availability import VenueAvailabilityService
+from services.weather_service import WeatherService
 from sqlalchemy.exc import SQLAlchemyError
 
 from backend.utils.logging import get_logger

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 import sqlite3
 
 from backend.models.tournament import Bracket, Match, Score
-from backend.services import live_performance_service
+from services import live_performance_service
 from backend.database import DB_PATH
 
 

--- a/services/tutor_service.py
+++ b/services/tutor_service.py
@@ -7,9 +7,9 @@ from typing import Dict, Optional
 from backend.models.tutor import Tutor
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod, METHOD_PROFILES
-from backend.services.avatar_service import AvatarService
-from backend.services.economy_service import EconomyService
-from backend.services.skill_service import SkillService, skill_service
+from services.avatar_service import AvatarService
+from services.economy_service import EconomyService
+from services.skill_service import SkillService, skill_service
 
 
 class TutorService:

--- a/services/university_service.py
+++ b/services/university_service.py
@@ -10,7 +10,7 @@ from typing import List
 from backend.database import DB_PATH
 from backend.models.course import Course
 from backend.models.skill import Skill
-from backend.services.skill_service import SkillService
+from services.skill_service import SkillService
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 

--- a/services/video_service.py
+++ b/services/video_service.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from typing import Dict, List
 
 from backend.models.video import Video
-from backend.services.economy_service import EconomyService
-from backend.services.media_moderation_service import media_moderation_service
-from backend.services.skill_service import SkillService
+from services.economy_service import EconomyService
+from services.media_moderation_service import media_moderation_service
+from services.skill_service import SkillService
 from backend.seeds.skill_seed import SEED_SKILLS
 from backend.utils.metrics import _REGISTRY, Histogram
 

--- a/services/vocal_training_service.py
+++ b/services/vocal_training_service.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from backend.models.learning_method import LearningMethod
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SEED_SKILLS
-from backend.services.skill_service import SkillService
-from backend.services.skill_service import skill_service as default_skill_service
+from services.skill_service import SkillService
+from services.skill_service import skill_service as default_skill_service
 
 
 class VocalTrainingService:


### PR DESCRIPTION
## Summary
- update all service modules to import from `services` rather than `backend.services`

## Testing
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c73c382acc83259b4adc76d19a7162