### PR TITLE
Use modding namespace for plugin loader

### DIFF
--- a/backend/tests/modding/test_plugin_loader.py
+++ b/backend/tests/modding/test_plugin_loader.py
@@ -1,9 +1,9 @@
-from backend.modding.loader import PluginLoader
+from modding.loader import PluginLoader
 
 
 def _create_plugin(tmp_path, monkeypatch, extra_code: str = ""):
     plugin_code = (
-        "from backend.modding.interfaces import PluginMeta\n"
+        "from modding.interfaces import PluginMeta\n"
         "class Sample:\n"
         "    meta = PluginMeta(name='sample', version='1.0', author='tester')\n"
         "    activated = False\n"

--- a/routes/admin_modding_routes.py
+++ b/routes/admin_modding_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
 
-from backend.modding.loader import PluginLoader
+from modding.loader import PluginLoader
 
 router = APIRouter(prefix="/modding", tags=["AdminModding"])
 


### PR DESCRIPTION
## Summary
- update plugin loader imports to modding namespace in tests and admin routes
- adjust sample plugin code to use modding.interfaces

## Testing
- `PYTHONPATH=. pytest backend/tests/modding/test_plugin_loader.py backend/tests/admin/test_admin_router.py` *(fails: No module named 'backend.auth')*

------
https://chatgpt.com/codex/tasks/task_e_68c73d6881d48325bb76ca9690e6652f