### PR TITLE
refactor auth import paths in utils

### DIFF
--- a/backend/utils/auth_utils.py
+++ b/backend/utils/auth_utils.py
@@ -1,9 +1,8 @@
 from datetime import datetime, timedelta
 
+from auth.jwt import encode
+from auth.service import get_user_by_username, verify_password
 from core.config import settings
-
-from backend.auth.jwt import encode
-from backend.services.auth_service import get_user_by_username, verify_password
 
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.auth.access_token_ttl_min
 


### PR DESCRIPTION
## Summary
- update auth utility imports to use new `auth` package paths

## Testing
- `ruff check backend/utils/auth_utils.py`
- `pytest backend/tests/auth` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c73d69aed083258e97bfc4eb612362