### PR TITLE
refactor: simplify service model imports

### DIFF
--- a/services/achievement_service.py
+++ b/services/achievement_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from backend.models.achievement import Achievement, PlayerAchievement
+from models.achievement import Achievement, PlayerAchievement
 from core.config import settings
 from utils.db import get_conn
 

--- a/services/activity_processor.py
+++ b/services/activity_processor.py
@@ -8,8 +8,8 @@ from datetime import date, timedelta
 from typing import Dict, List
 
 from backend.database import DB_PATH
-from backend.models import activity_log as activity_log_model
-from backend.models import user_settings
+from models import activity_log as activity_log_model
+from models import user_settings
 
 
 def _ensure_tables(cur: sqlite3.Cursor) -> None:

--- a/services/apprenticeship_service.py
+++ b/services/apprenticeship_service.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 
 from backend.database import DB_PATH
-from backend.models.apprenticeship import Apprenticeship
+from models.apprenticeship import Apprenticeship
 from backend.services.karma_service import KarmaService
 
 

--- a/services/arrangement_service.py
+++ b/services/arrangement_service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
-from backend.models.arrangement import ArrangementTrack
-from backend.models.song import Song
+from models.arrangement import ArrangementTrack
+from models.song import Song
 from backend.services.recording_service import RecordingService, recording_service
 
 

--- a/services/attribute_service.py
+++ b/services/attribute_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, Tuple
 
-from backend.models.attribute import Attribute
+from models.attribute import Attribute
 from backend.services.perk_service import perk_service
 
 

--- a/services/audio_mixing_service.py
+++ b/services/audio_mixing_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 

--- a/services/band_relationship_service.py
+++ b/services/band_relationship_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from backend.models.band_relationship import BandRelationship
+from models.band_relationship import BandRelationship
 
 
 @dataclass

--- a/services/band_service.py
+++ b/services/band_service.py
@@ -19,7 +19,7 @@ from backend.services.chemistry_service import ChemistryService
 from backend.services.band_relationship_service import BandRelationshipService
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService
-from backend.models.skill import Skill
+from models.skill import Skill
 
 # ---------------------------------------------------------------------------
 # Database setup

--- a/services/bank_service.py
+++ b/services/bank_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 
-from backend.models.banking import InterestAccount, Loan
+from models.banking import InterestAccount, Loan
 from backend.utils.logging import get_logger
 from .economy_service import EconomyService, EconomyError
 

--- a/services/books_service.py
+++ b/services/books_service.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Dict, List
 
-from backend.models.book import Book
-from backend.models.skill import Skill
-from backend.models.learning_method import LearningMethod
+from models.book import Book
+from models.skill import Skill
+from models.learning_method import LearningMethod
 from backend.services.skill_service import skill_service
 
 

--- a/services/business_service.py
+++ b/services/business_service.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 

--- a/services/business_training_service.py
+++ b/services/business_training_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service

--- a/services/chemistry_service.py
+++ b/services/chemistry_service.py
@@ -11,7 +11,7 @@ from sqlalchemy import create_engine, func
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 
-from backend.models.player_chemistry import Base, PlayerChemistry
+from models.player_chemistry import Base, PlayerChemistry
 
 DB_PATH = Path(__file__).resolve().parents[1] / "database" / "rockmundo.db"
 DATABASE_URL = f"sqlite:///{DB_PATH}"

--- a/services/city_service.py
+++ b/services/city_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import random
 from typing import Dict, List
 
-from backend.models.city import City
+from models.city import City
 
 
 class CityService:

--- a/services/contract_negotiation_service.py
+++ b/services/contract_negotiation_service.py
@@ -9,8 +9,8 @@ from sqlalchemy import JSON, Column, Integer, create_engine
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
-from backend.models.label_management_models import NegotiationStage
-from backend.models.record_contract import RecordContract, RoyaltyTier
+from models.label_management_models import NegotiationStage
+from models.record_contract import RecordContract, RoyaltyTier
 from backend.services.economy_service import EconomyService
 
 Base = declarative_base()

