### PR TITLE
Fix import path for XP reward service

### DIFF
--- a/services/economy_service.py
+++ b/services/economy_service.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from backend.services.xp_reward_service import xp_reward_service
+from services.xp_reward_service import xp_reward_service
 
 from backend.models.banking import Loan
 from backend.models.economy_config import get_config


### PR DESCRIPTION
## Summary
- fix xp reward service import to use local services package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68c73c39f6808325808cdec6a572f528