### PR TITLE
refactor: update storage imports

### DIFF
--- a/backend/tests/admin/test_admin_action_logging.py
+++ b/backend/tests/admin/test_admin_action_logging.py
@@ -7,7 +7,7 @@ from fastapi import Request
 
 from backend.routes import admin_media_moderation_routes as media_routes
 from backend.services.admin_service import AdminService, AdminActionRepository
-from backend.storage.local import LocalStorage
+from storage.local import LocalStorage
 from backend.services import storage_service
 from backend.utils.db import get_conn
 

--- a/backend/tests/modding/test_marketplace.py
+++ b/backend/tests/modding/test_marketplace.py
@@ -2,7 +2,7 @@ import sqlite3
 
 from backend.services.mod_marketplace_service import ModMarketplaceService
 from backend.services.economy_service import EconomyService
-from backend.storage.local import LocalStorage
+from storage.local import LocalStorage
 
 
 def test_marketplace_workflow(tmp_path):

--- a/backend/tests/routes/test_skin_marketplace_routes.py
+++ b/backend/tests/routes/test_skin_marketplace_routes.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 import base64
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from backend.storage.local import LocalStorage
+from storage.local import LocalStorage
 from backend.services.skin_service import SkinService, engine
 from models.skin import Skin
 from models.avatar import Base as AvatarBase

--- a/backend/tests/test_storage_local.py
+++ b/backend/tests/test_storage_local.py
@@ -1,5 +1,5 @@
 import os, tempfile
-from backend.storage.local import LocalStorage
+from storage.local import LocalStorage
 
 def test_local_roundtrip(tmp_path):
     root = tmp_path / "store"

--- a/backend/tests/test_storage_s3_mock.py
+++ b/backend/tests/test_storage_s3_mock.py
@@ -7,7 +7,7 @@ import pytest
 from moto import mock_aws
 from botocore.exceptions import ClientError
 
-from backend.storage.s3 import S3Storage
+from storage.s3 import S3Storage
 
 @mock_aws
 def test_s3_roundtrip(monkeypatch, tmp_path):

--- a/services/mod_marketplace_service.py
+++ b/services/mod_marketplace_service.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from backend.services.economy_service import EconomyService
 from backend.services.storage_service import get_storage_backend
-from backend.storage.base import StorageBackend
+from storage.base import StorageBackend
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/tests/test_s3_exists.py
+++ b/tests/test_s3_exists.py
@@ -38,7 +38,7 @@ def make_storage(monkeypatch):
         types.SimpleNamespace(ClientError=DummyClientError),
     )
 
-    s3_module = importlib.import_module("backend.storage.s3")
+    s3_module = importlib.import_module("storage.s3")
     importlib.reload(s3_module)
     storage = s3_module.S3Storage("bucket", "region")
     return storage, dummy_client, DummyClientError


### PR DESCRIPTION
## Summary
- replace `backend.storage` imports with direct `storage` equivalents
- adjust dynamic import in S3 tests to use `storage.s3`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c73d678c008325bbd069aae17f4989