### PR TITLE
refactor: update service imports

### DIFF
--- a/backend/tests/achievements/test_achievements.py
+++ b/backend/tests/achievements/test_achievements.py
@@ -7,9 +7,9 @@ sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 import pydantic
 
-from backend.services.achievement_service import AchievementService
-from backend.services.economy_service import EconomyService
-from backend.services.property_service import PropertyService
+from services.achievement_service import AchievementService
+from services.economy_service import EconomyService
+from services.property_service import PropertyService
 
 if not hasattr(pydantic, "Field"):
     def Field(default=None, **kwargs):
@@ -33,8 +33,8 @@ core_errors.TourMinStopsError = TourMinStopsError
 sys.modules["core.errors"] = core_errors
 
 from backend.routes import achievement_routes  # noqa: E402
-from backend.services.chart_service import calculate_weekly_chart  # noqa: E402
-from backend.services.tour_service import TourService  # noqa: E402
+from services.chart_service import calculate_weekly_chart  # noqa: E402
+from services.tour_service import TourService  # noqa: E402
 
 
 def setup_db(tmp_path):
@@ -72,7 +72,7 @@ def test_chart_topper_unlock(tmp_path):
     db = setup_db(tmp_path)
     ach = AchievementService(db)
     # patch chart_service globals
-    from backend.services import chart_service
+    from services import chart_service
     chart_service.DB_PATH = db
     chart_service.achievement_service = ach
 

--- a/backend/tests/admin/test_admin_action_logging.py
+++ b/backend/tests/admin/test_admin_action_logging.py
@@ -6,9 +6,9 @@ import tempfile
 from fastapi import Request
 
 from backend.routes import admin_media_moderation_routes as media_routes
-from backend.services.admin_service import AdminService, AdminActionRepository
+from services.admin_service import AdminService, AdminActionRepository
 from backend.storage.local import LocalStorage
-from backend.services import storage_service
+from services import storage_service
 from backend.utils.db import get_conn
 
 

--- a/backend/tests/admin/test_audit_logging.py
+++ b/backend/tests/admin/test_audit_logging.py
@@ -1,7 +1,7 @@
 import asyncio
 from fastapi import Request
 
