### PR TITLE
Refactor realtime imports to new module path

### DIFF
--- a/backend/monitoring/websocket.py
+++ b/backend/monitoring/websocket.py
@@ -26,7 +26,7 @@ def _snapshot() -> Dict[str, int]:
 
 async def _broadcast() -> None:
     try:
-        from backend.realtime.gateway import hub
+        from realtime.gateway import hub
     except Exception:  # pragma: no cover - hub not available
         return
     await hub.publish(TOPIC, _snapshot())

--- a/backend/tests/dialogue/test_dialogue.py
+++ b/backend/tests/dialogue/test_dialogue.py
@@ -2,9 +2,9 @@ import asyncio
 
 import pytest
 
-import backend.realtime.dialogue_gateway as dialogue_gateway
+import realtime.dialogue_gateway as dialogue_gateway
 from backend.models.dialogue import DialogueMessage
-from backend.realtime.dialogue_gateway import router as dialogue_router
+from realtime.dialogue_gateway import router as dialogue_router
 from backend.services.dialogue_service import DialogueService
 from fastapi import FastAPI
 from fastapi.testclient import TestClient

--- a/backend/tests/jam_sessions/test_jam_gateway.py
+++ b/backend/tests/jam_sessions/test_jam_gateway.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 
 import pytest
 
-from backend.realtime.jam_gateway import jam_ws, jam_service
+from realtime.jam_gateway import jam_ws, jam_service
 from backend.services.economy_service import EconomyService
 
 

--- a/backend/tests/social/test_fan_clubs.py
+++ b/backend/tests/social/test_fan_clubs.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime, timedelta
 
 from backend.services.fan_club_service import fan_club_service
-from backend.realtime.gateway import hub, _Subscriber, topic_for_user
+from realtime.gateway import hub, _Subscriber, topic_for_user
 
 
 def test_fan_club_membership_and_notifications():

--- a/backend/tests/social/test_friendships.py
+++ b/backend/tests/social/test_friendships.py
@@ -2,7 +2,7 @@ import asyncio
 import sqlite3
 
 from backend.services.social_service import social_service
-from backend.realtime import social_gateway
+from realtime import social_gateway
 
 
 def test_friend_request_flow(tmp_path, monkeypatch):

--- a/backend/tests/test_admin_dashboard_ws.py
+++ b/backend/tests/test_admin_dashboard_ws.py
@@ -4,8 +4,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from backend.realtime import admin_gateway
-from backend.realtime.admin_gateway import router as admin_router, publish_economy_alert
+from realtime import admin_gateway
+from realtime.admin_gateway import router as admin_router, publish_economy_alert
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_metrics_smoke.py
+++ b/backend/tests/test_metrics_smoke.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 
 from backend.api import app
-from backend.realtime.gateway import hub
+from realtime.gateway import hub
 from backend.services.economy_service import EconomyService
 
 

--- a/backend/tests/test_realtime_sse.py
+++ b/backend/tests/test_realtime_sse.py
@@ -3,8 +3,8 @@ import json
 import pytest
 from fastapi import FastAPI
 
-from backend.realtime.gateway import router as realtime_router
-from backend.realtime.publish import publish_mail_unread, publish_pulse_update
+from realtime.gateway import router as realtime_router
+from realtime.publish import publish_mail_unread, publish_pulse_update
 
 @pytest.fixture
 def app_fixture():

--- a/backend/tests/test_realtime_ws.py
+++ b/backend/tests/test_realtime_ws.py
@@ -5,8 +5,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from backend.realtime.gateway import router as realtime_router
-from backend.realtime.publish import publish_mail_unread, publish_pulse_update
+from realtime.gateway import router as realtime_router
+from realtime.publish import publish_mail_unread, publish_pulse_update
 
 @pytest.fixture
 def app_fixture():

--- a/backend/tests/test_websocket_metrics.py
+++ b/backend/tests/test_websocket_metrics.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from fastapi import WebSocketDisconnect
 
