### PR TITLE
refactor: update economy imports

### DIFF
--- a/backend/tests/economy/test_economy_service.py
+++ b/backend/tests/economy/test_economy_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.economy.models import Account, LedgerEntry
+from economy.models import Account, LedgerEntry
 from backend.services.economy_service import EconomyError, EconomyService
 
 

--- a/backend/tests/economy/test_gig_ledger.py
+++ b/backend/tests/economy/test_gig_ledger.py
@@ -4,7 +4,7 @@ import types
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
-from backend.economy.models import Account, LedgerEntry, Transaction as TransactionModel
+from economy.models import Account, LedgerEntry, Transaction as TransactionModel
 from backend.services.economy_service import EconomyService
 import backend.services.gig_service as gig_service
 

--- a/backend/tests/economy/test_recording_cost.py
+++ b/backend/tests/economy/test_recording_cost.py
@@ -40,7 +40,7 @@ sys.modules["utils.db"] = db_module
 from backend.services.economy_service import EconomyService
 from backend.services.tour_service import TourService
 from backend.services.weather_service import WeatherService
-from backend.economy.models import Account, LedgerEntry
+from economy.models import Account, LedgerEntry
 
 
 class DummyFameService:

--- a/backend/tests/routes/test_merch_routes.py
+++ b/backend/tests/routes/test_merch_routes.py
@@ -62,7 +62,7 @@ def test_purchase_flow_invokes_payment_and_updates_economy(tmp_path):
 
     assert gateway.counter == 1
 
-    from backend.economy.models import Account, Transaction as Tx
+    from economy.models import Account, Transaction as Tx
     from sqlalchemy import select
 
     with economy.SessionLocal() as session:

--- a/services/economy_service.py
+++ b/services/economy_service.py
@@ -14,7 +14,7 @@ from backend.utils.logging import get_logger
 from sqlalchemy import create_engine, select, or_
 from sqlalchemy.orm import Session, sessionmaker
 
-from backend.economy.models import (
+from economy.models import (
     Base,
     Account,
     Transaction as TransactionModel,


### PR DESCRIPTION
## Summary
- replace `backend.economy` imports with `economy`

## Testing
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c73d62d52c8325ac163e42d5c5ee54