-from backend.services.admin_audit_service import (
+from services.admin_audit_service import (
     get_admin_audit_service,
     audit_dependency,
 )

--- a/backend/tests/admin/test_economy_routes.py
+++ b/backend/tests/admin/test_economy_routes.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi import HTTPException, Request
 
 from backend.routes import admin_economy_routes as routes
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 from backend.models.economy_config import set_config, EconomyConfig
 
 

--- a/backend/tests/admin/test_monitoring_sessions.py
+++ b/backend/tests/admin/test_monitoring_sessions.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 import backend.routes.admin_monitoring_routes as monitoring_routes
-from backend.services.session_service import SessionService, get_session_service
+from services.session_service import SessionService, get_session_service
 
 
 def create_app(svc: SessionService) -> TestClient:

--- a/backend/tests/admin/test_name_pools_reload.py
+++ b/backend/tests/admin/test_name_pools_reload.py
@@ -1,4 +1,4 @@
-from backend.services.admin_service import AdminService, AdminActionRepository
+from services.admin_service import AdminService, AdminActionRepository
 from backend.utils import name_generator
 
 

--- a/backend/tests/admin/test_name_routes.py
+++ b/backend/tests/admin/test_name_routes.py
@@ -4,7 +4,7 @@ import types
 import fastapi
 from fastapi import Request
 
-from backend.services import name_dataset_service
+from services import name_dataset_service
 from backend.utils import name_generator
 
 

--- a/backend/tests/albums/test_album_service.py
+++ b/backend/tests/albums/test_album_service.py
@@ -3,8 +3,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from models.music import Base as MusicBase, Release
-from backend.services.album_service import AlbumService
-from backend.services.band_service import Base as BandBase, BandService, Band, BandCollaboration
+from services.album_service import AlbumService
+from services.band_service import Base as BandBase, BandService, Band, BandCollaboration
 
 
 def get_services():

--- a/backend/tests/analytics/test_analytics.py
+++ b/backend/tests/analytics/test_analytics.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException, Request
 from utils.db import get_conn
 
 from auth.dependencies import get_current_user_id, require_permission
-from backend.services.analytics_service import SERVICE_LATENCY_MS, AnalyticsService
+from services.analytics_service import SERVICE_LATENCY_MS, AnalyticsService
 from backend.utils.metrics import generate_latest
 
 DDL = """

--- a/backend/tests/analytics/test_fan_insights.py
+++ b/backend/tests/analytics/test_fan_insights.py
@@ -1,7 +1,7 @@
 import utils.db as db_utils
 from utils.db import get_conn
 
-from backend.services.fan_insight_service import FanInsightService
+from services.fan_insight_service import FanInsightService
 
 DDL = """
 CREATE TABLE users(id INTEGER PRIMARY KEY, age INTEGER, region TEXT);

--- a/backend/tests/analytics/test_seasonal_scores.py
+++ b/backend/tests/analytics/test_seasonal_scores.py
@@ -3,7 +3,7 @@ import sqlite3
 import pytest
 
 from backend.jobs.world_pulse_jobs import run_daily
-from backend.services.season_service import activate_season
+from services.season_service import activate_season
 
 DDL = """
 PRAGMA foreign_keys = ON;

--- a/backend/tests/avatar/test_skin_marketplace.py
+++ b/backend/tests/avatar/test_skin_marketplace.py
@@ -1,5 +1,5 @@
-from backend.services.avatar_service import AvatarService
-from backend.services.skin_service import SkinService, engine
+from services.avatar_service import AvatarService
+from services.skin_service import SkinService, engine
 from models.avatar import Avatar
 from models.skin import Skin
 from models.avatar_skin import AvatarSkin

--- a/backend/tests/avatars/test_avatar_service.py
+++ b/backend/tests/avatars/test_avatar_service.py
@@ -7,7 +7,7 @@ import pytest
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from schemas.avatar import AvatarCreate, AvatarUpdate
-from backend.services.avatar_service import AvatarService
+from services.avatar_service import AvatarService
 
 
 def get_service():

--- a/backend/tests/bands/test_band_service.py
+++ b/backend/tests/bands/test_band_service.py
@@ -11,10 +11,10 @@ from sqlalchemy.orm import sessionmaker
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from schemas.avatar import AvatarCreate
-from backend.services.avatar_service import AvatarService
-from backend.services.band_service import Base, BandMember, BandService
-from backend.services.band_relationship_service import BandRelationshipService
-from backend.services.skill_service import SkillService, SONGWRITING_SKILL
+from services.avatar_service import AvatarService
+from services.band_service import Base, BandMember, BandService
+from services.band_relationship_service import BandRelationshipService
+from services.skill_service import SkillService, SONGWRITING_SKILL
 
 
 def get_service():

--- a/backend/tests/business/test_business_skills.py
+++ b/backend/tests/business/test_business_skills.py
@@ -1,10 +1,10 @@
 import sqlite3
 
-from backend.services import fan_service
-from backend.services.business_service import BusinessService
-from backend.services.business_training_service import BusinessTrainingService
-from backend.services.skill_service import skill_service
-from backend.services.social_media_training_service import SocialMediaTrainingService
+from services import fan_service
+from services.business_service import BusinessService
+from services.business_training_service import BusinessTrainingService
+from services.skill_service import skill_service
+from services.social_media_training_service import SocialMediaTrainingService
 
 
 def test_business_training_awards_xp(tmp_path):

--- a/backend/tests/chemistry/test_player_chemistry.py
+++ b/backend/tests/chemistry/test_player_chemistry.py
@@ -3,7 +3,7 @@ import random
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.services.chemistry_service import ChemistryService, Base
+from services.chemistry_service import ChemistryService, Base
 
 
 def _service():

--- a/backend/tests/city/test_city_trends.py
+++ b/backend/tests/city/test_city_trends.py
@@ -2,9 +2,9 @@ import sqlite3
 import sqlite3
 from datetime import datetime
 
-from backend.services.city_service import city_service
-from backend.services import event_service, live_performance_service, setlist_service
-from backend.services.quest_service import QuestService
+from services.city_service import city_service
+from services import event_service, live_performance_service, setlist_service
+from services.quest_service import QuestService
 from backend.models.weather import Forecast
 from backend.models.city import City
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -21,8 +21,8 @@ from backend.auth.service import AuthService
 
 try:  # pragma: no cover - optional in minimal test runs
     from routes import payment_routes
-    from backend.services.economy_service import EconomyService
-    from backend.services.payment_service import PaymentService
+    from services.economy_service import EconomyService
+    from services.payment_service import PaymentService
 except Exception:  # pragma: no cover
     payment_routes = None  # type: ignore
     EconomyService = None  # type: ignore

--- a/backend/tests/construction/test_construction_service.py
+++ b/backend/tests/construction/test_construction_service.py
@@ -7,10 +7,10 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.services.construction_service import ConstructionService
-from backend.services.economy_service import EconomyService
-from backend.services.property_service import PropertyService
-from backend.services.venue_service import VenueService
+from services.construction_service import ConstructionService
+from services.economy_service import EconomyService
+from services.property_service import PropertyService
+from services.venue_service import VenueService
 from backend.models.construction import Blueprint, BuildPhase
 
 

--- a/backend/tests/contracts/test_negotiation_flow.py
+++ b/backend/tests/contracts/test_negotiation_flow.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import pytest
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.services.contract_negotiation_service import ContractNegotiationService
-from backend.services.economy_service import EconomyService
+from services.contract_negotiation_service import ContractNegotiationService
+from services.economy_service import EconomyService
 from backend.routes import contract_routes
 from backend.models.label_management_models import NegotiationStage
 

--- a/backend/tests/crowdfunding/test_crowdfunding_service.py
+++ b/backend/tests/crowdfunding/test_crowdfunding_service.py
@@ -1,5 +1,5 @@
-from backend.services.crowdfunding_service import CrowdfundingService
-from backend.services.economy_service import EconomyService
+from services.crowdfunding_service import CrowdfundingService
+from services.economy_service import EconomyService
 
 
 def test_pledge_and_distribution(tmp_path):

--- a/backend/tests/dialogue/test_dialogue.py
+++ b/backend/tests/dialogue/test_dialogue.py
@@ -5,7 +5,7 @@ import pytest
 import backend.realtime.dialogue_gateway as dialogue_gateway
 from backend.models.dialogue import DialogueMessage
 from backend.realtime.dialogue_gateway import router as dialogue_router
-from backend.services.dialogue_service import DialogueService
+from services.dialogue_service import DialogueService
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/backend/tests/economy/test_banking.py
+++ b/backend/tests/economy/test_banking.py
@@ -7,9 +7,9 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.services.economy_service import EconomyError, EconomyService
-from backend.services.property_service import PropertyService
-from backend.services.business_service import BusinessService
+from services.economy_service import EconomyError, EconomyService
+from services.property_service import PropertyService
+from services.business_service import BusinessService
 
 
 def setup_env():

--- a/backend/tests/economy/test_economy_service.py
+++ b/backend/tests/economy/test_economy_service.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from backend.economy.models import Account, LedgerEntry
-from backend.services.economy_service import EconomyError, EconomyService
+from services.economy_service import EconomyError, EconomyService
 
 
 def setup_service():

--- a/backend/tests/economy/test_gig_ledger.py
+++ b/backend/tests/economy/test_gig_ledger.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
 from backend.economy.models import Account, LedgerEntry, Transaction as TransactionModel
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 import backend.services.gig_service as gig_service
 
 

--- a/backend/tests/economy/test_recording_cost.py
+++ b/backend/tests/economy/test_recording_cost.py
@@ -37,9 +37,9 @@ utils_pkg.db = db_module
 sys.modules["utils"] = utils_pkg
 sys.modules["utils.db"] = db_module
 
-from backend.services.economy_service import EconomyService
-from backend.services.tour_service import TourService
-from backend.services.weather_service import WeatherService
+from services.economy_service import EconomyService
+from services.tour_service import TourService
+from services.weather_service import WeatherService
 from backend.economy.models import Account, LedgerEntry
 
 

--- a/backend/tests/festival_builder/test_service.py
+++ b/backend/tests/festival_builder/test_service.py
@@ -7,7 +7,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.services.festival_builder_service import (
+from services.festival_builder_service import (
     BookingConflictError,
     FestivalBuilderService,
     FestivalError,

--- a/backend/tests/gear/test_crafting.py
+++ b/backend/tests/gear/test_crafting.py
@@ -1,4 +1,4 @@
-from backend.services.gear_service import GearService
+from services.gear_service import GearService
 from backend.models.gear import BaseItem, GearComponent, StatModifier
 
 

--- a/backend/tests/image/test_image_skills.py
+++ b/backend/tests/image/test_image_skills.py
@@ -1,8 +1,8 @@
 import sqlite3
 
-from backend.services import fan_service
-from backend.services.image_training_service import ImageTrainingService
-from backend.services.skill_service import skill_service
+from services import fan_service
+from services.image_training_service import ImageTrainingService
+from services.skill_service import skill_service
 
 
 def test_image_training_awards_xp(tmp_path):

--- a/backend/tests/integration/test_user_flows.py
+++ b/backend/tests/integration/test_user_flows.py
@@ -1,4 +1,4 @@
-from backend.services import event_service
+from services import event_service
 
 
 def test_registration_event_transaction_flow(client, db_path, monkeypatch):
@@ -20,6 +20,6 @@ def test_registration_event_transaction_flow(client, db_path, monkeypatch):
     assert r.status_code == 200
     assert r.json()["status"] == "completed"
 
-    from backend.services.economy_service import EconomyService
+    from services.economy_service import EconomyService
     econ = EconomyService(db_path)
     assert econ.get_balance(uid) > 0

--- a/backend/tests/jam_sessions/test_jam_gateway.py
+++ b/backend/tests/jam_sessions/test_jam_gateway.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 import pytest
 
 from backend.realtime.jam_gateway import jam_ws, jam_service
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 
 class FakeWebSocket:

--- a/backend/tests/jam_sessions/test_jam_service_failure.py
+++ b/backend/tests/jam_sessions/test_jam_service_failure.py
@@ -1,8 +1,8 @@
 import logging
 import pytest
 
-from backend.services.jam_service import JamService
-from backend.services.economy_service import EconomyService
+from services.jam_service import JamService
+from services.economy_service import EconomyService
 
 
 class FailingEconomy(EconomyService):

--- a/backend/tests/labels/test_contract_negotiation_service.py
+++ b/backend/tests/labels/test_contract_negotiation_service.py
@@ -6,8 +6,8 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from backend.models.label_management_models import NegotiationStage
-from backend.services.contract_negotiation_service import ContractNegotiationService
-from backend.services.economy_service import EconomyService
+from services.contract_negotiation_service import ContractNegotiationService
+from services.economy_service import EconomyService
 
 
 def setup_services():

--- a/backend/tests/legacy/test_legacy_service.py
+++ b/backend/tests/legacy/test_legacy_service.py
@@ -9,9 +9,9 @@ import sys
 if str(sys_path) not in sys.path:
     sys.path.append(str(sys_path))
 
-from backend.services.legacy_service import LegacyService
-from backend.services.economy_service import EconomyService
-from backend.services.merch_service import MerchService
+from services.legacy_service import LegacyService
+from services.economy_service import EconomyService
+from services.merch_service import MerchService
 from backend.models.merch import ProductIn, SKUIn
 
 

--- a/backend/tests/legal/test_legal_routes.py
+++ b/backend/tests/legal/test_legal_routes.py
@@ -7,9 +7,9 @@ from fastapi.testclient import TestClient
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from routes import legal_routes
-from backend.services.economy_service import EconomyService
-from backend.services.legal_service import LegalService
-from backend.services.karma_service import KarmaService
+from services.economy_service import EconomyService
+from services.legal_service import LegalService
+from services.karma_service import KarmaService
 
 
 class KarmaDB:

--- a/backend/tests/legal/test_legal_service.py
+++ b/backend/tests/legal/test_legal_service.py
@@ -7,9 +7,9 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.services.economy_service import EconomyService
-from backend.services.legal_service import LegalService
-from backend.services.karma_service import KarmaService
+from services.economy_service import EconomyService
+from services.legal_service import LegalService
+from services.karma_service import KarmaService
 
 
 class InMemoryKarmaDB:

--- a/backend/tests/lifestyle/test_resilience_effects.py
+++ b/backend/tests/lifestyle/test_resilience_effects.py
@@ -6,8 +6,8 @@ from sqlalchemy.orm import sessionmaker
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from schemas.avatar import AvatarCreate
-from backend.services.avatar_service import AvatarService
-from backend.services import lifestyle_service
+from services.avatar_service import AvatarService
+from services import lifestyle_service
 
 
 class DummySkillService:

--- a/backend/tests/live_album/test_live_album_routes.py
+++ b/backend/tests/live_album/test_live_album_routes.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi import FastAPI
 
 from backend.routes import live_album_routes
-from backend.services import audio_mixing_service
+from services import audio_mixing_service
 
 
 def _insert_performance(cur, band_id, setlist, skill_gain, perf_score, city="", venue=""):

--- a/backend/tests/live_album/test_live_album_service.py
+++ b/backend/tests/live_album/test_live_album_service.py
@@ -3,8 +3,8 @@ import sqlite3
 
 import pytest
 
-from backend.services import audio_mixing_service
-from backend.services.live_album_service import LiveAlbumService
+from services import audio_mixing_service
+from services.live_album_service import LiveAlbumService
 
 
 def _insert_performance(cur, band_id, setlist, skill_gain, city="", venue=""):

--- a/backend/tests/live_performance/test_crowd_reaction.py
+++ b/backend/tests/live_performance/test_crowd_reaction.py
@@ -1,8 +1,8 @@
 import json
 import sqlite3
 
-from backend.services import live_performance_service, live_performance_analysis, setlist_service
-from backend.services.city_service import city_service
+from services import live_performance_service, live_performance_analysis, setlist_service
+from services.city_service import city_service
 from backend.models.city import City
 
 

--- a/backend/tests/live_performance/test_setlist_structure.py
+++ b/backend/tests/live_performance/test_setlist_structure.py
@@ -1,9 +1,9 @@
 import sqlite3
 import pytest
 
-from backend.services import live_performance_service
-from backend.services import live_performance_analysis, setlist_service
-from backend.services.city_service import city_service
+from services import live_performance_service
+from services import live_performance_analysis, setlist_service
+from services.city_service import city_service
 from backend.models.city import City
 
 

--- a/backend/tests/live_performance/test_skill_multiplier.py
+++ b/backend/tests/live_performance/test_skill_multiplier.py
@@ -1,9 +1,9 @@
 import sqlite3
 
-from backend.services import live_performance_service, live_performance_analysis
-from backend.services.city_service import city_service
+from services import live_performance_service, live_performance_analysis
+from services.city_service import city_service
 from backend.models.city import City
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 from backend.models.skill import Skill
 from seeds.skill_seed import SKILL_NAME_TO_ID
 

--- a/backend/tests/merch/test_merch_service.py
+++ b/backend/tests/merch/test_merch_service.py
@@ -10,8 +10,8 @@ if str(sys_path) not in sys.path:
     sys.path.append(str(sys_path))
 
 from backend.models.merch import ProductIn, SKUIn
-from backend.services.economy_service import EconomyService
-from backend.services.merch_service import MerchError, MerchService
+from services.economy_service import EconomyService
+from services.merch_service import MerchError, MerchService
 
 
 def setup_service():

--- a/backend/tests/modding/test_marketplace.py
+++ b/backend/tests/modding/test_marketplace.py
@@ -1,7 +1,7 @@
 import sqlite3
 
-from backend.services.mod_marketplace_service import ModMarketplaceService
-from backend.services.economy_service import EconomyService
+from services.mod_marketplace_service import ModMarketplaceService
+from services.economy_service import EconomyService
 from backend.storage.local import LocalStorage
 
 

--- a/backend/tests/notifications/test_schedule_reminders.py
+++ b/backend/tests/notifications/test_schedule_reminders.py
@@ -3,9 +3,9 @@ import sqlite3
 from datetime import datetime
 
 from backend import database
-from backend.services import scheduler_service
+from services import scheduler_service
 from backend.models import notification_models
-from backend.services.notifications_service import NotificationsService
+from services.notifications_service import NotificationsService
 
 
 DDL = """

--- a/backend/tests/payment/test_payment_service.py
+++ b/backend/tests/payment/test_payment_service.py
@@ -8,8 +8,8 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.services.economy_service import EconomyService
-from backend.services.payment_service import (
+from services.economy_service import EconomyService
+from services.payment_service import (
     PaymentError,
     PaymentService,
     PayPalGateway,

--- a/backend/tests/payment/test_stripe_api_gateway.py
+++ b/backend/tests/payment/test_stripe_api_gateway.py
@@ -6,8 +6,8 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.services.economy_service import EconomyService
-from backend.services.payment_service import (
+from services.economy_service import EconomyService
+from services.payment_service import (
     PaymentError,
     PaymentService,
     StripeAPIGateway,

--- a/backend/tests/production/test_production_skills_bonus.py
+++ b/backend/tests/production/test_production_skills_bonus.py
@@ -1,5 +1,5 @@
-from backend.services.music_production_service import MusicProductionService
-from backend.services.skill_service import skill_service
+from services.music_production_service import MusicProductionService
+from services.skill_service import skill_service
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 

--- a/backend/tests/production/test_release_flow.py
+++ b/backend/tests/production/test_release_flow.py
@@ -1,4 +1,4 @@
-from backend.services.production_service import ProductionService
+from services.production_service import ProductionService
 
 
 class FakeEconomy:

--- a/backend/tests/production/test_sound_design_production.py
+++ b/backend/tests/production/test_sound_design_production.py
@@ -1,5 +1,5 @@
-from backend.services.music_production_service import MusicProductionService
-from backend.services.skill_service import skill_service
+from services.music_production_service import MusicProductionService
+from services.skill_service import skill_service
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 

--- a/backend/tests/production/test_tech_savvy_production.py
+++ b/backend/tests/production/test_tech_savvy_production.py
@@ -1,4 +1,4 @@
-from backend.services.music_production_service import MusicProductionService
+from services.music_production_service import MusicProductionService
 
 
 class DummyAvatar:

--- a/backend/tests/property/test_property_service.py
+++ b/backend/tests/property/test_property_service.py
@@ -7,8 +7,8 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.services.property_service import PropertyService
-from backend.services.economy_service import EconomyService
+from services.property_service import PropertyService
+from services.economy_service import EconomyService
 
 
 class DummyFameService:

--- a/backend/tests/quest/test_quest_logic.py
+++ b/backend/tests/quest/test_quest_logic.py
@@ -1,5 +1,5 @@
 from backend.models.quest import Quest, QuestStage, QuestReward
-from backend.services.quest_service import QuestService
+from services.quest_service import QuestService
 
 
 def sample_quest():

--- a/backend/tests/radio/test_radio_service.py
+++ b/backend/tests/radio/test_radio_service.py
@@ -2,9 +2,9 @@ import tempfile
 
 import pytest
 
-from backend.services.radio_service import RadioService
-from backend.services.economy_service import EconomyService
-from backend.services.analytics_service import AnalyticsService
+from services.radio_service import RadioService
+from services.economy_service import EconomyService
+from services.analytics_service import AnalyticsService
 
 
 def setup_services(tmp_path):

--- a/backend/tests/recording/test_session_skill_effects.py
+++ b/backend/tests/recording/test_session_skill_effects.py
@@ -1,7 +1,7 @@
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.recording_service import RecordingService
-from backend.services.skill_service import skill_service
+from services.recording_service import RecordingService
+from services.skill_service import skill_service
 
 
 def _set_skills(band_id: int, level: int) -> None:

--- a/backend/tests/rehearsal/test_peer_learning_service.py
+++ b/backend/tests/rehearsal/test_peer_learning_service.py
@@ -1,10 +1,10 @@
 import sqlite3
 from datetime import datetime
 
-from backend.services import scheduler_service
-from backend.services.rehearsal_service import RehearsalService
-from backend.services.peer_learning_service import peer_learning_service
-from backend.services.skill_service import skill_service
+from services import scheduler_service
+from services.rehearsal_service import RehearsalService
+from services.peer_learning_service import peer_learning_service
+from services.skill_service import skill_service
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 

--- a/backend/tests/rehearsal/test_rehearsal_service.py
+++ b/backend/tests/rehearsal/test_rehearsal_service.py
@@ -1,6 +1,6 @@
 import sqlite3
-from backend.services.rehearsal_service import RehearsalService
-from backend.services import event_service
+from services.rehearsal_service import RehearsalService
+from services import event_service
 
 
 def _setup(tmp_path):

--- a/backend/tests/routes/test_merch_routes.py
+++ b/backend/tests/routes/test_merch_routes.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from backend.services.economy_service import EconomyService
-from backend.services.merch_service import MerchService
-from backend.services.payment_service import MockGateway, PaymentService
+from services.economy_service import EconomyService
+from services.merch_service import MerchService
+from services.payment_service import MockGateway, PaymentService
 
 import auth.dependencies as auth_dep
 from typing import List

--- a/backend/tests/routes/test_payment_routes.py
+++ b/backend/tests/routes/test_payment_routes.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from routes import payment_routes
-from backend.services.economy_service import EconomyService
-from backend.services.payment_service import PaymentService
+from services.economy_service import EconomyService
+from services.payment_service import PaymentService
 
 
 def create_app(tmp_path, succeed: bool = True):

--- a/backend/tests/routes/test_skin_marketplace_routes.py
+++ b/backend/tests/routes/test_skin_marketplace_routes.py
@@ -3,11 +3,11 @@ import base64
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from backend.storage.local import LocalStorage
-from backend.services.skin_service import SkinService, engine
+from services.skin_service import SkinService, engine
 from models.skin import Skin
 from models.avatar import Base as AvatarBase
-from backend.services.payment_service import PaymentService, MockGateway
-from backend.services.economy_service import EconomyService
+from services.payment_service import PaymentService, MockGateway
+from services.economy_service import EconomyService
 from routes import skin_marketplace
 
 

--- a/backend/tests/routes/test_songwriting_routes.py
+++ b/backend/tests/routes/test_songwriting_routes.py
@@ -6,8 +6,8 @@ from fastapi import FastAPI
 Path(__file__).resolve().parents[2].joinpath("database").mkdir(exist_ok=True)
 
 from backend.routes import songwriting_routes  # noqa: E402
-from backend.services.originality_service import OriginalityService  # noqa: E402
-from backend.services.songwriting_service import SongwritingService  # noqa: E402
+from services.originality_service import OriginalityService  # noqa: E402
+from services.songwriting_service import SongwritingService  # noqa: E402
 
 
 class FakeLLM:

--- a/backend/tests/royalties/test_sponsorship_reconciliation.py
+++ b/backend/tests/royalties/test_sponsorship_reconciliation.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from backend.config import revenue
 from backend.jobs import sponsor_reconciliation_job
-from backend.services.sponsorship_service import SponsorshipService
+from services.sponsorship_service import SponsorshipService
 
 
 def _setup_db(db_path: str) -> None:

--- a/backend/tests/royalties/test_venue_sponsorship_payouts.py
+++ b/backend/tests/royalties/test_venue_sponsorship_payouts.py
@@ -1,8 +1,8 @@
 import sqlite3
 
 from backend.config import revenue
-from backend.services.jobs_royalties import RoyaltyJobsService
-from backend.services.venue_sponsorships_service import SponsorshipIn, VenueSponsorshipsService
+from services.jobs_royalties import RoyaltyJobsService
+from services.venue_sponsorships_service import SponsorshipIn, VenueSponsorshipsService
 
 
 def test_venue_sponsorship_payout(tmp_path):

--- a/backend/tests/schedule/test_percentage_plan.py
+++ b/backend/tests/schedule/test_percentage_plan.py
@@ -1,4 +1,4 @@
-from backend.services.plan_service import PlanService
+from services.plan_service import PlanService
 
 
 def test_percentage_distribution():

--- a/backend/tests/schedule/test_plan_service.py
+++ b/backend/tests/schedule/test_plan_service.py
@@ -1,4 +1,4 @@
-from backend.services.plan_service import PlanService
+from services.plan_service import PlanService
 
 
 def test_category_mapping():

--- a/backend/tests/schedule/test_recommendations.py
+++ b/backend/tests/schedule/test_recommendations.py
@@ -3,8 +3,8 @@ from fastapi.testclient import TestClient
 
 from backend.models.skill import Skill
 from backend.routes import schedule_routes
-from backend.services.plan_service import PlanService
-from backend.services.skill_service import skill_service
+from services.plan_service import PlanService
+from services.skill_service import skill_service
 
 
 def setup_function(_):

--- a/backend/tests/schedule/test_rest_validation.py
+++ b/backend/tests/schedule/test_rest_validation.py
@@ -2,7 +2,7 @@ import sqlite3
 
 import pytest
 
-from backend.services import schedule_service
+from services import schedule_service
 
 
 def _init_db(path):

--- a/backend/tests/services/test_arrangement_service.py
+++ b/backend/tests/services/test_arrangement_service.py
@@ -1,7 +1,7 @@
 from backend.models.song import Song
-from backend.services.arrangement_service import ArrangementService
-from backend.services.recording_service import RecordingService
-from backend.services.economy_service import EconomyService
+from services.arrangement_service import ArrangementService
+from services.recording_service import RecordingService
+from services.economy_service import EconomyService
 
 
 def test_arrangement_tracks_feed_recording(tmp_path):

--- a/backend/tests/services/test_band_relationship_networking.py
+++ b/backend/tests/services/test_band_relationship_networking.py
@@ -1,5 +1,5 @@
 import pytest
-from backend.services.band_relationship_service import BandRelationshipService
+from services.band_relationship_service import BandRelationshipService
 
 
 def test_high_profile_collab_requires_networking():

--- a/backend/tests/services/test_discord_service.py
+++ b/backend/tests/services/test_discord_service.py
@@ -2,7 +2,7 @@
 
 import pytest
 from core.config import settings
-from backend.services import discord_service
+from services import discord_service
 
 
 def test_send_message_posts_content(monkeypatch):

--- a/backend/tests/services/test_event_service.py
+++ b/backend/tests/services/test_event_service.py
@@ -2,11 +2,11 @@ import sqlite3
 
 import pytest
 from seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services import event_service
+from services import event_service
 
 from backend.models.event import Event, EventType
 from backend.models.skill import Skill
-from backend.services.skill_service import SkillService
+from services.skill_service import SkillService
 
 
 def test_roll_for_daily_event_trigger(monkeypatch):

--- a/backend/tests/services/test_events_service_timezone.py
+++ b/backend/tests/services/test_events_service_timezone.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from backend.services import events_service
+from services import events_service
 
 
 def test_schedule_event_stores_timezone(monkeypatch):

--- a/backend/tests/services/test_media_moderation_service.py
+++ b/backend/tests/services/test_media_moderation_service.py
@@ -2,10 +2,10 @@ import tempfile
 
 import pytest
 
-from backend.services.economy_service import EconomyService
-from backend.services.media_moderation_service import media_moderation_service
-from backend.services.skill_service import SkillService
-from backend.services.video_service import VideoService
+from services.economy_service import EconomyService
+from services.media_moderation_service import media_moderation_service
+from services.skill_service import SkillService
+from services.video_service import VideoService
 
 
 def _setup_video_service():

--- a/backend/tests/services/test_npc_ai_service.py
+++ b/backend/tests/services/test_npc_ai_service.py
@@ -1,8 +1,8 @@
 from backend.models.npc import NPC
 import services.npc_ai_service as npc_ai_module
-from backend.services.npc_ai_service import npc_ai_service
-from backend.services import event_service
-from backend.services.npc_service import NPCService
+from services.npc_ai_service import npc_ai_service
+from services import event_service
+from services.npc_service import NPCService
 
 
 def test_generate_daily_behavior(monkeypatch):

--- a/backend/tests/services/test_random_event_service.py
+++ b/backend/tests/services/test_random_event_service.py
@@ -1,4 +1,4 @@
-from backend.services.random_event_service import RandomEventService
+from services.random_event_service import RandomEventService
 
 
 class DummyDB:

--- a/backend/tests/services/test_skill_service_xp_items.py
+++ b/backend/tests/services/test_skill_service_xp_items.py
@@ -1,8 +1,8 @@
 import pytest
 from backend.models.skill import Skill
 from backend.models.xp_item import XPItem
-from backend.services.skill_service import SkillService
-from backend.services.xp_item_service import XPItemService
+from services.skill_service import SkillService
+from services.xp_item_service import XPItemService
 
 
 class DummyXPEvents:

--- a/backend/tests/services/test_song_remaster_service.py
+++ b/backend/tests/services/test_song_remaster_service.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-from backend.services.song_remaster_service import SongRemasterService
+from services.song_remaster_service import SongRemasterService
 import backend.services.song_popularity_service as sp_module
 
 

--- a/backend/tests/services/test_song_service.py
+++ b/backend/tests/services/test_song_service.py
@@ -1,6 +1,6 @@
 import pytest
 
-from backend.services.song_service import SongService
+from services.song_service import SongService
 from backend.jobs.royalty_clearing_job import run as royalty_run
 from backend.utils.db import aget_conn
 

--- a/backend/tests/services/test_xp_event_service.py
+++ b/backend/tests/services/test_xp_event_service.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import pytest
 
 from backend.models.xp_event import XPEvent
-from backend.services.xp_event_service import XPEventService
+from services.xp_event_service import XPEventService
 
 
 def test_additive_stacking(tmp_path):

--- a/backend/tests/skills/test_attribute_effects.py
+++ b/backend/tests/skills/test_attribute_effects.py
@@ -5,8 +5,8 @@ from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from backend.models.skill import Skill
 from backend.schemas.avatar import AvatarCreate
-from backend.services.avatar_service import AvatarService
-from backend.services.skill_service import SkillService
+from services.avatar_service import AvatarService
+from services.skill_service import SkillService
 
 
 def _setup_service(attr1: dict, attr2: dict) -> AvatarService:

--- a/backend/tests/skills/test_discipline_effect.py
+++ b/backend/tests/skills/test_discipline_effect.py
@@ -6,8 +6,8 @@ from models.character import Base as CharacterBase, Character
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
 from backend.schemas.avatar import AvatarCreate
-from backend.services.avatar_service import AvatarService
-from backend.services.skill_service import SkillService
+from services.avatar_service import AvatarService
+from services.skill_service import SkillService
 
 
 def _setup_avatar_service(disc1: int, disc2: int) -> AvatarService:

--- a/backend/tests/skills/test_fatigue_system.py
+++ b/backend/tests/skills/test_fatigue_system.py
@@ -8,8 +8,8 @@ from sqlalchemy.orm import sessionmaker
 from backend.models.learning_method import LearningMethod
 from backend.models.skill import Skill
 from backend.schemas.avatar import AvatarCreate, AvatarUpdate
-from backend.services.avatar_service import AvatarService
-from backend.services.skill_service import SkillService
+from services.avatar_service import AvatarService
+from services.skill_service import SkillService
 
 
 def _setup_services() -> tuple[AvatarService, SkillService]:

--- a/backend/tests/skills/test_stamina_decay.py
+++ b/backend/tests/skills/test_stamina_decay.py
@@ -7,8 +7,8 @@ from models.character import Base as CharacterBase, Character
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
 from backend.schemas.avatar import AvatarCreate
-from backend.services.avatar_service import AvatarService
-from backend.services.skill_service import SkillService
+from services.avatar_service import AvatarService
+from services.skill_service import SkillService
 
 
 def _setup_avatar_service(stamina1: int, stamina2: int) -> AvatarService:

--- a/backend/tests/social/test_fan_charisma.py
+++ b/backend/tests/social/test_fan_charisma.py
@@ -6,8 +6,8 @@ from sqlalchemy.orm import sessionmaker
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from backend.schemas.avatar import AvatarCreate
-from backend.services.avatar_service import AvatarService
-from backend.services.fan_club_service import FanClubService
+from services.avatar_service import AvatarService
+from services.fan_club_service import FanClubService
 
 
 @pytest.fixture

--- a/backend/tests/social/test_fan_clubs.py
+++ b/backend/tests/social/test_fan_clubs.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from datetime import datetime, timedelta
 
-from backend.services.fan_club_service import fan_club_service
+from services.fan_club_service import fan_club_service
 from backend.realtime.gateway import hub, _Subscriber, topic_for_user
 
 

--- a/backend/tests/social/test_fan_service_charisma.py
+++ b/backend/tests/social/test_fan_service_charisma.py
@@ -5,8 +5,8 @@ from sqlalchemy.orm import sessionmaker
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from backend.schemas.avatar import AvatarCreate
-from backend.services.avatar_service import AvatarService
-from backend.services import fan_service
+from services.avatar_service import AvatarService
+from services import fan_service
 
 
 def _setup_avatar(charisma: int) -> AvatarService:

--- a/backend/tests/social/test_friendships.py
+++ b/backend/tests/social/test_friendships.py
@@ -1,7 +1,7 @@
 import asyncio
 import sqlite3
 
-from backend.services.social_service import social_service
+from services.social_service import social_service
 from backend.realtime import social_gateway
 
 

--- a/backend/tests/social/test_social_media_boosts.py
+++ b/backend/tests/social/test_social_media_boosts.py
@@ -1,7 +1,7 @@
 import sqlite3
 
-from backend.services.stream_service import StreamService
-from backend.services import fan_service
+from services.stream_service import StreamService
+from services import fan_service
 
 
 class DummyDB:

--- a/backend/tests/songwriting/test_songwriting_service.py
+++ b/backend/tests/songwriting/test_songwriting_service.py
@@ -7,14 +7,14 @@ from sqlalchemy.orm import sessionmaker
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from schemas.avatar import AvatarCreate
-from backend.services.avatar_service import AvatarService
+from services.avatar_service import AvatarService
 
 Path(__file__).resolve().parents[2].joinpath("database").mkdir(exist_ok=True)
 
-from backend.services.band_service import BandService, Base  # noqa: E402
-from backend.services.originality_service import OriginalityService  # noqa: E402
-from backend.services.skill_service import SONGWRITING_SKILL, SkillService  # noqa: E402
-from backend.services.songwriting_service import SongwritingService  # noqa: E402
+from services.band_service import BandService, Base  # noqa: E402
+from services.originality_service import OriginalityService  # noqa: E402
+from services.skill_service import SONGWRITING_SKILL, SkillService  # noqa: E402
+from services.songwriting_service import SongwritingService  # noqa: E402
 
 
 class FakeLLM:

--- a/backend/tests/test_dashboard_summary_smoke.py
+++ b/backend/tests/test_dashboard_summary_smoke.py
@@ -1,5 +1,5 @@
 # File: backend/tests/test_dashboard_summary_smoke.py
-from backend.services.dashboard_service import DashboardService
+from services.dashboard_service import DashboardService
 
 from utils.db import get_conn
 

--- a/backend/tests/test_drug_transactions.py
+++ b/backend/tests/test_drug_transactions.py
@@ -2,13 +2,13 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from routes import shop_routes
-from backend.services.item_service import ItemService
-from backend.services.city_shop_service import CityShopService
-from backend.services.loyalty_service import LoyaltyService
-from backend.services.membership_service import MembershipService
-from backend.services.shop_npc_service import ShopNPCService
-from backend.services.npc_service import NPCService
-from backend.services.economy_service import EconomyService
+from services.item_service import ItemService
+from services.city_shop_service import CityShopService
+from services.loyalty_service import LoyaltyService
+from services.membership_service import MembershipService
+from services.shop_npc_service import ShopNPCService
+from services.npc_service import NPCService
+from services.economy_service import EconomyService
 from models.item import ItemCategory
 from models.drug import Drug
 
@@ -31,7 +31,7 @@ def create_app(tmp_path):
     shop_routes.shop_npc_service = npc_shop
     shop_routes._economy = economy
     # ensure city shop service uses the test item service
-    from backend.services import city_shop_service as city_module
+    from services import city_shop_service as city_module
 
     city_module.item_service = item_svc
     city_module._economy = economy

--- a/backend/tests/test_luck_bonus.py
+++ b/backend/tests/test_luck_bonus.py
@@ -1,6 +1,6 @@
 import random
 
-from backend.services.random_event_service import RandomEventService
+from services.random_event_service import RandomEventService
 
 
 def run_trials(service, luck: int, iterations: int = 1000) -> int:

--- a/backend/tests/test_mail_smoke.py
+++ b/backend/tests/test_mail_smoke.py
@@ -1,8 +1,8 @@
 # File: backend/tests/test_mail_smoke.py
 import pytest
 from utils.db import aget_conn
-from backend.services.mail_service import MailService
-from backend.services.notifications_service import NotificationsService
+from services.mail_service import MailService
+from services.notifications_service import NotificationsService
 
 MAIL_DDL = """
 CREATE TABLE IF NOT EXISTS mail_threads (

--- a/backend/tests/test_media_monitor.py
+++ b/backend/tests/test_media_monitor.py
@@ -1,9 +1,9 @@
 import sqlite3
 
 from backend.database import DB_PATH
-from backend.services.media_monitor_service import MediaMonitorService
+from services.media_monitor_service import MediaMonitorService
 import backend.services.song_popularity_service as sp_module
-from backend.services.song_popularity_service import song_popularity_service
+from services.song_popularity_service import song_popularity_service
 
 
 def _reset_db():

--- a/backend/tests/test_metrics_smoke.py
+++ b/backend/tests/test_metrics_smoke.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 from backend.api import app
 from backend.realtime.gateway import hub
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 
 def test_metrics_endpoint_exposes_counters(tmp_path):

--- a/backend/tests/test_recording_service.py
+++ b/backend/tests/test_recording_service.py
@@ -1,6 +1,6 @@
 import pytest
 
-from backend.services.recording_service import RecordingService
+from services.recording_service import RecordingService
 
 
 class DummyEconomy:

--- a/backend/tests/test_social_sentiment.py
+++ b/backend/tests/test_social_sentiment.py
@@ -1,8 +1,8 @@
 import sqlite3
 
 from backend.database import DB_PATH
-from backend.services.social_sentiment_service import SocialSentimentService
-from backend.services.song_popularity_service import get_current_popularity
+from services.social_sentiment_service import SocialSentimentService
+from services.song_popularity_service import get_current_popularity
 
 
 def _reset_db():

--- a/backend/tests/test_song_popularity.py
+++ b/backend/tests/test_song_popularity.py
@@ -8,8 +8,8 @@ except Exception:  # pragma: no cover
     FastAPI = None  # type: ignore
 
 from backend.database import DB_PATH
-from backend.services import song_popularity_service
-from backend.services.song_popularity_service import (
+from services import song_popularity_service
+from services.song_popularity_service import (
     HALF_LIFE_DAYS,
     add_event,
     apply_decay,
@@ -73,7 +73,7 @@ def test_forecast_generation():
     _reset_db()
     add_event(4, 10, "stream")
     add_event(4, 5, "sale")
-    from backend.services.song_popularity_forecast import forecast_service
+    from services.song_popularity_forecast import forecast_service
 
     forecasts = forecast_service.forecast_song(4, days=3)
     assert len(forecasts) == 3

--- a/backend/tests/test_songwriting_ws.py
+++ b/backend/tests/test_songwriting_ws.py
@@ -7,8 +7,8 @@ from fastapi import FastAPI
 Path(__file__).resolve().parents[1].joinpath("database").mkdir(exist_ok=True)
 
 from backend.routes import songwriting_routes  # noqa: E402
-from backend.services.originality_service import OriginalityService  # noqa: E402
-from backend.services.songwriting_service import SongwritingService  # noqa: E402
+from services.originality_service import OriginalityService  # noqa: E402
+from services.songwriting_service import SongwritingService  # noqa: E402
 
 
 class FakeLLM:

--- a/backend/tests/test_support_service.py
+++ b/backend/tests/test_support_service.py
@@ -1,5 +1,5 @@
 import pytest
-from backend.services.support_service import SupportService, SupportServiceError
+from services.support_service import SupportService, SupportServiceError
 from utils.db import get_conn
 
 

--- a/backend/tests/test_tour_service_error_handling.py
+++ b/backend/tests/test_tour_service_error_handling.py
@@ -24,8 +24,8 @@ core_errors.VenueConflictError = VenueConflictError
 core_errors.TourMinStopsError = TourMinStopsError
 sys.modules["core.errors"] = core_errors
 
-from backend.services.economy_service import EconomyService  # noqa: E402
-from backend.services.tour_service import TourService  # noqa: E402
+from services.economy_service import EconomyService  # noqa: E402
+from services.tour_service import TourService  # noqa: E402
 
 
 class BoomEconomy(EconomyService):

--- a/backend/tests/test_venue_overlap_smoke.py
+++ b/backend/tests/test_venue_overlap_smoke.py
@@ -1,7 +1,7 @@
 # File: backend/tests/test_venue_overlap_smoke.py
 import pytest
 from utils.db import get_conn
-from backend.services.tour_service import TourService, TourError
+from services.tour_service import TourService, TourError
 
 DDL = """
 CREATE TABLE IF NOT EXISTS venues (

--- a/backend/tests/tour/test_tour.py
+++ b/backend/tests/tour/test_tour.py
@@ -36,9 +36,9 @@ core_errors.TourMinStopsError = TourMinStopsError
 sys.modules["core.errors"] = core_errors
 
 from backend.routes.tour_routes import router
-from backend.services.tour_service import TourService
-from backend.services.weather_service import WeatherService
-from backend.services.economy_service import EconomyService
+from services.tour_service import TourService
+from services.weather_service import WeatherService
+from services.economy_service import EconomyService
 from backend.models.tour import TicketTier, Expense
 from backend.models.economy_config import set_config, EconomyConfig
 import importlib

--- a/backend/tests/tournament/test_tournament_service.py
+++ b/backend/tests/tournament/test_tournament_service.py
@@ -10,7 +10,7 @@ import sys
 if str(sys_path) not in sys.path:
     sys.path.append(str(sys_path))
 
-from backend.services.tournament_service import TournamentService
+from services.tournament_service import TournamentService
 
 
 class DummyPerformance:

--- a/backend/tests/video/test_video_routes.py
+++ b/backend/tests/video/test_video_routes.py
@@ -4,9 +4,9 @@ import tempfile
 from fastapi import HTTPException
 import tempfile
 from routes import video_routes
-from backend.services.economy_service import EconomyService
-from backend.services.skill_service import SkillService
-from backend.services.video_service import VideoService
+from services.economy_service import EconomyService
+from services.skill_service import SkillService
+from services.video_service import VideoService
 
 
 async def _require_permission_stub(roles, user_id):

--- a/backend/tests/video/test_video_service.py
+++ b/backend/tests/video/test_video_service.py
@@ -1,8 +1,8 @@
 import tempfile
 
-from backend.services.economy_service import EconomyService
-from backend.services.skill_service import SkillService
-from backend.services.video_service import SERVICE_LATENCY_MS, VideoService, XP_PER_VIEW
+from services.economy_service import EconomyService
+from services.skill_service import SkillService
+from services.video_service import SERVICE_LATENCY_MS, VideoService, XP_PER_VIEW
 from seeds.skill_seed import SEED_SKILLS
 CONTENT_CREATION_SKILL = next(s for s in SEED_SKILLS if s.name == "content_creation")
 

--- a/backend/tests/weather/test_weather_service.py
+++ b/backend/tests/weather/test_weather_service.py
@@ -7,10 +7,10 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from backend.models.weather import ClimateZone, Forecast, WeatherEvent
-from backend.services import event_service
-from backend.services.economy_service import EconomyService
-from backend.services.property_service import PropertyService
-from backend.services.weather_service import WeatherService, weather_service
+from services import event_service
+from services.economy_service import EconomyService
+from services.property_service import PropertyService
+from services.weather_service import WeatherService, weather_service
 
 
 def test_forecast_generates_event(monkeypatch):

--- a/backend/utils/auth_utils.py
+++ b/backend/utils/auth_utils.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from core.config import settings
 
 from backend.auth.jwt import encode
-from backend.services.auth_service import get_user_by_username, verify_password
+from services.auth_service import get_user_by_username, verify_password
 
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.auth.access_token_ttl_min
 

--- a/jobs/cleanup_event_effects.py
+++ b/jobs/cleanup_event_effects.py
@@ -1,6 +1,6 @@
 """Clear expired event effects from the database."""
 
-from backend.services.event_service import clear_expired_events
+from services.event_service import clear_expired_events
 
 
 def run() -> tuple[int, str]:

--- a/jobs/lifestyle_jobs.py
+++ b/jobs/lifestyle_jobs.py
@@ -1,6 +1,6 @@
 """Scheduler job for daily lifestyle decay and XP rewards."""
 
-from backend.services.lifestyle_scheduler import apply_lifestyle_decay_and_xp_effects
+from services.lifestyle_scheduler import apply_lifestyle_decay_and_xp_effects
 
 
 def run() -> tuple[int, str]:

--- a/jobs/random_events.py
+++ b/jobs/random_events.py
@@ -1,5 +1,5 @@
 """Scheduler job to trigger random events."""
-from backend.services.random_event_service import random_event_service
+from services.random_event_service import random_event_service
 
 
 def run() -> tuple[int, str]:

--- a/jobs/sponsor_reconciliation_job.py
+++ b/jobs/sponsor_reconciliation_job.py
@@ -6,8 +6,8 @@ import asyncio
 import sqlite3
 from typing import Any, Dict
 
-from backend.services.jobs_royalties import RoyaltyJobsService
-from backend.services.sponsorship_service import SponsorshipService
+from services.jobs_royalties import RoyaltyJobsService
+from services.sponsorship_service import SponsorshipService
 from backend.utils.metrics import Counter
 
 RECONCILIATION_JOB_FAILURES = Counter(

--- a/jobs/world_pulse_jobs.py
+++ b/jobs/world_pulse_jobs.py
@@ -10,7 +10,7 @@ import os
 from datetime import date, datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
-from backend.services.season_service import SeasonScheduler
+from services.season_service import SeasonScheduler
 
 try:
     # Preferred: shared project connection helper

--- a/live3d/engine.py
+++ b/live3d/engine.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
 
-from backend.services import gig_service
+from services import gig_service
 
 
 class PerformanceRenderer:

--- a/models/daily_loop.py
+++ b/models/daily_loop.py
@@ -4,7 +4,7 @@ from datetime import date, timedelta
 from typing import Dict, Optional
 
 from backend.database import DB_PATH
-from backend.services.xp_reward_service import xp_reward_service
+from services.xp_reward_service import xp_reward_service
 from backend.models import weekly_drop, tier_track
 
 CHALLENGES = [

--- a/models/event_routes.py
+++ b/models/event_routes.py
@@ -1,7 +1,7 @@
 # routes/event_routes.py
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.event_service import apply_event_effect, roll_for_daily_event
+from services.event_service import apply_event_effect, roll_for_daily_event
 
 from fastapi import APIRouter
 

--- a/realtime/dialogue_gateway.py
+++ b/realtime/dialogue_gateway.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from backend.models.dialogue import DialogueMessage
 from backend.realtime.gateway import get_current_user_id_dep
 from backend.monitoring.websocket import track_connect, track_disconnect, track_message
-from backend.services.dialogue_service import DialogueService
+from services.dialogue_service import DialogueService
 
 router = APIRouter(prefix="/dialogue", tags=["dialogue"])
 

--- a/realtime/jam_gateway.py
+++ b/realtime/jam_gateway.py
@@ -11,7 +11,7 @@ try:  # pragma: no cover - explicit failure if FastAPI missing
 except ModuleNotFoundError as exc:  # pragma: no cover - FastAPI required
     raise ImportError("FastAPI must be installed to use backend.realtime.jam_gateway") from exc
 
-from backend.services.jam_service import JamService
+from services.jam_service import JamService
 from .gateway import get_current_user_id_dep
 from backend.monitoring.websocket import track_connect, track_disconnect, track_message
 

--- a/services/ai_art_service.py
+++ b/services/ai_art_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import List
 
-from backend.services.storage_service import get_storage_backend
+from services.storage_service import get_storage_backend
 
 
 class AIArtService:

--- a/services/album_service.py
+++ b/services/album_service.py
@@ -15,7 +15,7 @@ from typing import Callable, Iterable
 
 from models.music import Base as MusicBase  # noqa: F401
 from models.music import Release, Track
-from backend.services.band_service import (  # noqa: F401
+from services.band_service import (  # noqa: F401
     BandCollaboration,
     BandService,
 )

--- a/services/apprenticeship_service.py
+++ b/services/apprenticeship_service.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from backend.database import DB_PATH
 from backend.models.apprenticeship import Apprenticeship
-from backend.services.karma_service import KarmaService
+from services.karma_service import KarmaService
 
 
 class ApprenticeshipService:

--- a/services/arrangement_service.py
+++ b/services/arrangement_service.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 from backend.models.arrangement import ArrangementTrack
 from backend.models.song import Song
-from backend.services.recording_service import RecordingService, recording_service
+from services.recording_service import RecordingService, recording_service
 
 
 class ArrangementService:

--- a/services/attribute_service.py
+++ b/services/attribute_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Tuple
 
 from backend.models.attribute import Attribute
-from backend.services.perk_service import perk_service
+from services.perk_service import perk_service
 
 
 class AttributeService:

--- a/services/audio_mixing_service.py
+++ b/services/audio_mixing_service.py
@@ -4,7 +4,7 @@ from typing import List
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 
 
 def mix_tracks(performance_ids: List[int], user_id: int | None = None) -> List[int]:

--- a/services/band_service.py
+++ b/services/band_service.py
@@ -15,10 +15,10 @@ from typing import Callable, Optional
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, create_engine, func
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
-from backend.services.chemistry_service import ChemistryService
-from backend.services.band_relationship_service import BandRelationshipService
-from backend.services.avatar_service import AvatarService
-from backend.services.skill_service import SkillService
+from services.chemistry_service import ChemistryService
+from services.band_relationship_service import BandRelationshipService
+from services.avatar_service import AvatarService
+from services.skill_service import SkillService
 from backend.models.skill import Skill
 
 # ---------------------------------------------------------------------------

--- a/services/books_service.py
+++ b/services/books_service.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 from backend.models.book import Book
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 
 
 class BooksService:
@@ -69,7 +69,7 @@ class BooksService:
             "hours": hours,
         }
 
-        from backend.services.scheduler_service import schedule_task
+        from services.scheduler_service import schedule_task
 
         return schedule_task("complete_reading", params, run_at.isoformat())
 

--- a/services/business_service.py
+++ b/services/business_service.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 
 from .economy_service import EconomyError, EconomyService
 

--- a/services/business_training_service.py
+++ b/services/business_training_service.py
@@ -4,8 +4,8 @@ from typing import Dict
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import SkillService
-from backend.services.skill_service import skill_service as default_skill_service
+from services.skill_service import SkillService
+from services.skill_service import skill_service as default_skill_service
 
 
 class BusinessTrainingService:

--- a/services/calendar_export.py
+++ b/services/calendar_export.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-from backend.services.schedule_service import schedule_service
+from services.schedule_service import schedule_service
 
 
 def daily_schedule_to_ics(user_id: int, date: str) -> str:

--- a/services/chart_service.py
+++ b/services/chart_service.py
@@ -1,8 +1,8 @@
 import sqlite3
 from datetime import datetime, timedelta
 
-from backend.services.achievement_service import AchievementService
-from backend.services.legacy_service import LegacyService
+from services.achievement_service import AchievementService
+from services.legacy_service import LegacyService
 
 from backend.database import DB_PATH
 

--- a/services/city_shop_service.py
+++ b/services/city_shop_service.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from datetime import datetime
 
-from backend.services.item_service import item_service
-from backend.services.books_service import books_service
-from backend.services.economy_service import EconomyService
+from services.item_service import item_service
+from services.books_service import books_service
+from services.economy_service import EconomyService
 
 from .economy_service import EconomyService, EconomyError
 from .item_service import item_service

--- a/services/contract_negotiation_service.py
+++ b/services/contract_negotiation_service.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 from backend.models.label_management_models import NegotiationStage
 from backend.models.record_contract import RecordContract, RoyaltyTier
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 Base = declarative_base()
 

--- a/services/cover_service.py
+++ b/services/cover_service.py
@@ -1,7 +1,7 @@
 """Service for handling song covers by other artists."""
 
-from backend.services.song_popularity_service import add_event
-from backend.services.song_service import SongService
+from services.song_popularity_service import add_event
+from services.song_service import SongService
 
 song_service = SongService()
 

--- a/services/crafting_service.py
+++ b/services/crafting_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, asdict
 from typing import Dict, List
 
-from backend.services.item_service import item_service
+from services.item_service import item_service
 
 
 @dataclass

--- a/services/crowdfunding_service.py
+++ b/services/crowdfunding_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from pathlib import Path
 from typing import Optional
 
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/dialogue_service.py
+++ b/services/dialogue_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import List, Optional, Protocol
 
 from backend.models.dialogue import DialogueMessage
-from backend.services.moderation_service import moderate_content
+from services.moderation_service import moderate_content
 
 
 class LLMProvider(Protocol):

--- a/services/economy_admin_service.py
+++ b/services/economy_admin_service.py
@@ -11,7 +11,7 @@ from backend.models.economy_config import (
     set_config,
     save_config,
 )
-from backend.services.economy_service import EconomyService, TransactionRecord
+from services.economy_service import EconomyService, TransactionRecord
 
 
 class EconomyAdminService:

--- a/services/economy_service.py
+++ b/services/economy_service.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from backend.services.xp_reward_service import xp_reward_service
+from services.xp_reward_service import xp_reward_service
 
 from backend.models.banking import Loan
 from backend.models.economy_config import get_config

--- a/services/fan_club_service.py
+++ b/services/fan_club_service.py
@@ -8,7 +8,7 @@ from backend.realtime.publish import (
     publish_fan_club_event_invite,
     publish_fan_club_post,
 )
-from backend.services.avatar_service import AvatarService
+from services.avatar_service import AvatarService
 
 
 @dataclass

--- a/services/fan_interaction_service.py
+++ b/services/fan_interaction_service.py
@@ -1,8 +1,8 @@
 import sqlite3
 from datetime import datetime
 from backend.database import DB_PATH
-from backend.services import fan_service
-from backend.services.skill_service import skill_service
+from services import fan_service
+from services.skill_service import skill_service
 from backend.seeds.skill_seed import SEED_SKILLS
 
 FASHION_SKILL = next(s for s in SEED_SKILLS if s.name == "fashion")

--- a/services/fan_service.py
+++ b/services/fan_service.py
@@ -3,8 +3,8 @@ import sqlite3
 from backend.database import DB_PATH
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.avatar_service import AvatarService
-from backend.services.skill_service import skill_service
+from services.avatar_service import AvatarService
+from services.skill_service import skill_service
 
 avatar_service = AvatarService()
 

--- a/services/festival_builder_service.py
+++ b/services/festival_builder_service.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from backend.services.economy_service import EconomyService
-from backend.services.legacy_service import LegacyService
+from services.economy_service import EconomyService
+from services.legacy_service import LegacyService
 
 from backend.models.festival import FestivalProposal
 from backend.models.festival_builder import (

--- a/services/gifting_service.py
+++ b/services/gifting_service.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.services.xp_reward_service import xp_reward_service
+from services.xp_reward_service import xp_reward_service
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/gig_service.py
+++ b/services/gig_service.py
@@ -3,14 +3,14 @@ import random
 from datetime import datetime, timedelta
 
 from backend.database import DB_PATH
-from backend.services import fan_service
-from backend.services.skill_service import skill_service
+from services import fan_service
+from services.skill_service import skill_service
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 try:  # pragma: no cover - optional in minimal environments
-    from backend.services.band_service import BandService
+    from services.band_service import BandService
 except Exception:  # pragma: no cover
     class BandService:  # type: ignore
         def get_band_info(self, _band_id: int):
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover
             return None
 
 try:  # pragma: no cover - optional avatar dependency
-    from backend.services.avatar_service import AvatarService
+    from services.avatar_service import AvatarService
     from backend.schemas.avatar import AvatarUpdate
 except Exception:  # pragma: no cover
     class AvatarUpdate:  # type: ignore

--- a/services/image_training_service.py
+++ b/services/image_training_service.py
@@ -6,8 +6,8 @@ from typing import Dict
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import SkillService
-from backend.services.skill_service import skill_service as default_skill_service
+from services.skill_service import SkillService
+from services.skill_service import skill_service as default_skill_service
 
 
 class ImageTrainingService:

--- a/services/indie_release_service.py
+++ b/services/indie_release_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from backend.models.label_management_models import ClauseTemplate
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 
 @dataclass

--- a/services/jam_service.py
+++ b/services/jam_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Dict, Optional, Set
 
 from backend.models.jam_session import AudioStream, JamSession
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 STUDIO_RENTAL_CENTS = 100
 PREMIUM_STREAM_CENTS = 25

--- a/services/karma_service.py
+++ b/services/karma_service.py
@@ -2,8 +2,8 @@
 from datetime import datetime
 
 from models.karma_event import KarmaEvent
-from backend.services.karma_db import KarmaDB
-from backend.services.xp_reward_service import xp_reward_service
+from services.karma_db import KarmaDB
+from services.xp_reward_service import xp_reward_service
 
 
 class KarmaService:

--- a/services/legal_service.py
+++ b/services/legal_service.py
@@ -5,8 +5,8 @@ from typing import Dict, Optional, Protocol
 
 from datetime import datetime
 
-from backend.services.economy_service import EconomyService, EconomyError
-from backend.services.karma_service import KarmaService
+from services.economy_service import EconomyService, EconomyError
+from services.karma_service import KarmaService
 from models.legal import LegalCase, Filing, Verdict
 
 

--- a/services/live_album_service.py
+++ b/services/live_album_service.py
@@ -12,9 +12,9 @@ from typing import Dict, List
 from models.album import Album
 
 from backend.database import DB_PATH
-from backend.services import audio_mixing_service, chart_service
-from backend.services.ai_art_service import ai_art_service
-from backend.services.sales_service import SalesService
+from services import audio_mixing_service, chart_service
+from services.ai_art_service import ai_art_service
+from services.sales_service import SalesService
 
 
 class LiveAlbumService:

--- a/services/live_performance_service.py
+++ b/services/live_performance_service.py
@@ -5,13 +5,13 @@ from datetime import datetime
 from typing import Dict, Generator, Iterable, Optional
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 from backend.models.skill import Skill
 
 from backend.database import DB_PATH
-from backend.services import live_performance_analysis
+from services import live_performance_analysis
 try:
-    from backend.services.chemistry_service import ChemistryService
+    from services.chemistry_service import ChemistryService
 except Exception:  # pragma: no cover - fallback if DB unavailable
     class ChemistryService:  # type: ignore
         def initialize_pair(self, a, b):
@@ -19,10 +19,10 @@ except Exception:  # pragma: no cover - fallback if DB unavailable
 
         def adjust_pair(self, a, b, delta):  # noqa: D401 - simple stub
             return type("P", (), {"score": 50})()
-from backend.services.city_service import city_service
-from backend.services.event_service import is_skill_blocked
-from backend.services.gear_service import gear_service
-from backend.services.setlist_service import get_approved_setlist
+from services.city_service import city_service
+from services.event_service import is_skill_blocked
+from services.gear_service import gear_service
+from services.setlist_service import get_approved_setlist
 
 try:
     from backend.realtime.polling import poll_hub

--- a/services/mail_service.py
+++ b/services/mail_service.py
@@ -6,8 +6,8 @@ import time
 import uuid
 from typing import Dict, List, Optional
 
-from backend.services.notifications_service import NotificationsService
-from backend.services.storage_service import get_storage_backend
+from services.notifications_service import NotificationsService
+from services.storage_service import get_storage_backend
 from utils.db import get_conn
 
 

--- a/services/marketplace_service.py
+++ b/services/marketplace_service.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from backend.services.economy_service import EconomyService, EconomyError
+from services.economy_service import EconomyService, EconomyError
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/media_event_service.py
+++ b/services/media_event_service.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from backend.services.song_popularity_service import SongPopularityService, song_popularity_service
+from services.song_popularity_service import SongPopularityService, song_popularity_service
 
 
 class MediaEventService:

--- a/services/media_moderation_service.py
+++ b/services/media_moderation_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, List, Optional
 
-from backend.services.moderation_service import (
+from services.moderation_service import (
     BANNED_WORDS as TEXT_BANNED_WORDS,
     moderate_content,
 )

--- a/services/media_monitor_service.py
+++ b/services/media_monitor_service.py
@@ -1,7 +1,7 @@
 import re
 from typing import Callable, Dict, List
 
-from backend.services.song_popularity_service import song_popularity_service
+from services.song_popularity_service import song_popularity_service
 
 
 class MediaMonitorService:

--- a/services/media_service.py
+++ b/services/media_service.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 
 from models.influencer_models import Collaboration, CollaborationStatus
 
-from backend.services.song_popularity_service import add_event
+from services.song_popularity_service import add_event
 
 
 def record_media_placement(song_id: int, placement_type: str) -> None:

--- a/services/merch_service.py
+++ b/services/merch_service.py
@@ -4,9 +4,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from backend.models.merch import CartItem, ProductIn, SKUIn
-from backend.services.economy_service import EconomyError, EconomyService
-from backend.services.payment_service import PaymentError, PaymentService
-from backend.services.legacy_service import LegacyService
+from services.economy_service import EconomyError, EconomyService
+from services.payment_service import PaymentError, PaymentService
+from services.legacy_service import LegacyService
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/mod_marketplace_service.py
+++ b/services/mod_marketplace_service.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Dict, List, Optional
 from uuid import uuid4
 
-from backend.services.economy_service import EconomyService
-from backend.services.storage_service import get_storage_backend
+from services.economy_service import EconomyService
+from services.storage_service import get_storage_backend
 from backend.storage.base import StorageBackend
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"

--- a/services/music_production_service.py
+++ b/services/music_production_service.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.avatar_service import AvatarService
+from services.avatar_service import AvatarService
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 
 
 class MusicProductionService:

--- a/services/npc_band_service.py
+++ b/services/npc_band_service.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 import random
 
 try:  # pragma: no cover - import path shim
-    from backend.services.world_pulse_service import get_current_season
+    from services.world_pulse_service import get_current_season
 except Exception:  # pragma: no cover
-    from backend.services.world_pulse_service import get_current_season
+    from services.world_pulse_service import get_current_season
 
 class NPCBandService:
     def __init__(self, db):

--- a/services/payment_service.py
+++ b/services/payment_service.py
@@ -11,7 +11,7 @@ from typing import Dict, Optional
 from uuid import uuid4
 
 from backend.models.payment import PremiumCurrency, PurchaseRecord, SubscriptionPlan
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 
 class PaymentError(Exception):

--- a/services/peer_learning_service.py
+++ b/services/peer_learning_service.py
@@ -6,7 +6,7 @@ from typing import Iterable, List
 
 from backend.database import DB_PATH
 from backend.models.skill import Skill
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 PERFORMANCE_SKILL = Skill(
@@ -51,7 +51,7 @@ class PeerLearningService:
     # ------------------------------------------------------------------
     def schedule_session(self, band_id: int, members: Iterable[int], run_at: str) -> dict:
         """Schedule a peer learning session via the scheduler service."""
-        from backend.services.scheduler_service import schedule_task
+        from services.scheduler_service import schedule_task
 
         member_list = list(members)
         try:

--- a/services/plan_service.py
+++ b/services/plan_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List
 
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 
 # Default mapping of category -> list of activity names.
 CATEGORY_MAP: Dict[str, List[str]] = {

--- a/services/quest_service.py
+++ b/services/quest_service.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import Dict
 
 from backend.models.quest import Quest, QuestReward, QuestStage
-from backend.services.city_service import city_service
-from backend.services.quest_admin_service import QuestAdminService
-from backend.services.xp_event_service import XPEventService
+from services.city_service import city_service
+from services.quest_admin_service import QuestAdminService
+from services.xp_event_service import XPEventService
 
 
 class QuestService:

--- a/services/radio_service.py
+++ b/services/radio_service.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import Optional
 
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 AD_REVENUE_CENTS = 1  # revenue per listener

--- a/services/random_event_service.py
+++ b/services/random_event_service.py
@@ -5,9 +5,9 @@ from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.models.random_event import RandomEvent
 from backend.models.random_events import ADDICTION_EVENTS
 from backend.models.skill import Skill
-from backend.services.addiction_service import addiction_service
-from backend.services.notifications_service import NotificationsService
-from backend.services.skill_service import skill_service
+from services.addiction_service import addiction_service
+from services.notifications_service import NotificationsService
+from services.skill_service import skill_service
 
 
 class RandomEventService:

--- a/services/recording_service.py
+++ b/services/recording_service.py
@@ -6,9 +6,9 @@ from backend.models.learning_method import LearningMethod
 from backend.models.recording_session import RecordingSession
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.chemistry_service import ChemistryService
-from backend.services.economy_service import EconomyError, EconomyService
-from backend.services.skill_service import skill_service
+from services.chemistry_service import ChemistryService
+from services.economy_service import EconomyError, EconomyService
+from services.skill_service import skill_service
 
 
 class RecordingService:

--- a/services/rehearsal_service.py
+++ b/services/rehearsal_service.py
@@ -14,9 +14,9 @@ from typing import Iterable, List, Optional
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
-from backend.services.event_service import is_skill_blocked
-from backend.services.gear_service import gear_service
-from backend.services.peer_learning_service import peer_learning_service
+from services.event_service import is_skill_blocked
+from services.gear_service import gear_service
+from services.peer_learning_service import peer_learning_service
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -8,17 +8,17 @@ from backend.models.notification_models import (
     alert_no_plan,
     alert_pending_outcomes,
 )
-from backend.services import chart_service, fan_service, song_popularity_service
-from backend.services.activity_processor import process_previous_day
-from backend.services.books_service import books_service
-from backend.services.event_service import end_shop_event, start_shop_event
-from backend.services.npc_service import npc_service
-from backend.services.peer_learning_service import run_scheduled_session
-from backend.services.schedule_service import schedule_service
-from backend.services.shop_restock_service import restock_handler
-from backend.services.skill_service import skill_service
-from backend.services.social_sentiment_service import social_sentiment_service
-from backend.services.song_popularity_forecast import forecast_service
+from services import chart_service, fan_service, song_popularity_service
+from services.activity_processor import process_previous_day
+from services.books_service import books_service
+from services.event_service import end_shop_event, start_shop_event
+from services.npc_service import npc_service
+from services.peer_learning_service import run_scheduled_session
+from services.schedule_service import schedule_service
+from services.shop_restock_service import restock_handler
+from services.skill_service import skill_service
+from services.social_sentiment_service import social_sentiment_service
+from services.song_popularity_forecast import forecast_service
 
 
 def _plan_reminder(user_id: int, day: str) -> dict:

--- a/services/shop_npc_service.py
+++ b/services/shop_npc_service.py
@@ -4,9 +4,9 @@ from datetime import date
 from typing import Dict, List, Optional
 
 from backend.models.npc_dialogue import DialogueNode, DialogueResponse, DialogueTree
-from backend.services.npc_service import NPCService
-from backend.services.city_shop_service import CityShopService, city_shop_service
-from backend.services.item_service import item_service as default_item_service, ItemService
+from services.npc_service import NPCService
+from services.city_shop_service import CityShopService, city_shop_service
+from services.item_service import item_service as default_item_service, ItemService
 
 
 class ShopNPCService:

--- a/services/shop_restock_service.py
+++ b/services/shop_restock_service.py
@@ -34,7 +34,7 @@ def schedule_restock(
     shop_id: int, kind: str, item_id: int, interval: int, quantity: int
 ) -> Dict[str, int]:
     """Schedule recurring restocking for a shop item or book."""
-    from backend.services.scheduler_service import schedule_task
+    from services.scheduler_service import schedule_task
 
     run_at = (datetime.utcnow() + timedelta(days=interval)).isoformat()
     return schedule_task(

--- a/services/social_media_training_service.py
+++ b/services/social_media_training_service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import SkillService
-from backend.services.skill_service import skill_service as default_skill_service
+from services.skill_service import SkillService
+from services.skill_service import skill_service as default_skill_service
 
 
 class SocialMediaTrainingService:

--- a/services/social_sentiment_service.py
+++ b/services/social_sentiment_service.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Callable, Dict, List, Optional
 
 from backend.database import DB_PATH
-from backend.services.song_popularity_service import add_event
+from services.song_popularity_service import add_event
 
 
 def _ensure_schema(cur: sqlite3.Cursor) -> None:

--- a/services/song_popularity_forecast.py
+++ b/services/song_popularity_forecast.py
@@ -132,7 +132,7 @@ forecast_service = SongPopularityForecastService()
 def _schedule_forecast_recompute() -> None:
     """Schedule nightly recomputation of all song forecasts."""
     try:  # best effort; scheduler may not be set up in all environments
-        from backend.services.scheduler_service import schedule_task
+        from services.scheduler_service import schedule_task
 
         run_at = (datetime.utcnow() + timedelta(days=1)).isoformat()
         schedule_task(

--- a/services/song_popularity_service.py
+++ b/services/song_popularity_service.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from backend.database import DB_PATH
-from backend.services.song_popularity_forecast import forecast_service
+from services.song_popularity_forecast import forecast_service
 
 # Supported region codes and platforms
 ALLOWED_REGION_CODES = {"global", "US", "EU"}
@@ -457,7 +457,7 @@ def schedule_global_aggregation() -> None:
     try:
         from datetime import timedelta
 
-        from backend.services.scheduler_service import schedule_task
+        from services.scheduler_service import schedule_task
 
         run_at = (datetime.utcnow() + timedelta(days=1)).isoformat()
         schedule_task(

--- a/services/song_remaster_service.py
+++ b/services/song_remaster_service.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from typing import Dict, Optional
 
 from backend.database import DB_PATH
-from backend.services.song_service import SongService
-from backend.services.song_popularity_service import song_popularity_service
+from services.song_service import SongService
+from services.song_popularity_service import song_popularity_service
 
 
 class SongRemasterService:

--- a/services/songwriting_service.py
+++ b/services/songwriting_service.py
@@ -8,23 +8,23 @@ from backend.models.song import Song
 from backend.models.song_draft_version import SongDraftVersion
 from backend.models.songwriting import GenerationMetadata, LyricDraft
 from backend.models.theme import THEMES
-from backend.services.ai_art_service import AIArtService, ai_art_service
-from backend.services.band_service import BandService
-from backend.services.chemistry_service import ChemistryService
-from backend.services.avatar_service import AvatarService
-from backend.services.originality_service import (
+from services.ai_art_service import AIArtService, ai_art_service
+from services.band_service import BandService
+from services.chemistry_service import ChemistryService
+from services.avatar_service import AvatarService
+from services.originality_service import (
     OriginalityService,
     originality_service,
 )
-from backend.services.skill_service import (
+from services.skill_service import (
     SkillService,
 )
-from backend.services.skill_service import (
+from services.skill_service import (
     skill_service as skill_service_instance,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
-    from backend.services.legal_service import LegalService
+    from services.legal_service import LegalService
 
 
 class _Message:

--- a/services/stream_service.py
+++ b/services/stream_service.py
@@ -1,6 +1,6 @@
 
 from models.stream import Stream
-from backend.services.avatar_service import AvatarService
+from services.avatar_service import AvatarService
 
 PLATFORM_PAYOUTS = {
     "Spotify": 0.003,

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -8,8 +8,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback to package
 from backend.database import DB_PATH
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import skill_service
-from backend.services.song_popularity_service import add_event
+from services.skill_service import skill_service
+from services.song_popularity_service import add_event
 
 
 async def _stream_song(user_id: int, song_id: int) -> dict:

--- a/services/ticketing_service.py
+++ b/services/ticketing_service.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.services.economy_service import EconomyError, EconomyService
+from services.economy_service import EconomyError, EconomyService
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/tour_logistics_service.py
+++ b/services/tour_logistics_service.py
@@ -4,7 +4,7 @@ from models.tour_route import TourRoute
 from datetime import datetime, timedelta
 import random
 
-from backend.services.transport_service import TransportService
+from services.transport_service import TransportService
 
 class TourLogisticsService:
     def __init__(self, db, transport: TransportService | None = None):

--- a/services/tour_service.py
+++ b/services/tour_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Dict, List, Optional
 from utils.db import get_conn
-from backend.services.venue_availability import VenueAvailabilityService
+from services.venue_availability import VenueAvailabilityService
 from core.errors import AppError, TourMinStopsError, VenueConflictError
 import sqlite3
 from typing import Any, Dict, List, Optional
@@ -13,11 +13,11 @@ from core.errors import AppError, TourMinStopsError, VenueConflictError
 from models.economy_config import get_config
 from models.tour import Expense, TicketTier, TourLeg
 from models.tour import Tour as TourModel
-from backend.services.achievement_service import AchievementService
-from backend.services.economy_service import EconomyService
-from backend.services.fame_service import FameService
-from backend.services.venue_availability import VenueAvailabilityService
-from backend.services.weather_service import WeatherService
+from services.achievement_service import AchievementService
+from services.economy_service import EconomyService
+from services.fame_service import FameService
+from services.venue_availability import VenueAvailabilityService
+from services.weather_service import WeatherService
 from sqlalchemy.exc import SQLAlchemyError
 
 from backend.utils.logging import get_logger

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 import sqlite3
 
 from backend.models.tournament import Bracket, Match, Score
-from backend.services import live_performance_service
+from services import live_performance_service
 from backend.database import DB_PATH
 
 

--- a/services/tutor_service.py
+++ b/services/tutor_service.py
@@ -7,9 +7,9 @@ from typing import Dict, Optional
 from backend.models.tutor import Tutor
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod, METHOD_PROFILES
-from backend.services.avatar_service import AvatarService
-from backend.services.economy_service import EconomyService
-from backend.services.skill_service import SkillService, skill_service
+from services.avatar_service import AvatarService
+from services.economy_service import EconomyService
+from services.skill_service import SkillService, skill_service
 
 
 class TutorService:

--- a/services/university_service.py
+++ b/services/university_service.py
@@ -10,7 +10,7 @@ from typing import List
 from backend.database import DB_PATH
 from backend.models.course import Course
 from backend.models.skill import Skill
-from backend.services.skill_service import SkillService
+from services.skill_service import SkillService
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 

--- a/services/video_service.py
+++ b/services/video_service.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from typing import Dict, List
 
 from backend.models.video import Video
-from backend.services.economy_service import EconomyService
-from backend.services.media_moderation_service import media_moderation_service
-from backend.services.skill_service import SkillService
+from services.economy_service import EconomyService
+from services.media_moderation_service import media_moderation_service
+from services.skill_service import SkillService
 from backend.seeds.skill_seed import SEED_SKILLS
 from backend.utils.metrics import _REGISTRY, Histogram
 

--- a/services/vocal_training_service.py
+++ b/services/vocal_training_service.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from backend.models.learning_method import LearningMethod
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SEED_SKILLS
-from backend.services.skill_service import SkillService
-from backend.services.skill_service import skill_service as default_skill_service
+from services.skill_service import SkillService
+from services.skill_service import skill_service as default_skill_service
 
 
 class VocalTrainingService:

--- a/tests/live_album/test_audio_mixing.py
+++ b/tests/live_album/test_audio_mixing.py
@@ -5,9 +5,9 @@ import pytest
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services import audio_mixing_service
-from backend.services.live_album_service import LiveAlbumService
-from backend.services.skill_service import skill_service
+from services import audio_mixing_service
+from services.live_album_service import LiveAlbumService
+from services.skill_service import skill_service
 
 
 def _insert_performance(cur, band_id, setlist, skill_gain, city="", venue=""):

--- a/tests/test_exercise_cooldown.py
+++ b/tests/test_exercise_cooldown.py
@@ -13,8 +13,8 @@ utils_mod.db = utils_db_mod
 sys.modules["utils"] = utils_mod
 sys.modules["utils.db"] = utils_db_mod
 
-from backend.services import lifestyle_service
-from backend.services.notifications_service import NotificationsService
+from services import lifestyle_service
+from services.notifications_service import NotificationsService
 from backend.models import notification_models
 
 

--- a/tests/test_festival_proposals.py
+++ b/tests/test_festival_proposals.py
@@ -6,7 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
-from backend.services.festival_proposal_service import (  # noqa: E402
+from services.festival_proposal_service import (  # noqa: E402
     FestivalProposalService,
     ProposalIn,
 )

--- a/tests/test_gig_persistence.py
+++ b/tests/test_gig_persistence.py
@@ -46,14 +46,14 @@ def _setup_db(db_path: Path) -> None:
 
 
 def test_gig_completion_persists_services(monkeypatch, tmp_path):
-    from backend.services import gig_service as gs
-    from backend.services import fan_service
-    from backend.services.skill_service import SkillService
-    from backend.services.band_service import BandService as BandSvc, Base as BandBase
-    from backend.services.avatar_service import (
+    from services import gig_service as gs
+    from services import fan_service
+    from services.skill_service import SkillService
+    from services.band_service import BandService as BandSvc, Base as BandBase
+    from services.avatar_service import (
         AvatarService as AvatarSvc,
     )
-    from backend.services.economy_service import EconomyService as EconSvc
+    from services.economy_service import EconomyService as EconSvc
     from backend.schemas.avatar import AvatarCreate
     from models.avatar import Base as AvatarBase
     from models import avatar_skin  # noqa: F401

--- a/tests/test_gig_skill_multiplier.py
+++ b/tests/test_gig_skill_multiplier.py
@@ -1,8 +1,8 @@
 import sqlite3
 from pathlib import Path
 
-from backend.services import gig_service as gs
-from backend.services.skill_service import skill_service
+from services import gig_service as gs
+from services.skill_service import skill_service
 from backend.models.skill import Skill
 from seeds.skill_seed import SKILL_NAME_TO_ID
 

--- a/tests/test_image_skills.py
+++ b/tests/test_image_skills.py
@@ -9,14 +9,14 @@ sys.path.append(str(ROOT / "backend"))
 
 from backend.seeds.skill_seed import SEED_SKILLS
 from backend.models.learning_method import METHOD_PROFILES, LearningMethod
-from backend.services import fan_interaction_service, fan_service
-from backend.services.image_training_service import (
+from services import fan_interaction_service, fan_service
+from services.image_training_service import (
     Stylist,
     StylistService,
     study_image_tutorial,
 )
-from backend.services.skill_service import SkillService
-from backend.services.economy_service import EconomyService
+from services.skill_service import SkillService
+from services.economy_service import EconomyService
 
 
 FASHION_SKILL = next(s for s in SEED_SKILLS if s.name == "fashion")

--- a/tests/test_jobs_charts_multi_country.py
+++ b/tests/test_jobs_charts_multi_country.py
@@ -22,7 +22,7 @@ chart_service_stub.get_chart = lambda *a, **k: []
 sys.modules["backend.services.chart_service"] = chart_service_stub
 
 from backend import database
-from backend.services.jobs_charts import ChartsJobsService
+from services.jobs_charts import ChartsJobsService
 from backend.routes import chart_routes
 
 def _setup_db(tmp_path):

--- a/tests/test_lifestyle_config.py
+++ b/tests/test_lifestyle_config.py
@@ -1,5 +1,5 @@
 from backend.config import lifestyle as cfg
-from backend.services.lifestyle_scheduler import lifestyle_xp_modifier
+from services.lifestyle_scheduler import lifestyle_xp_modifier
 
 
 def test_default_lifestyle_config_values() -> None:

--- a/tests/test_lifestyle_scheduler.py
+++ b/tests/test_lifestyle_scheduler.py
@@ -1,7 +1,7 @@
 import sqlite3
 from datetime import datetime
 
-from backend.services import lifestyle_scheduler, xp_reward_service
+from services import lifestyle_scheduler, xp_reward_service
 
 
 def test_scheduler_applies_xp_without_lock(monkeypatch, tmp_path):

--- a/tests/test_lifestyle_xp.py
+++ b/tests/test_lifestyle_xp.py
@@ -1,4 +1,4 @@
-from backend.services import lifestyle_service
+from services import lifestyle_service
 
 
 def _collect(monkeypatch):

--- a/tests/test_live_album_integration.py
+++ b/tests/test_live_album_integration.py
@@ -8,9 +8,9 @@ sv = sys.path
 sv.append(str(BASE_DIR))
 sv.append(str(BASE_DIR / "backend"))
 
-from backend.services.sales_service import SalesService
-from backend.services.economy_service import EconomyService
-from backend.services import chart_service
+from services.sales_service import SalesService
+from services.economy_service import EconomyService
+from services import chart_service
 
 
 class DummyFameService:

--- a/tests/test_live_streaming.py
+++ b/tests/test_live_streaming.py
@@ -1,5 +1,5 @@
-from backend.services import streaming_service as ss
-from backend.services.skill_service import skill_service
+from services import streaming_service as ss
+from services.skill_service import skill_service
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 

--- a/tests/test_notifications_logging.py
+++ b/tests/test_notifications_logging.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from backend.services import notifications_service as ns
+from services import notifications_service as ns
 
 
 @pytest.fixture

--- a/tests/test_notifications_service.py
+++ b/tests/test_notifications_service.py
@@ -5,7 +5,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from backend.services.notifications_service import NotificationsService
+from services.notifications_service import NotificationsService
 
 
 def _setup_db(path):

--- a/tests/test_npc_seasonal_events.py
+++ b/tests/test_npc_seasonal_events.py
@@ -10,8 +10,8 @@ sys.path.append(str(root_dir))
 sys.path.append(str(root_dir / "backend"))
 
 import backend.services.npc_service as npc_service_module
-from backend.services.npc_service import NPCService
-from backend.services import scheduler_service
+from services.npc_service import NPCService
+from services import scheduler_service
 
 
 def _setup_scheduler(tmp_path):

--- a/tests/test_onboarding_service.py
+++ b/tests/test_onboarding_service.py
@@ -1,4 +1,4 @@
-from backend.services.onboarding_question_service import OnboardingQuestionService
+from services.onboarding_question_service import OnboardingQuestionService
 
 
 def test_get_questions_returns_three_unique_questions() -> None:

--- a/tests/test_perk_service.py
+++ b/tests/test_perk_service.py
@@ -7,9 +7,9 @@ sys.path.append(str(ROOT / "backend"))
 
 from backend.models.perk import Perk
 from backend.models.skill import Skill
-from backend.services.attribute_service import AttributeService
-from backend.services.perk_service import perk_service
-from backend.services.skill_service import SkillService
+from services.attribute_service import AttributeService
+from services.perk_service import perk_service
+from services.skill_service import SkillService
 
 
 def setup_function() -> None:

--- a/tests/test_practice_xp.py
+++ b/tests/test_practice_xp.py
@@ -6,7 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
-from backend.services.skill_service import skill_service
+from services.skill_service import skill_service
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
@@ -38,7 +38,7 @@ def _setup_gig_db(db_path: Path) -> None:
 
 
 def test_gig_performance_grants_skill(monkeypatch, tmp_path):
-    from backend.services import gig_service as gs
+    from services import gig_service as gs
 
     db = tmp_path / "gig.db"
     _setup_gig_db(db)
@@ -78,7 +78,7 @@ class DummyEconomy:
 
 
 def test_recording_session_grants_skill():
-    from backend.services.recording_service import RecordingService
+    from services.recording_service import RecordingService
 
     economy = DummyEconomy()
     svc = RecordingService(economy=economy)
@@ -97,7 +97,7 @@ def test_recording_session_grants_skill():
 
 
 def test_gig_voice_influence(monkeypatch, tmp_path):
-    from backend.services import gig_service as gs
+    from services import gig_service as gs
 
     db = tmp_path / "gig.db"
     _setup_gig_db(db)

--- a/tests/test_reputation_service.py
+++ b/tests/test_reputation_service.py
@@ -5,8 +5,8 @@ sys.path.append(str(ROOT / "backend"))
 
 import pytest
 
-from backend.services.reputation_service import ReputationService
-from backend.services import event_service
+from services.reputation_service import ReputationService
+from services import event_service
 
 
 def test_reputation_accumulation_and_elite_unlock(tmp_path):

--- a/tests/test_sales_concurrency.py
+++ b/tests/test_sales_concurrency.py
@@ -1,7 +1,7 @@
 import asyncio
 
-from backend.services.sales_service import SalesService, SalesError
-from backend.services.economy_service import EconomyService
+from services.sales_service import SalesService, SalesError
+from services.economy_service import EconomyService
 
 
 def test_concurrent_vinyl_purchase(tmp_path):

--- a/tests/test_shop_event_service.py
+++ b/tests/test_shop_event_service.py
@@ -22,7 +22,7 @@ sys.modules["seeds.skill_seed"] = fake_seed
 
 import backend.services.event_service as event_service_module  # noqa: E402
 from backend import database  # noqa: E402
-from backend.services.event_service import (  # noqa: E402
+from services.event_service import (  # noqa: E402
     end_shop_event,
     schedule_shop_event,
     start_shop_event,

--- a/tests/test_skill_category_multiplier.py
+++ b/tests/test_skill_category_multiplier.py
@@ -5,9 +5,9 @@ import pytest
 
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services import gig_service as gs
-from backend.services.skill_service import SkillService, skill_service
-from backend.services.recording_service import RecordingService
+from services import gig_service as gs
+from services.skill_service import SkillService, skill_service
+from services.recording_service import RecordingService
 
 
 class DummyEconomy:

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -46,10 +46,10 @@ from backend.models.learning_method import LearningMethod
 from backend.models.skill import Skill, SkillSpecialization
 from backend.models.xp_config import XPConfig, get_config, set_config
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.skill_service import SkillService
+from services.skill_service import SkillService
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
-from backend.services.vocal_training_service import VocalTrainingService
-from backend.services.recording_service import RecordingService
+from services.vocal_training_service import VocalTrainingService
+from services.recording_service import RecordingService
 item_service = None  # set in _setup_device
 
 
@@ -230,7 +230,7 @@ def _setup_device() -> int:
         sys.modules["backend.services.notifications_service"] = types.SimpleNamespace(
             NotificationsService=object
         )
-    from backend.services.item_service import item_service as svc
+    from services.item_service import item_service as svc
 
     global item_service
     item_service = svc

--- a/tests/test_stage_presence_gig_rewards.py
+++ b/tests/test_stage_presence_gig_rewards.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-from backend.services import gig_service as gs
+from services import gig_service as gs
 
 
 def _setup_gig_db(db_path):

--- a/tests/test_tour_service_logging.py
+++ b/tests/test_tour_service_logging.py
@@ -39,7 +39,7 @@ import backend.models as backend_models
 sys.modules.setdefault("models", backend_models)
 
 import backend.services.tour_service as tour_service_module
-from backend.services.tour_service import TourService
+from services.tour_service import TourService
 
 
 class DummyEconomy:

--- a/tests/test_tutor_service.py
+++ b/tests/test_tutor_service.py
@@ -8,10 +8,10 @@ from backend.models.skill import Skill
 from backend.models.tutor import Tutor
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
-from backend.services.economy_service import EconomyService
-from backend.services.skill_service import SkillService
-from backend.services.tutor_service import TutorService
-from backend.services.avatar_service import AvatarService
+from services.economy_service import EconomyService
+from services.skill_service import SkillService
+from services.tutor_service import TutorService
+from services.avatar_service import AvatarService
 from backend.schemas.avatar import AvatarCreate, AvatarUpdate
 
 

--- a/tests/test_university_service.py
+++ b/tests/test_university_service.py
@@ -7,8 +7,8 @@ root_dir = Path(__file__).resolve().parents[1]
 sys.path.append(str(root_dir))
 sys.path.append(str(root_dir / "backend"))
 
-from backend.services.university_service import UniversityService
-from backend.services.skill_service import SkillService
+from services.university_service import UniversityService
+from services.skill_service import SkillService
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 

--- a/tests/test_vinyl_orders.py
+++ b/tests/test_vinyl_orders.py
@@ -5,7 +5,7 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
-from backend.services.sales_service import SalesService
+from services.sales_service import SalesService
 
 
 def _create_service(tmp_path):

--- a/tests/test_xp_reward_baseline.py
+++ b/tests/test_xp_reward_baseline.py
@@ -8,7 +8,7 @@ sys.path.append(str(root_dir))
 sys.path.append(str(root_dir / "backend"))
 
 from backend.models.xp_config import XPConfig, set_config  # noqa: E402
-from backend.services import scheduler_service, xp_reward_service  # noqa: E402
+from services import scheduler_service, xp_reward_service  # noqa: E402
 
 
 def _setup_db(tmp_path):


### PR DESCRIPTION
## Summary
- replace `backend.services` imports with `services` equivalents
- ensure no remaining `backend.services` imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c73d5ee38083259cb969c872c5015f