--- a/services/course_admin_service.py
+++ b/services/course_admin_service.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from backend.database import DB_PATH
-from backend.models.course import Course
+from models.course import Course
 
 
 class CourseAdminService:

--- a/services/dialogue_service.py
+++ b/services/dialogue_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import List, Optional, Protocol
 
-from backend.models.dialogue import DialogueMessage
+from models.dialogue import DialogueMessage
 from backend.services.moderation_service import moderate_content
 
 

--- a/services/economy_admin_service.py
+++ b/services/economy_admin_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List
 
-from backend.models.economy_config import (
+from models.economy_config import (
     EconomyConfig,
     get_config,
     set_config,

--- a/services/economy_service.py
+++ b/services/economy_service.py
@@ -7,8 +7,8 @@ from typing import Optional
 
 from backend.services.xp_reward_service import xp_reward_service
 
-from backend.models.banking import Loan
-from backend.models.economy_config import get_config
+from models.banking import Loan
+from models.economy_config import get_config
 from backend.utils.logging import get_logger
 
 from sqlalchemy import create_engine, select, or_

--- a/services/event_service.py
+++ b/services/event_service.py
@@ -8,10 +8,10 @@ from typing import Any, Dict, List
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
 from backend.database import DB_PATH
-from backend.models.event import Event
-from backend.models.event_effect import EventEffect
-from backend.models.npc import NPC
-from backend.models.skill import Skill
+from models.event import Event
+from models.event_effect import EventEffect
+from models.npc import NPC
+from models.skill import Skill
 
 from .city_service import city_service
 from .npc_ai_service import npc_ai_service

--- a/services/fan_insight_service.py
+++ b/services/fan_insight_service.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 
 from utils.db import cached_query
 
-from backend.models.analytics import (
+from models.analytics import (
     AgeBucket,
     FanSegmentSummary,
     FanTrends,

--- a/services/fan_service.py
+++ b/services/fan_service.py
@@ -1,7 +1,7 @@
 import sqlite3
 
 from backend.database import DB_PATH
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import skill_service

--- a/services/festival_builder_service.py
+++ b/services/festival_builder_service.py
@@ -6,15 +6,15 @@ from typing import Dict, List, Optional
 from backend.services.economy_service import EconomyService
 from backend.services.legacy_service import LegacyService
 
-from backend.models.festival import FestivalProposal
-from backend.models.festival_builder import (
+from models.festival import FestivalProposal
+from models.festival_builder import (
     FestivalBuilder,
     Slot,
     Sponsor,
     Stage,
     TicketTier,
 )
-from backend.models.ticketing_models import Ticket
+from models.ticketing_models import Ticket
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/gear_service.py
+++ b/services/gear_service.py
@@ -6,7 +6,7 @@ from dataclasses import asdict
 from itertools import chain
 from typing import Dict, List
 
-from backend.models.gear import BaseItem, GearComponent, GearItem, StatModifier
+from models.gear import BaseItem, GearComponent, GearItem, StatModifier
 
 
 class GearService:

--- a/services/gig_service.py
+++ b/services/gig_service.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta
 from backend.database import DB_PATH
 from backend.services import fan_service
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
-from backend.models.learning_method import LearningMethod
+from models.skill import Skill
+from models.learning_method import LearningMethod
 from backend.services.economy_service import EconomyService
 
 try:  # pragma: no cover - optional in minimal environments

--- a/services/image_training_service.py
+++ b/services/image_training_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service

--- a/services/indie_release_service.py
+++ b/services/indie_release_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from backend.models.label_management_models import ClauseTemplate
+from models.label_management_models import ClauseTemplate
 from backend.services.economy_service import EconomyService
 
 

--- a/services/jam_service.py
+++ b/services/jam_service.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import Dict, Optional, Set
 
-from backend.models.jam_session import AudioStream, JamSession
+from models.jam_session import AudioStream, JamSession
 from backend.services.economy_service import EconomyService
 
 STUDIO_RENTAL_CENTS = 100

--- a/services/karma_db.py
+++ b/services/karma_db.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import List, Dict, Any
 
 from backend.database import DB_PATH
-from backend.models.karma_event import KarmaEvent
+from models.karma_event import KarmaEvent
 
 
 class KarmaDB:

--- a/services/lifestyle_service.py
+++ b/services/lifestyle_service.py
@@ -5,7 +5,7 @@ import random
 import sqlite3
 
 from backend.database import DB_PATH
-from backend.models import notification_models
+from models import notification_models
 
 from .skill_service import skill_service
 from .xp_reward_service import xp_reward_service
@@ -19,7 +19,7 @@ EXERCISE_COOLDOWN = timedelta(hours=6)
 EXERCISE_FITNESS_BONUS = 5
 
 
-from backend.models import activity as activity_models
+from models import activity as activity_models
 
 _ACTIVITY_MAP = {
     "gym": activity_models.gym,

--- a/services/live_performance_service.py
+++ b/services/live_performance_service.py
@@ -6,7 +6,7 @@ from typing import Dict, Generator, Iterable, Optional
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
+from models.skill import Skill
 
 from backend.database import DB_PATH
 from backend.services import live_performance_analysis

--- a/services/marketing_ai_service.py
+++ b/services/marketing_ai_service.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 from typing import Dict, List
 
-from backend.models.promotion import Promotion
+from models.promotion import Promotion
 
 # In-memory storage for accepted promotions
 _promotions_db: List[Promotion] = []

--- a/services/merch_service.py
+++ b/services/merch_service.py
@@ -3,7 +3,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.models.merch import CartItem, ProductIn, SKUIn
+from models.merch import CartItem, ProductIn, SKUIn
 from backend.services.economy_service import EconomyError, EconomyService
 from backend.services.payment_service import PaymentError, PaymentService
 from backend.services.legacy_service import LegacyService

--- a/services/music_production_service.py
+++ b/services/music_production_service.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 """Music production utilities influenced by avatar tech savvy."""
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.avatar_service import AvatarService
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 

--- a/services/npc_ai_service.py
+++ b/services/npc_ai_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 from typing import Dict, List, Optional
 
-from backend.models.npc import NPC
+from models.npc import NPC
 
 
 class NPCAIService:

--- a/services/npc_service.py
+++ b/services/npc_service.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import random
 from typing import Dict, List, Optional
 
-from backend.models.npc import NPC
-from backend.models.npc_dialogue import DialogueTree
+from models.npc import NPC
+from models.npc_dialogue import DialogueTree
 
 
 # Simple seasonal event definitions used by ``generate_seasonal_event``.

--- a/services/onboarding_question_service.py
+++ b/services/onboarding_question_service.py
@@ -3,7 +3,7 @@
 import random
 from typing import Dict, List
 
-from backend.models.onboarding import Question
+from models.onboarding import Question
 from backend.seeds.question_seed import QUESTIONS
 
 

--- a/services/online_tutorial_admin_service.py
+++ b/services/online_tutorial_admin_service.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import List, Optional
 
-from backend.models.online_tutorial import OnlineTutorial
+from models.online_tutorial import OnlineTutorial
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/originality_service.py
+++ b/services/originality_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import hashlib
 from typing import Dict, Tuple
 
-from backend.models.lyric_hash import LyricHash
+from models.lyric_hash import LyricHash
 
 
 class OriginalityService:

--- a/services/payment_service.py
+++ b/services/payment_service.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional
 from uuid import uuid4
 
-from backend.models.payment import PremiumCurrency, PurchaseRecord, SubscriptionPlan
+from models.payment import PremiumCurrency, PurchaseRecord, SubscriptionPlan
 from backend.services.economy_service import EconomyService
 
 

--- a/services/peer_learning_service.py
+++ b/services/peer_learning_service.py
@@ -5,7 +5,7 @@ import sqlite3
 from typing import Iterable, List
 
 from backend.database import DB_PATH
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.services.skill_service import skill_service
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 

--- a/services/production_service.py
+++ b/services/production_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
-from backend.models.production import (
+from models.production import (
     MixingSession,
     ReleaseMetadata,
     StudioSession,

--- a/services/quest_admin_service.py
+++ b/services/quest_admin_service.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.models.quest import (
+from models.quest import (
     QuestDB,
     QuestStageDB,
     QuestBranchDB,

--- a/services/quest_service.py
+++ b/services/quest_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from backend.models.quest import Quest, QuestReward, QuestStage
+from models.quest import Quest, QuestReward, QuestStage
 from backend.services.city_service import city_service
 from backend.services.quest_admin_service import QuestAdminService
 from backend.services.xp_event_service import XPEventService

--- a/services/random_event_service.py
+++ b/services/random_event_service.py
@@ -2,9 +2,9 @@ import random
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
-from backend.models.random_event import RandomEvent
-from backend.models.random_events import ADDICTION_EVENTS
-from backend.models.skill import Skill
+from models.random_event import RandomEvent
+from models.random_events import ADDICTION_EVENTS
+from models.skill import Skill
 from backend.services.addiction_service import addiction_service
 from backend.services.notifications_service import NotificationsService
 from backend.services.skill_service import skill_service

--- a/services/recording_service.py
+++ b/services/recording_service.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
-from backend.models.learning_method import LearningMethod
-from backend.models.recording_session import RecordingSession
-from backend.models.skill import Skill
+from models.learning_method import LearningMethod
+from models.recording_session import RecordingSession
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.chemistry_service import ChemistryService
 from backend.services.economy_service import EconomyError, EconomyService

--- a/services/reputation_service.py
+++ b/services/reputation_service.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from backend.database import DB_PATH
-from backend.models.reputation import ReputationEvent
+from models.reputation import ReputationEvent
 
 
 class ReputationService:

--- a/services/schedule_service.py
+++ b/services/schedule_service.py
@@ -72,15 +72,15 @@ __all__ = ["save_daily_plan"]
 
 from typing import List, Dict, Iterable
 
-from backend.models import activity as activity_model
-from backend.models import band_schedule as band_schedule_model
-from backend.models import daily_schedule as schedule_model
-from backend.models import next_day_schedule as next_day_model
-from backend.models import default_schedule as default_model
-from backend.models import weekly_schedule as weekly_model
-from backend.models import recurring_schedule as recurring_model
-from backend.models import default_schedule_templates as template_model
-from backend.models import user_settings
+from models import activity as activity_model
+from models import band_schedule as band_schedule_model
+from models import daily_schedule as schedule_model
+from models import next_day_schedule as next_day_model
+from models import default_schedule as default_model
+from models import weekly_schedule as weekly_model
+from models import recurring_schedule as recurring_model
+from models import default_schedule_templates as template_model
+from models import user_settings
 
 
 def _log_schedule_change(user_id: int, date: str, slot: int, before, after) -> None:

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -3,8 +3,8 @@ import sqlite3
 from datetime import date, datetime, timedelta
 
 from backend.database import DB_PATH
-from backend.models import daily_loop
-from backend.models.notification_models import (
+from models import daily_loop
+from models.notification_models import (
     alert_no_plan,
     alert_pending_outcomes,
 )

--- a/services/shop_npc_service.py
+++ b/services/shop_npc_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Dict, List, Optional
 
-from backend.models.npc_dialogue import DialogueNode, DialogueResponse, DialogueTree
+from models.npc_dialogue import DialogueNode, DialogueResponse, DialogueTree
 from backend.services.npc_service import NPCService
 from backend.services.city_shop_service import CityShopService, city_shop_service
 from backend.services.item_service import item_service as default_item_service, ItemService

--- a/services/social_media_training_service.py
+++ b/services/social_media_training_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service

--- a/services/songwriting_service.py
+++ b/services/songwriting_service.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Set
 
-from backend.models.song import Song
-from backend.models.song_draft_version import SongDraftVersion
-from backend.models.songwriting import GenerationMetadata, LyricDraft
-from backend.models.theme import THEMES
+from models.song import Song
+from models.song_draft_version import SongDraftVersion
+from models.songwriting import GenerationMetadata, LyricDraft
+from models.theme import THEMES
 from backend.services.ai_art_service import AIArtService, ai_art_service
 from backend.services.band_service import BandService
 from backend.services.chemistry_service import ChemistryService

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -6,7 +6,7 @@ try:  # pragma: no cover - prefer local stub if available
 except ModuleNotFoundError:  # pragma: no cover - fallback to package
     import aiosqlite  # type: ignore
 from backend.database import DB_PATH
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 from backend.services.song_popularity_service import add_event

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 import sqlite3
 
-from backend.models.tournament import Bracket, Match, Score
+from models.tournament import Bracket, Match, Score
 from backend.services import live_performance_service
 from backend.database import DB_PATH
 

--- a/services/tutor_admin_service.py
+++ b/services/tutor_admin_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from typing import List, Optional
 
 from backend.database import DB_PATH
-from backend.models.tutor import Tutor
+from models.tutor import Tutor
 
 
 class TutorAdminService:

--- a/services/tutor_service.py
+++ b/services/tutor_service.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Dict, Optional
 
-from backend.models.tutor import Tutor
-from backend.models.skill import Skill
-from backend.models.learning_method import LearningMethod, METHOD_PROFILES
+from models.tutor import Tutor
+from models.skill import Skill
+from models.learning_method import LearningMethod, METHOD_PROFILES
 from backend.services.avatar_service import AvatarService
 from backend.services.economy_service import EconomyService
 from backend.services.skill_service import SkillService, skill_service

--- a/services/university_service.py
+++ b/services/university_service.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from typing import List
 
 from backend.database import DB_PATH
-from backend.models.course import Course
-from backend.models.skill import Skill
+from models.course import Course
+from models.skill import Skill
 from backend.services.skill_service import SkillService
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 

--- a/services/venue_sponsorships_service.py
+++ b/services/venue_sponsorships_service.py
@@ -10,7 +10,7 @@ from backend.config.revenue import (
     SPONSOR_IMPRESSION_RATE_CENTS,
     SPONSOR_PAYOUT_SPLIT,
 )
-from backend.models.venue_sponsorship import (
+from models.venue_sponsorship import (
     NegotiationStage,
     SponsorshipNegotiation,
 )

--- a/services/video_service.py
+++ b/services/video_service.py
@@ -4,7 +4,7 @@ import time
 from datetime import datetime
 from typing import Dict, List
 
-from backend.models.video import Video
+from models.video import Video
 from backend.services.economy_service import EconomyService
 from backend.services.media_moderation_service import media_moderation_service
 from backend.services.skill_service import SkillService

--- a/services/vocal_training_service.py
+++ b/services/vocal_training_service.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from backend.models.learning_method import LearningMethod
-from backend.models.skill import Skill
+from models.learning_method import LearningMethod
+from models.skill import Skill
 from backend.seeds.skill_seed import SEED_SKILLS
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service

--- a/services/weather_service.py
+++ b/services/weather_service.py
@@ -5,7 +5,7 @@ import random
 from datetime import date
 from typing import Dict, List, Optional
 
-from backend.models.weather import ClimateZone, Forecast, WeatherEvent
+from models.weather import ClimateZone, Forecast, WeatherEvent
 
 
 class WeatherService:

--- a/services/workshop_admin_service.py
+++ b/services/workshop_admin_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from typing import List, Optional
 
 from backend.database import DB_PATH
-from backend.models.workshop import Workshop
+from models.workshop import Workshop
 
 
 class WorkshopAdminService:

--- a/services/xp_admin_service.py
+++ b/services/xp_admin_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from backend.models.xp_config import (
+from models.xp_config import (
     XPConfig,
     get_config,
     set_config,

--- a/services/xp_reward_service.py
+++ b/services/xp_reward_service.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
-from backend.models.xp_config import get_config
+from models.xp_config import get_config
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 


### PR DESCRIPTION
## Summary
- replace `backend.models` imports in services with `models` to simplify paths

## Testing
- `pytest` *(fails: 51 errors during collection)*
- `ruff check services` *(fails: Found 254 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c73c38a3948325b58866cf4df47225