-from backend.realtime.gateway import websocket_gateway
+from realtime.gateway import websocket_gateway
 from backend.monitoring.websocket import (
     CONNECTIONS_ACTIVE,
     CONNECTIONS_TOTAL,

--- a/realtime/dialogue_gateway.py
+++ b/realtime/dialogue_gateway.py
@@ -6,7 +6,7 @@ from typing import List
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 
 from backend.models.dialogue import DialogueMessage
-from backend.realtime.gateway import get_current_user_id_dep
+from realtime.gateway import get_current_user_id_dep
 from backend.monitoring.websocket import track_connect, track_disconnect, track_message
 from backend.services.dialogue_service import DialogueService
 

--- a/realtime/jam_gateway.py
+++ b/realtime/jam_gateway.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 try:  # pragma: no cover - explicit failure if FastAPI missing
     from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 except ModuleNotFoundError as exc:  # pragma: no cover - FastAPI required
-    raise ImportError("FastAPI must be installed to use backend.realtime.jam_gateway") from exc
+    raise ImportError("FastAPI must be installed to use realtime.jam_gateway") from exc
 
 from backend.services.jam_service import JamService
 from .gateway import get_current_user_id_dep

--- a/realtime/polling.py
+++ b/realtime/polling.py
@@ -8,7 +8,7 @@ from typing import Dict
 try:  # pragma: no cover - explicit failure if FastAPI missing
     from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 except ModuleNotFoundError as exc:  # pragma: no cover - FastAPI required
-    raise ImportError("FastAPI must be installed to use backend.realtime.polling") from exc
+    raise ImportError("FastAPI must be installed to use realtime.polling") from exc
 
 from .gateway import get_current_user_id_dep
 from backend.monitoring.websocket import track_connect, track_disconnect, track_message

--- a/routes/jam_ws.py
+++ b/routes/jam_ws.py
@@ -3,6 +3,6 @@
 This module simply re-exports the realtime jam gateway router so it can be
 mounted alongside other route modules.
 """
-from backend.realtime.jam_gateway import router
+from realtime.jam_gateway import router
 
 __all__ = ["router"]

--- a/routes/notifications_ws.py
+++ b/routes/notifications_ws.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
 
-from backend.realtime.gateway import (
+from realtime.gateway import (
     _Subscriber,
     get_current_user_id_dep,
     hub,

--- a/services/fan_club_service.py
+++ b/services/fan_club_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from backend.realtime.publish import (
+from realtime.publish import (
     publish_fan_club_event_invite,
     publish_fan_club_post,
 )

--- a/services/live_performance_service.py
+++ b/services/live_performance_service.py
@@ -25,7 +25,7 @@ from backend.services.gear_service import gear_service
 from backend.services.setlist_service import get_approved_setlist
 
 try:
-    from backend.realtime.polling import poll_hub
+    from realtime.polling import poll_hub
 except Exception:  # pragma: no cover - optional realtime module
     poll_hub = None  # type: ignore
 

--- a/services/social_service.py
+++ b/services/social_service.py
@@ -5,7 +5,7 @@ import sqlite3
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-from backend.realtime.social_gateway import publish_forum_reply, publish_friend_request
+from realtime.social_gateway import publish_forum_reply, publish_friend_request
 
 
 @dataclass

--- a/tests/realtime/conftest.py
+++ b/tests/realtime/conftest.py
@@ -19,7 +19,7 @@ def jam_app():
     original_mod = sys.modules.get("backend.services.jam_service")
     sys.modules["backend.services.jam_service"] = fake_module
 
-    jam_gateway = importlib.reload(importlib.import_module("backend.realtime.jam_gateway"))
+    jam_gateway = importlib.reload(importlib.import_module("realtime.jam_gateway"))
 
     app = FastAPI()
     service = FakeJamService()

--- a/tests/realtime/test_polling_ws.py
+++ b/tests/realtime/test_polling_ws.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
-from backend.realtime import polling
+from realtime import polling
 
 
 def create_app() -> FastAPI:


### PR DESCRIPTION
## Summary
- replace `backend.realtime` imports with `realtime` equivalents across codebase
- adjust realtime gateway error messages and service imports for new package layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68c73d646ec88325bb33f5f213d747f6