### PR TITLE
refactor: update database imports

### DIFF
--- a/backend/tests/test_media_monitor.py
+++ b/backend/tests/test_media_monitor.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services.media_monitor_service import MediaMonitorService
 import backend.services.song_popularity_service as sp_module
 from backend.services.song_popularity_service import song_popularity_service

--- a/backend/tests/test_social_sentiment.py
+++ b/backend/tests/test_social_sentiment.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services.social_sentiment_service import SocialSentimentService
 from backend.services.song_popularity_service import get_current_popularity
 

--- a/backend/tests/test_song_popularity.py
+++ b/backend/tests/test_song_popularity.py
@@ -7,7 +7,7 @@ try:  # pragma: no cover - FastAPI optional in some test suites
 except Exception:  # pragma: no cover
     FastAPI = None  # type: ignore
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services import song_popularity_service
 from backend.services.song_popularity_service import (
     HALF_LIFE_DAYS,

--- a/jobs/data_hygiene_jobs.py
+++ b/jobs/data_hygiene_jobs.py
@@ -79,7 +79,6 @@ def get_conn(db_path: Optional[str] = None) -> sqlite3.Connection:
     # Try project-level helpers first
     for mod_name in (
         "backend.core.database",
-        "backend.database",
         "database",
     ):
         try:

--- a/jobs/royalty_clearing_job.py
+++ b/jobs/royalty_clearing_job.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import sqlite3
 from typing import Iterable, Tuple
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def _fetch_outstanding(cur: sqlite3.Cursor) -> Iterable[Tuple[int, int, int, int]]:

--- a/jobs/world_pulse_jobs.py
+++ b/jobs/world_pulse_jobs.py
@@ -14,7 +14,7 @@ from backend.services.season_service import SeasonScheduler
 
 try:
     # Preferred: shared project connection helper
-    from backend.database import get_conn  # type: ignore
+    from database import get_conn  # type: ignore
 except Exception:
     # Fallback: local minimal connector for tests or standalone runs
     import sqlite3

--- a/models/activity.py
+++ b/models/activity.py
@@ -2,7 +2,7 @@ import sqlite3
 from dataclasses import dataclass
 from typing import List, Optional, Dict
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 @dataclass(frozen=True)

--- a/models/activity_log.py
+++ b/models/activity_log.py
@@ -2,7 +2,7 @@ import json
 import sqlite3
 from typing import Dict, List
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def _ensure_table(cur: sqlite3.Cursor) -> None:

--- a/models/band_schedule.py
+++ b/models/band_schedule.py
@@ -1,7 +1,7 @@
 import sqlite3
 from typing import List, Dict
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def add_entry(band_id: int, date: str, slot: int, activity_id: int) -> None:

--- a/models/daily_loop.py
+++ b/models/daily_loop.py
@@ -3,7 +3,7 @@ import sqlite3
 from datetime import date, timedelta
 from typing import Dict, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services.xp_reward_service import xp_reward_service
 from backend.models import weekly_drop, tier_track
 

--- a/models/daily_schedule.py
+++ b/models/daily_schedule.py
@@ -1,7 +1,7 @@
 import sqlite3
 from typing import Dict, List
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 # Maximum number of exercise activities permitted in a single day.
 # Additional exercise sessions beyond this limit are rejected when

--- a/models/default_schedule.py
+++ b/models/default_schedule.py
@@ -1,7 +1,7 @@
 import sqlite3
 from typing import Iterable, List, Dict, Tuple
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def set_plan(user_id: int, day_of_week: str, entries: Iterable[Tuple[int, int]]) -> None:

--- a/models/default_schedule_templates.py
+++ b/models/default_schedule_templates.py
@@ -2,7 +2,7 @@ import sqlite3
 import sqlite3
 from typing import Iterable, List, Dict, Tuple
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def create_template(user_id: int, name: str, entries: Iterable[Tuple[int, int]]) -> int:

--- a/models/next_day_schedule.py
+++ b/models/next_day_schedule.py
@@ -1,7 +1,7 @@
 import sqlite3
 from typing import Dict, List
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def add_entry(user_id: int, date: str, slot: int, activity_id: int) -> None:

--- a/models/tier_track.py
+++ b/models/tier_track.py
@@ -1,7 +1,7 @@
 import sqlite3
 from typing import Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def set_reward(tier: int, reward: str) -> None:

--- a/models/weekly_drop.py
+++ b/models/weekly_drop.py
@@ -2,7 +2,7 @@ import sqlite3
 from datetime import date
 from typing import Dict, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def schedule_drop(user_id: int, drop_date: str, reward: str) -> None:

--- a/models/weekly_schedule.py
+++ b/models/weekly_schedule.py
@@ -1,7 +1,7 @@
 import sqlite3
 from typing import List, Dict, Iterable, Tuple
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def add_entry(user_id: int, week_start: str, day: str, slot: int, activity_id: int) -> None:

--- a/routes/admin_season_routes.py
+++ b/routes/admin_season_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 
 from auth.dependencies import require_permission
-from backend.database import get_conn
+from database import get_conn
 from services.season_service import activate_season, deactivate_season
 
 router = APIRouter(

--- a/routes/chart_routes.py
+++ b/routes/chart_routes.py
@@ -3,7 +3,7 @@ import sqlite3
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from auth.dependencies import get_current_user_id
-from backend.database import DB_PATH
+from database import DB_PATH
 from services.chart_service import calculate_weekly_chart, get_chart
 
 router = APIRouter(prefix="/charts", tags=["Charts"])

--- a/routes/tour_collab_routes.py
+++ b/routes/tour_collab_routes.py
@@ -5,7 +5,7 @@ import sqlite3
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 router = APIRouter(prefix="/tour-collab", tags=["TourCollab"])
 

--- a/scripts/migrate_daily_schedule_slots.py
+++ b/scripts/migrate_daily_schedule_slots.py
@@ -7,7 +7,7 @@ the new schema.
 """
 
 import sqlite3
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def migrate() -> None:

--- a/services/activity_processor.py
+++ b/services/activity_processor.py
@@ -7,7 +7,7 @@ import sqlite3
 from datetime import date, timedelta
 from typing import Dict, List
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models import activity_log as activity_log_model
 from backend.models import user_settings
 

--- a/services/ai_tour_manager_service.py
+++ b/services/ai_tour_manager_service.py
@@ -1,7 +1,7 @@
 import sqlite3
 import random
 from datetime import datetime
-from backend.database import DB_PATH
+from database import DB_PATH
 
 def unlock_ai_manager(band_id: int) -> dict:
     conn = sqlite3.connect(DB_PATH)

--- a/services/apprenticeship_service.py
+++ b/services/apprenticeship_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from datetime import datetime
 from pathlib import Path
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.apprenticeship import Apprenticeship
 from backend.services.karma_service import KarmaService
 

--- a/services/chart_service.py
+++ b/services/chart_service.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from backend.services.achievement_service import AchievementService
 from backend.services.legacy_service import LegacyService
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 achievement_service = AchievementService(DB_PATH)
 legacy_service = LegacyService(DB_PATH)

--- a/services/chat_service.py
+++ b/services/chat_service.py
@@ -1,7 +1,7 @@
 import sqlite3
 from datetime import datetime
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 

--- a/services/course_admin_service.py
+++ b/services/course_admin_service.py
@@ -5,7 +5,7 @@ import sqlite3
 from pathlib import Path
 from typing import List, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.course import Course
 
 

--- a/services/event_service.py
+++ b/services/event_service.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.event import Event
 from backend.models.event_effect import EventEffect
 from backend.models.npc import NPC

--- a/services/fan_interaction_service.py
+++ b/services/fan_interaction_service.py
@@ -1,6 +1,6 @@
 import sqlite3
 from datetime import datetime
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services import fan_service
 from backend.services.skill_service import skill_service
 from backend.seeds.skill_seed import SEED_SKILLS

--- a/services/fan_service.py
+++ b/services/fan_service.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.avatar_service import AvatarService

--- a/services/gig_service.py
+++ b/services/gig_service.py
@@ -2,7 +2,7 @@ import sqlite3
 import random
 from datetime import datetime, timedelta
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services import fan_service
 from backend.services.skill_service import skill_service
 from backend.models.skill import Skill

--- a/services/karma_db.py
+++ b/services/karma_db.py
@@ -4,7 +4,7 @@ import sqlite3
 from pathlib import Path
 from typing import List, Dict, Any
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.karma_event import KarmaEvent
 
 

--- a/services/labels_service.py
+++ b/services/labels_service.py
@@ -1,6 +1,6 @@
 import sqlite3
 from datetime import datetime, timezone
-from backend.database import DB_PATH
+from database import DB_PATH
 
 def create_label(name: str, founder_user_id: int, sign_up_fee: int = 0) -> dict:
     conn = sqlite3.connect(DB_PATH)

--- a/services/legacy_service.py
+++ b/services/legacy_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 class LegacyService:

--- a/services/lifestyle_service.py
+++ b/services/lifestyle_service.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import random
 import sqlite3
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models import notification_models
 
 from .skill_service import skill_service

--- a/services/live_album_service.py
+++ b/services/live_album_service.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 
 from models.album import Album
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services import audio_mixing_service, chart_service
 from backend.services.ai_art_service import ai_art_service
 from backend.services.sales_service import SalesService

--- a/services/live_performance_analysis.py
+++ b/services/live_performance_analysis.py
@@ -2,7 +2,7 @@ import json
 import sqlite3
 from datetime import datetime
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def store_setlist_summary(summary: dict) -> None:

--- a/services/live_performance_service.py
+++ b/services/live_performance_service.py
@@ -8,7 +8,7 @@ from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 from backend.models.skill import Skill
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services import live_performance_analysis
 try:
     from backend.services.chemistry_service import ChemistryService

--- a/services/mailbox_service.py
+++ b/services/mailbox_service.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Dict, List
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from utils.db import aget_conn
 
 

--- a/services/peer_learning_service.py
+++ b/services/peer_learning_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import sqlite3
 from typing import Iterable, List
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.skill import Skill
 from backend.services.skill_service import skill_service
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -1,7 +1,7 @@
 import sqlite3
 from typing import Dict
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 class ReportService:

--- a/services/reputation_service.py
+++ b/services/reputation_service.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.reputation import ReputationEvent
 
 

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -2,7 +2,7 @@ import json
 import sqlite3
 from datetime import date, datetime, timedelta
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models import daily_loop
 from backend.models.notification_models import (
     alert_no_plan,

--- a/services/setlist_service.py
+++ b/services/setlist_service.py
@@ -1,6 +1,6 @@
 import json
 import sqlite3
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def create_revision(setlist_id: int, setlist, author: str) -> int:

--- a/services/shop_restock_service.py
+++ b/services/shop_restock_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from datetime import datetime, timedelta
 from typing import Dict
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def _update_quantity(table: str, shop_id: int, item_id: int, quantity: int) -> None:

--- a/services/social_sentiment_service.py
+++ b/services/social_sentiment_service.py
@@ -2,7 +2,7 @@ import sqlite3
 from datetime import datetime
 from typing import Callable, Dict, List, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services.song_popularity_service import add_event
 
 

--- a/services/song_popularity_forecast.py
+++ b/services/song_popularity_forecast.py
@@ -5,7 +5,7 @@ import sqlite3
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 try:
     from statsmodels.tsa.arima.model import ARIMA  # type: ignore

--- a/services/song_popularity_service.py
+++ b/services/song_popularity_service.py
@@ -3,7 +3,7 @@ import sqlite3
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services.song_popularity_forecast import forecast_service
 
 # Supported region codes and platforms

--- a/services/song_remaster_service.py
+++ b/services/song_remaster_service.py
@@ -2,7 +2,7 @@ import sqlite3
 from datetime import datetime
 from typing import Dict, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.services.song_service import SongService
 from backend.services.song_popularity_service import song_popularity_service
 

--- a/services/song_service.py
+++ b/services/song_service.py
@@ -2,7 +2,7 @@ import sqlite3
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 class SongService:

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -5,7 +5,7 @@ try:  # pragma: no cover - prefer local stub if available
     import utils.aiosqlite_local as aiosqlite
 except ModuleNotFoundError:  # pragma: no cover - fallback to package
     import aiosqlite  # type: ignore
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -5,7 +5,7 @@ import sqlite3
 
 from backend.models.tournament import Bracket, Match, Score
 from backend.services import live_performance_service
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 class TournamentService:

--- a/services/tutor_admin_service.py
+++ b/services/tutor_admin_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sqlite3
 from typing import List, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.tutor import Tutor
 
 

--- a/services/university_service.py
+++ b/services/university_service.py
@@ -7,7 +7,7 @@ import sqlite3
 from pathlib import Path
 from typing import List
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.course import Course
 from backend.models.skill import Skill
 from backend.services.skill_service import SkillService

--- a/services/workshop_admin_service.py
+++ b/services/workshop_admin_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sqlite3
 from typing import List, Optional
 
-from backend.database import DB_PATH
+from database import DB_PATH
 from backend.models.workshop import Workshop
 
 


### PR DESCRIPTION
## Summary
- refactor imports to use `database` module directly
- drop outdated `backend.database` fallback in data hygiene job

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c73d5fdf1c8325b3c59953c3b4dcac