### PR TITLE
Use api:app as Uvicorn entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 8000
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 # Run the application
-CMD ["uvicorn", "backend.api:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.MD
+++ b/README.MD
@@ -31,7 +31,7 @@ chmod -R 775 var/storage                  # adjust UID/GID as needed
 python -m backend.scripts.seed_demo  # creates demo data: users, skills, genres, etc.
 
 # 5) Run the API
-uvicorn backend.api:app --reload --port 8000
+uvicorn api:app --reload --port 8000
 ```
 
 > When running via Docker, mount `var/storage` and ensure it is owned by the

--- a/UPDATED_README.md
+++ b/UPDATED_README.md
@@ -27,7 +27,7 @@ cp .env.example .env.storage
 python -m backend.scripts.seed_demo  # creates demo data: users, skills, genres, etc.
 
 # 4) Run the API
-uvicorn backend.api:app --reload --port 8000
+uvicorn api:app --reload --port 8000
 ```
 
 Open:

--- a/api.py
+++ b/api.py
@@ -1,7 +1,7 @@
 """Expose the FastAPI application instance.
 
 This tiny module allows tools like ``uvicorn`` to load the pre-configured
-application by importing :mod:`backend.api`.
+application by importing :mod:`api` (``uvicorn api:app``).
 """
 
 from .main import app

--- a/backend/tests/test_metrics_smoke.py
+++ b/backend/tests/test_metrics_smoke.py
@@ -1,8 +1,8 @@
 from fastapi.testclient import TestClient
 
-from backend.api import app
-from backend.realtime.gateway import hub
-from backend.services.economy_service import EconomyService
+from api import app
+from realtime.gateway import hub
+from services.economy_service import EconomyService
 
 
 def test_metrics_endpoint_exposes_counters(tmp_path):

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -12,13 +12,12 @@ import sys
 from pathlib import Path
 
 
-# Ensure project root and ``backend`` package are on the import path so that
-# modules like ``auth`` can be imported when this script is executed directly.
+# Ensure project root is on the import path so that modules like ``auth`` can be
+# imported when this script is executed directly.
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend"))
 
-from backend.api import app  # noqa: E402  (import after path manipulation)
+from api import app  # noqa: E402  (import after path manipulation)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- reference `api:app` instead of `backend.api:app` in docs and Dockerfile
- update OpenAPI generation script and metrics test for new module path
- clarify `api.py` docstring for direct Uvicorn usage

## Testing
- `ruff check scripts/generate_openapi.py api.py backend/tests/test_metrics_smoke.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c73d5e219c8325adb10d1acaad4aa2