### PR TITLE
refactor: simplify models imports

### DIFF
--- a/backend/tests/admin/test_audit_logging.py
+++ b/backend/tests/admin/test_audit_logging.py
@@ -6,7 +6,7 @@ from backend.services.admin_audit_service import (
     audit_dependency,
 )
 from backend.routes import admin_media_moderation_routes as media_routes
-from backend.models.economy_config import set_config, save_config, EconomyConfig
+from models.economy_config import set_config, save_config, EconomyConfig
 
 
 def test_log_action_and_query(tmp_path):

--- a/backend/tests/admin/test_economy_routes.py
+++ b/backend/tests/admin/test_economy_routes.py
@@ -5,7 +5,7 @@ from fastapi import HTTPException, Request
 
 from backend.routes import admin_economy_routes as routes
 from backend.services.economy_service import EconomyService
-from backend.models.economy_config import set_config, EconomyConfig
+from models.economy_config import set_config, EconomyConfig
 
 
 def test_admin_economy_routes_require_admin():

--- a/backend/tests/admin/test_skill_persistence.py
+++ b/backend/tests/admin/test_skill_persistence.py
@@ -6,7 +6,7 @@ import types
 from fastapi import Request
 
 import backend.seeds.skill_seed as skill_seed
-from backend.models import skill_seed_store
+from models import skill_seed_store
 
 
 def test_skills_persist_across_restarts(tmp_path, monkeypatch):

--- a/backend/tests/city/test_city_trends.py
+++ b/backend/tests/city/test_city_trends.py
@@ -5,8 +5,8 @@ from datetime import datetime
 from backend.services.city_service import city_service
 from backend.services import event_service, live_performance_service, setlist_service
 from backend.services.quest_service import QuestService
-from backend.models.weather import Forecast
-from backend.models.city import City
+from models.weather import Forecast
+from models.city import City
 
 
 def setup_function(_):

--- a/backend/tests/construction/test_construction_service.py
+++ b/backend/tests/construction/test_construction_service.py
@@ -11,7 +11,7 @@ from backend.services.construction_service import ConstructionService
 from backend.services.economy_service import EconomyService
 from backend.services.property_service import PropertyService
 from backend.services.venue_service import VenueService
-from backend.models.construction import Blueprint, BuildPhase
+from models.construction import Blueprint, BuildPhase
 
 
 @pytest.fixture

--- a/backend/tests/contracts/test_negotiation_flow.py
+++ b/backend/tests/contracts/test_negotiation_flow.py
@@ -9,7 +9,7 @@ sys.path.append(str(Path(__file__).resolve().parents[3]))
 from backend.services.contract_negotiation_service import ContractNegotiationService
 from backend.services.economy_service import EconomyService
 from backend.routes import contract_routes
-from backend.models.label_management_models import NegotiationStage
+from models.label_management_models import NegotiationStage
 
 
 def setup_service():

--- a/backend/tests/dialogue/test_dialogue.py
+++ b/backend/tests/dialogue/test_dialogue.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 
 import backend.realtime.dialogue_gateway as dialogue_gateway
-from backend.models.dialogue import DialogueMessage
+from models.dialogue import DialogueMessage
 from backend.realtime.dialogue_gateway import router as dialogue_router
 from backend.services.dialogue_service import DialogueService
 from fastapi import FastAPI

--- a/backend/tests/gear/test_crafting.py
+++ b/backend/tests/gear/test_crafting.py
@@ -1,5 +1,5 @@
 from backend.services.gear_service import GearService
-from backend.models.gear import BaseItem, GearComponent, StatModifier
+from models.gear import BaseItem, GearComponent, StatModifier
 
 
 def test_crafting_success(monkeypatch):

--- a/backend/tests/labels/test_contract_negotiation_service.py
+++ b/backend/tests/labels/test_contract_negotiation_service.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.models.label_management_models import NegotiationStage
+from models.label_management_models import NegotiationStage
 from backend.services.contract_negotiation_service import ContractNegotiationService
 from backend.services.economy_service import EconomyService
 

--- a/backend/tests/legacy/test_legacy_service.py
+++ b/backend/tests/legacy/test_legacy_service.py
@@ -12,7 +12,7 @@ if str(sys_path) not in sys.path:
 from backend.services.legacy_service import LegacyService
 from backend.services.economy_service import EconomyService
 from backend.services.merch_service import MerchService
-from backend.models.merch import ProductIn, SKUIn
+from models.merch import ProductIn, SKUIn
 
 
 def setup_merch_with_legacy():

--- a/backend/tests/live_performance/test_crowd_reaction.py
+++ b/backend/tests/live_performance/test_crowd_reaction.py
@@ -3,7 +3,7 @@ import sqlite3
 
 from backend.services import live_performance_service, live_performance_analysis, setlist_service
 from backend.services.city_service import city_service
-from backend.models.city import City
+from models.city import City
 
 
 def test_crowd_reaction_adjusts_and_logs(monkeypatch, tmp_path):

--- a/backend/tests/live_performance/test_setlist_structure.py
+++ b/backend/tests/live_performance/test_setlist_structure.py
@@ -4,7 +4,7 @@ import pytest
 from backend.services import live_performance_service
 from backend.services import live_performance_analysis, setlist_service
 from backend.services.city_service import city_service
-from backend.models.city import City
+from models.city import City
 
 
 def test_simulate_gig_parses_structured_setlist(monkeypatch, tmp_path):

--- a/backend/tests/live_performance/test_skill_multiplier.py
+++ b/backend/tests/live_performance/test_skill_multiplier.py
@@ -2,9 +2,9 @@ import sqlite3
 
 from backend.services import live_performance_service, live_performance_analysis
 from backend.services.city_service import city_service
-from backend.models.city import City
+from models.city import City
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
+from models.skill import Skill
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
 

--- a/backend/tests/merch/test_merch_service.py
+++ b/backend/tests/merch/test_merch_service.py
@@ -9,7 +9,7 @@ import sys
 if str(sys_path) not in sys.path:
     sys.path.append(str(sys_path))
 
-from backend.models.merch import ProductIn, SKUIn
+from models.merch import ProductIn, SKUIn
 from backend.services.economy_service import EconomyService
 from backend.services.merch_service import MerchError, MerchService
 

--- a/backend/tests/notifications/test_schedule_reminders.py
+++ b/backend/tests/notifications/test_schedule_reminders.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from backend import database
 from backend.services import scheduler_service
-from backend.models import notification_models
+from models import notification_models
 from backend.services.notifications_service import NotificationsService
 
 

--- a/backend/tests/production/test_production_skills_bonus.py
+++ b/backend/tests/production/test_production_skills_bonus.py
@@ -1,6 +1,6 @@
 from backend.services.music_production_service import MusicProductionService
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 

--- a/backend/tests/production/test_sound_design_production.py
+++ b/backend/tests/production/test_sound_design_production.py
@@ -1,6 +1,6 @@
 from backend.services.music_production_service import MusicProductionService
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 

--- a/backend/tests/quest/test_quest_logic.py
+++ b/backend/tests/quest/test_quest_logic.py
@@ -1,4 +1,4 @@
-from backend.models.quest import Quest, QuestStage, QuestReward
+from models.quest import Quest, QuestStage, QuestReward
 from backend.services.quest_service import QuestService
 
 

--- a/backend/tests/recording/test_session_skill_effects.py
+++ b/backend/tests/recording/test_session_skill_effects.py
@@ -1,4 +1,4 @@
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.recording_service import RecordingService
 from backend.services.skill_service import skill_service

--- a/backend/tests/schedule/test_activity_processing.py
+++ b/backend/tests/schedule/test_activity_processing.py
@@ -11,8 +11,8 @@ def setup_db(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_activity_requirements.py
+++ b/backend/tests/schedule/test_activity_requirements.py
@@ -28,8 +28,8 @@ def setup_db(tmp_path):
         )
         conn.commit()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_auto_reschedule.py
+++ b/backend/tests/schedule/test_auto_reschedule.py
@@ -10,10 +10,10 @@ def setup_db(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
-    from backend.models import next_day_schedule as next_model
-    from backend.models import user_settings as settings_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
+    from models import next_day_schedule as next_model
+    from models import user_settings as settings_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_band_schedule.py
+++ b/backend/tests/schedule/test_band_schedule.py
@@ -8,9 +8,9 @@ def setup_db(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
-    from backend.models import band_schedule as band_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
+    from models import band_schedule as band_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_calendar_export.py
+++ b/backend/tests/schedule/test_calendar_export.py
@@ -12,8 +12,8 @@ def setup_app(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_conflicts.py
+++ b/backend/tests/schedule/test_conflicts.py
@@ -11,8 +11,8 @@ def setup_db(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_daily_loop_progress.py
+++ b/backend/tests/schedule/test_daily_loop_progress.py
@@ -5,7 +5,7 @@ def setup_db(tmp_path):
     db_file = tmp_path / "daily_loop.db"
     database.DB_PATH = db_file
     database.init_db()
-    from backend.models import daily_loop as dl_model
+    from models import daily_loop as dl_model
     dl_model.DB_PATH = db_file
     return dl_model
 

--- a/backend/tests/schedule/test_default_plan.py
+++ b/backend/tests/schedule/test_default_plan.py
@@ -13,10 +13,10 @@ def setup_app(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as ds_model
-    from backend.models import default_schedule as def_model
-    from backend.models import daily_loop as dl_model
+    from models import activity as activity_model
+    from models import daily_schedule as ds_model
+    from models import default_schedule as def_model
+    from models import daily_loop as dl_model
 
     activity_model.DB_PATH = db_file
     ds_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_energy_budget.py
+++ b/backend/tests/schedule/test_energy_budget.py
@@ -14,8 +14,8 @@ def setup_db(tmp_path):
     database.init_db()
 
     # Point models at the temp database
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_multi_day.py
+++ b/backend/tests/schedule/test_multi_day.py
@@ -11,8 +11,8 @@ def setup_db(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file
     import backend.services.schedule_service as service_module

--- a/backend/tests/schedule/test_plan_simulation.py
+++ b/backend/tests/schedule/test_plan_simulation.py
@@ -12,7 +12,7 @@ def setup_app(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
+    from models import activity as activity_model
 
     activity_model.DB_PATH = db_file
 

--- a/backend/tests/schedule/test_recommendations.py
+++ b/backend/tests/schedule/test_recommendations.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.routes import schedule_routes
 from backend.services.plan_service import PlanService
 from backend.services.skill_service import skill_service

--- a/backend/tests/schedule/test_recurring_templates.py
+++ b/backend/tests/schedule/test_recurring_templates.py
@@ -13,11 +13,11 @@ def setup_app(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as ds_model
-    from backend.models import default_schedule as def_model
-    from backend.models import daily_loop as dl_model
-    from backend.models import recurring_schedule as rec_model
+    from models import activity as activity_model
+    from models import daily_schedule as ds_model
+    from models import default_schedule as def_model
+    from models import daily_loop as dl_model
+    from models import recurring_schedule as rec_model
 
     activity_model.DB_PATH = db_file
     ds_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_schedule_analytics.py
+++ b/backend/tests/schedule/test_schedule_analytics.py
@@ -8,8 +8,8 @@ def setup_service(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_schedule_completion.py
+++ b/backend/tests/schedule/test_schedule_completion.py
@@ -13,9 +13,9 @@ def setup_app(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import activity_log as log_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import activity_log as log_model
+    from models import daily_schedule as schedule_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_schedule_copy.py
+++ b/backend/tests/schedule/test_schedule_copy.py
@@ -10,8 +10,8 @@ def setup_app(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_schedule_crud.py
+++ b/backend/tests/schedule/test_schedule_crud.py
@@ -10,8 +10,8 @@ def setup_db(tmp_path):
     database.init_db()
 
     # reload models to pick up patched DB_PATH
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file
     import backend.services.schedule_service as service_module

--- a/backend/tests/schedule/test_schedule_history.py
+++ b/backend/tests/schedule/test_schedule_history.py
@@ -12,8 +12,8 @@ def setup_app(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_schedule_templates.py
+++ b/backend/tests/schedule/test_schedule_templates.py
@@ -12,10 +12,10 @@ def setup_app(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as ds_model
-    from backend.models import default_schedule as def_model
-    from backend.models import default_schedule_templates as tmpl_model
+    from models import activity as activity_model
+    from models import daily_schedule as ds_model
+    from models import default_schedule as def_model
+    from models import default_schedule_templates as tmpl_model
 
     activity_model.DB_PATH = db_file
     ds_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_timezone.py
+++ b/backend/tests/schedule/test_timezone.py
@@ -9,9 +9,9 @@ def setup_db(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import daily_schedule as schedule_model
-    from backend.models import user_settings as settings_model
+    from models import activity as activity_model
+    from models import daily_schedule as schedule_model
+    from models import user_settings as settings_model
 
     activity_model.DB_PATH = db_file
     schedule_model.DB_PATH = db_file

--- a/backend/tests/schedule/test_weekly_plan.py
+++ b/backend/tests/schedule/test_weekly_plan.py
@@ -12,8 +12,8 @@ def setup_app(tmp_path):
     database.DB_PATH = db_file
     database.init_db()
 
-    from backend.models import activity as activity_model
-    from backend.models import weekly_schedule as weekly_model
+    from models import activity as activity_model
+    from models import weekly_schedule as weekly_model
 
     activity_model.DB_PATH = db_file
     weekly_model.DB_PATH = db_file

--- a/backend/tests/services/test_arrangement_service.py
+++ b/backend/tests/services/test_arrangement_service.py
@@ -1,4 +1,4 @@
-from backend.models.song import Song
+from models.song import Song
 from backend.services.arrangement_service import ArrangementService
 from backend.services.recording_service import RecordingService
 from backend.services.economy_service import EconomyService

--- a/backend/tests/services/test_event_service.py
+++ b/backend/tests/services/test_event_service.py
@@ -4,8 +4,8 @@ import pytest
 from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services import event_service
 
-from backend.models.event import Event, EventType
-from backend.models.skill import Skill
+from models.event import Event, EventType
+from models.skill import Skill
 from backend.services.skill_service import SkillService
 
 

--- a/backend/tests/services/test_npc_ai_service.py
+++ b/backend/tests/services/test_npc_ai_service.py
@@ -1,4 +1,4 @@
-from backend.models.npc import NPC
+from models.npc import NPC
 import services.npc_ai_service as npc_ai_module
 from backend.services.npc_ai_service import npc_ai_service
 from backend.services import event_service

--- a/backend/tests/services/test_skill_service_xp_items.py
+++ b/backend/tests/services/test_skill_service_xp_items.py
@@ -1,6 +1,6 @@
 import pytest
-from backend.models.skill import Skill
-from backend.models.xp_item import XPItem
+from models.skill import Skill
+from models.xp_item import XPItem
 from backend.services.skill_service import SkillService
 from backend.services.xp_item_service import XPItemService
 

--- a/backend/tests/services/test_xp_event_service.py
+++ b/backend/tests/services/test_xp_event_service.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from backend.models.xp_event import XPEvent
+from models.xp_event import XPEvent
 from backend.services.xp_event_service import XPEventService
 
 

--- a/backend/tests/skills/test_attribute_effects.py
+++ b/backend/tests/skills/test_attribute_effects.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import sessionmaker
 
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.schemas.avatar import AvatarCreate
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService

--- a/backend/tests/skills/test_discipline_effect.py
+++ b/backend/tests/skills/test_discipline_effect.py
@@ -3,8 +3,8 @@ from sqlalchemy.orm import sessionmaker
 
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
-from backend.models.skill import Skill
-from backend.models.learning_method import LearningMethod
+from models.skill import Skill
+from models.learning_method import LearningMethod
 from backend.schemas.avatar import AvatarCreate
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService

--- a/backend/tests/skills/test_fatigue_system.py
+++ b/backend/tests/skills/test_fatigue_system.py
@@ -5,8 +5,8 @@ from models.character import Character
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.models.learning_method import LearningMethod
-from backend.models.skill import Skill
+from models.learning_method import LearningMethod
+from models.skill import Skill
 from backend.schemas.avatar import AvatarCreate, AvatarUpdate
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService

--- a/backend/tests/skills/test_stamina_decay.py
+++ b/backend/tests/skills/test_stamina_decay.py
@@ -4,8 +4,8 @@ from sqlalchemy.orm import sessionmaker
 
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
-from backend.models.skill import Skill
-from backend.models.learning_method import LearningMethod
+from models.skill import Skill
+from models.learning_method import LearningMethod
 from backend.schemas.avatar import AvatarCreate
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService

--- a/backend/tests/tour/test_tour.py
+++ b/backend/tests/tour/test_tour.py
@@ -39,11 +39,11 @@ from backend.routes.tour_routes import router
 from backend.services.tour_service import TourService
 from backend.services.weather_service import WeatherService
 from backend.services.economy_service import EconomyService
-from backend.models.tour import TicketTier, Expense
-from backend.models.economy_config import set_config, EconomyConfig
+from models.tour import TicketTier, Expense
+from models.economy_config import set_config, EconomyConfig
 import importlib
 alt_economy = importlib.import_module("models.economy_config")
-from backend.models.weather import Forecast, WeatherEvent
+from models.weather import Forecast, WeatherEvent
 
 
 @pytest.fixture

--- a/backend/tests/weather/test_weather_service.py
+++ b/backend/tests/weather/test_weather_service.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from backend.models.weather import ClimateZone, Forecast, WeatherEvent
+from models.weather import ClimateZone, Forecast, WeatherEvent
 from backend.services import event_service
 from backend.services.economy_service import EconomyService
 from backend.services.property_service import PropertyService

--- a/models/daily_loop.py
+++ b/models/daily_loop.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 
 from backend.database import DB_PATH
 from backend.services.xp_reward_service import xp_reward_service
-from backend.models import weekly_drop, tier_track
+from models import weekly_drop, tier_track
 
 CHALLENGES = [
     "Practice scales",

--- a/models/skill_seed_store.py
+++ b/models/skill_seed_store.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import List
 
-from backend.models.skill import Skill
+from models.skill import Skill
 
 # Path to the JSON file storing persisted skills
 SKILL_SEED_PATH = Path(__file__).resolve().parent.parent / "database" / "skill_seed.json"

--- a/models/song.py
+++ b/models/song.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from backend.models.arrangement import ArrangementTrack
+from models.arrangement import ArrangementTrack
 
 
 class Song:

--- a/realtime/dialogue_gateway.py
+++ b/realtime/dialogue_gateway.py
@@ -5,7 +5,7 @@ from typing import List
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 
-from backend.models.dialogue import DialogueMessage
+from models.dialogue import DialogueMessage
 from backend.realtime.gateway import get_current_user_id_dep
 from backend.monitoring.websocket import track_connect, track_disconnect, track_message
 from backend.services.dialogue_service import DialogueService

--- a/routes/admin_course_routes.py
+++ b/routes/admin_course_routes.py
@@ -2,7 +2,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from auth.dependencies import get_current_user_id, require_permission
-from backend.models.course import Course
+from models.course import Course
 from services.admin_audit_service import audit_dependency
 from services.course_admin_service import course_admin_service, CourseAdminService
 from pydantic import BaseModel

--- a/routes/admin_drug_routes.py
+++ b/routes/admin_drug_routes.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from auth.dependencies import require_admin
-from backend.models.item import Item, ItemCategory
-from backend.models.drug import Drug
+from models.item import Item, ItemCategory
+from models.drug import Drug
 from services.admin_audit_service import audit_dependency
 from services.item_service import ItemService
 

--- a/routes/admin_economy_routes.py
+++ b/routes/admin_economy_routes.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 from auth.dependencies import get_current_user_id, require_permission
 from services.economy_admin_service import EconomyAdminService
-from backend.models.economy_config import EconomyConfig
+from models.economy_config import EconomyConfig
 from services.admin_audit_service import audit_dependency
 
 router = APIRouter(

--- a/routes/admin_item_routes.py
+++ b/routes/admin_item_routes.py
@@ -2,7 +2,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from auth.dependencies import get_current_user_id, require_permission
-from backend.models.item import Item
+from models.item import Item
 from services.admin_audit_service import audit_dependency
 from services.item_service import ItemService
 from pydantic import BaseModel

--- a/routes/admin_music_routes.py
+++ b/routes/admin_music_routes.py
@@ -2,12 +2,12 @@ from typing import List
 
 import backend.seeds.genre_seed as genre_seed
 import backend.seeds.skill_seed as skill_seed
-from backend.models.skill_seed_store import load_skills, save_skills
+from models.skill_seed_store import load_skills, save_skills
 import backend.seeds.stage_equipment_seed as equipment_seed
 from auth.dependencies import get_current_user_id, require_permission
-from backend.models.genre import Genre
-from backend.models.skill import Skill
-from backend.models.stage_equipment import StageEquipment
+from models.genre import Genre
+from models.skill import Skill
+from models.stage_equipment import StageEquipment
 from backend.schemas.admin_music_schema import (
     GenreSchema,
     SkillSchema,

--- a/routes/admin_online_tutorial_routes.py
+++ b/routes/admin_online_tutorial_routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from auth.dependencies import get_current_user_id, require_permission
-from backend.models.online_tutorial import OnlineTutorial
+from models.online_tutorial import OnlineTutorial
 from services.admin_audit_service import audit_dependency
 from services.online_tutorial_admin_service import (
     OnlineTutorialAdminService,

--- a/routes/admin_tutor_routes.py
+++ b/routes/admin_tutor_routes.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from auth.dependencies import get_current_user_id, require_permission
-from backend.models.tutor import Tutor
+from models.tutor import Tutor
 from services.admin_audit_service import audit_dependency
 from services.tutor_admin_service import (
     TutorAdminService,

--- a/routes/admin_workshop_routes.py
+++ b/routes/admin_workshop_routes.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from auth.dependencies import get_current_user_id, require_permission
-from backend.models.workshop import Workshop
+from models.workshop import Workshop
 from services.admin_audit_service import audit_dependency
 from services.workshop_admin_service import (
     WorkshopAdminService,

--- a/routes/admin_xp_event_routes.py
+++ b/routes/admin_xp_event_routes.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 
 from auth.dependencies import get_current_user_id, require_permission
-from backend.models.xp_event import XPEvent
+from models.xp_event import XPEvent
 from services.admin_audit_service import audit_dependency
 from services.xp_event_service import XPEventService
 from fastapi import APIRouter, Depends, HTTPException, Request

--- a/routes/admin_xp_item_routes.py
+++ b/routes/admin_xp_item_routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from auth.dependencies import get_current_user_id, require_permission
-from backend.models.xp_item import XPItem
+from models.xp_item import XPItem
 from services.admin_audit_service import audit_dependency
 from services.xp_item_service import XPItemService
 

--- a/routes/admin_xp_routes.py
+++ b/routes/admin_xp_routes.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 from auth.dependencies import get_current_user_id, require_permission
 from services.xp_admin_service import XPAdminService
-from backend.models.xp_config import XPConfig
+from models.xp_config import XPConfig
 from services.admin_audit_service import audit_dependency
 
 router = APIRouter(

--- a/routes/analytics_routes.py
+++ b/routes/analytics_routes.py
@@ -7,7 +7,7 @@ except Exception:  # pragma: no cover - fallback for stubs
         return dependency
 
 from auth.dependencies import require_permission
-from backend.models.analytics import (
+from models.analytics import (
     AggregatedMetrics,
     FanSegmentSummary,
     FanTrends,

--- a/routes/business_training_routes.py
+++ b/routes/business_training_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from services.business_training_service import business_training_service
 
 router = APIRouter(prefix="/training/business", tags=["BusinessTraining"])

--- a/routes/daily_loop_routes.py
+++ b/routes/daily_loop_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from backend.models import daily_loop
+from models import daily_loop
 
 router = APIRouter(prefix="/daily", tags=["DailyLoop"])
 

--- a/routes/festival_builder_routes.py
+++ b/routes/festival_builder_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 
 from auth.dependencies import get_current_user_id, require_permission
-from backend.models.festival_builder import FestivalBuilder
+from models.festival_builder import FestivalBuilder
 from services.festival_builder_service import (
     BookingConflictError,
     FestivalBuilderService,

--- a/routes/gig.py
+++ b/routes/gig.py
@@ -11,7 +11,7 @@ from utils.i18n import _
 from services.band_service import BandService
 from services.skill_service import skill_service as skill_service_instance
 from services.fame_service import FameService
-from backend.models.skill import Skill
+from models.skill import Skill
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
 band_service = BandService()

--- a/routes/image_training_routes.py
+++ b/routes/image_training_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from services.image_training_service import image_training_service
 
 router = APIRouter(prefix="/training/image", tags=["ImageTraining"])

--- a/routes/learning_routes.py
+++ b/routes/learning_routes.py
@@ -3,8 +3,8 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from backend.models.learning_method import LearningMethod
-from backend.models.skill import Skill
+from models.learning_method import LearningMethod
+from models.skill import Skill
 from services.skill_service import SkillService
 
 router = APIRouter(prefix="/learning", tags=["Learning"])

--- a/routes/merch_routes.py
+++ b/routes/merch_routes.py
@@ -3,7 +3,7 @@ from typing import List
 from auth.dependencies import get_current_user_id, require_permission  # noqa: F401
 from services.economy_service import EconomyService
 from services.merch_service import MerchError, MerchService
-from backend.models.merch import ProductIn, SKUIn
+from models.merch import ProductIn, SKUIn
 from fastapi import APIRouter, Depends, HTTPException, Request  # noqa: F401
 from pydantic import BaseModel
 

--- a/routes/payment_routes.py
+++ b/routes/payment_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from backend.models.payment import SubscriptionPlan
+from models.payment import SubscriptionPlan
 from services.economy_service import EconomyService
 from services.payment_service import (
     PaymentError,

--- a/routes/playlist_routes.py
+++ b/routes/playlist_routes.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from backend.models.playlist import Playlist
+from models.playlist import Playlist
 
 router = APIRouter()
 

--- a/routes/quest_routes.py
+++ b/routes/quest_routes.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from services.quest_service import QuestService
-from backend.models.quest import QuestStage, QuestReward
+from models.quest import QuestStage, QuestReward
 
 
 quest_routes = APIRouter()

--- a/routes/songwriting_routes.py
+++ b/routes/songwriting_routes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisco
 from pydantic import BaseModel, validator
 
 from auth.dependencies import get_current_user_id
-from backend.models.theme import THEMES
+from models.theme import THEMES
 from services.skill_service import skill_service
 from services.songwriting_service import songwriting_service
 

--- a/routes/user_settings_routes.py
+++ b/routes/user_settings_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from backend.models import user_settings
+from models import user_settings
 
 router = APIRouter(prefix="/user-settings", tags=["UserSettings"])
 

--- a/routes/weather_routes.py
+++ b/routes/weather_routes.py
@@ -1,4 +1,4 @@
-from backend.models.weather import Forecast
+from models.weather import Forecast
 from services.weather_service import weather_service
 from fastapi import APIRouter
 from pydantic import BaseModel

--- a/seeds/genre_seed.py
+++ b/seeds/genre_seed.py
@@ -2,7 +2,7 @@
 
 """Seed data for music genres with demographic preferences."""
 
-from backend.models.genre import Genre
+from models.genre import Genre
 
 SEED_GENRES = [
     Genre(

--- a/seeds/quest_data.py
+++ b/seeds/quest_data.py
@@ -1,4 +1,4 @@
-from backend.models.quest import Quest, QuestStage, QuestReward
+from models.quest import Quest, QuestStage, QuestReward
 
 
 def get_seed_quests():

--- a/seeds/question_seed.py
+++ b/seeds/question_seed.py
@@ -1,6 +1,6 @@
 """Seed data for onboarding questions."""
 
-from backend.models.onboarding import Question, QuestionOption
+from models.onboarding import Question, QuestionOption
 
 # Define the first question with distinct options.
 QUESTIONS: list[Question] = [

--- a/seeds/stage_equipment_seed.py
+++ b/seeds/stage_equipment_seed.py
@@ -1,4 +1,4 @@
-from backend.models.stage_equipment import StageEquipment
+from models.stage_equipment import StageEquipment
 
 # Parody stage equipment with genre affinities and 11-star rating system
 SEED_STAGE_EQUIPMENT = [

--- a/seeds/weather_seed.py
+++ b/seeds/weather_seed.py
@@ -1,6 +1,6 @@
 """Seed initial climate zones."""
 
-from backend.models.weather import ClimateZone
+from models.weather import ClimateZone
 
 
 def get_seed_climate_zones():

--- a/services/achievement_service.py
+++ b/services/achievement_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from backend.models.achievement import Achievement, PlayerAchievement
+from models.achievement import Achievement, PlayerAchievement
 from core.config import settings
 from utils.db import get_conn
 

--- a/services/activity_processor.py
+++ b/services/activity_processor.py
@@ -8,8 +8,8 @@ from datetime import date, timedelta
 from typing import Dict, List
 
 from backend.database import DB_PATH
-from backend.models import activity_log as activity_log_model
-from backend.models import user_settings
+from models import activity_log as activity_log_model
+from models import user_settings
 
 
 def _ensure_tables(cur: sqlite3.Cursor) -> None:

--- a/services/apprenticeship_service.py
+++ b/services/apprenticeship_service.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 
 from backend.database import DB_PATH
-from backend.models.apprenticeship import Apprenticeship
+from models.apprenticeship import Apprenticeship
 from backend.services.karma_service import KarmaService
 
 

--- a/services/arrangement_service.py
+++ b/services/arrangement_service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
-from backend.models.arrangement import ArrangementTrack
-from backend.models.song import Song
+from models.arrangement import ArrangementTrack
+from models.song import Song
 from backend.services.recording_service import RecordingService, recording_service
 
 

--- a/services/attribute_service.py
+++ b/services/attribute_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, Tuple
 
-from backend.models.attribute import Attribute
+from models.attribute import Attribute
 from backend.services.perk_service import perk_service
 
 

--- a/services/audio_mixing_service.py
+++ b/services/audio_mixing_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 

--- a/services/band_relationship_service.py
+++ b/services/band_relationship_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from backend.models.band_relationship import BandRelationship
+from models.band_relationship import BandRelationship
 
 
 @dataclass

--- a/services/band_service.py
+++ b/services/band_service.py
@@ -19,7 +19,7 @@ from backend.services.chemistry_service import ChemistryService
 from backend.services.band_relationship_service import BandRelationshipService
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService
-from backend.models.skill import Skill
+from models.skill import Skill
 
 # ---------------------------------------------------------------------------
 # Database setup

--- a/services/bank_service.py
+++ b/services/bank_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 
-from backend.models.banking import InterestAccount, Loan
+from models.banking import InterestAccount, Loan
 from backend.utils.logging import get_logger
 from .economy_service import EconomyService, EconomyError
 

--- a/services/books_service.py
+++ b/services/books_service.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Dict, List
 
-from backend.models.book import Book
-from backend.models.skill import Skill
-from backend.models.learning_method import LearningMethod
+from models.book import Book
+from models.skill import Skill
+from models.learning_method import LearningMethod
 from backend.services.skill_service import skill_service
 
 

--- a/services/business_service.py
+++ b/services/business_service.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 

--- a/services/business_training_service.py
+++ b/services/business_training_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service

--- a/services/chemistry_service.py
+++ b/services/chemistry_service.py
@@ -11,7 +11,7 @@ from sqlalchemy import create_engine, func
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 
-from backend.models.player_chemistry import Base, PlayerChemistry
+from models.player_chemistry import Base, PlayerChemistry
 
 DB_PATH = Path(__file__).resolve().parents[1] / "database" / "rockmundo.db"
 DATABASE_URL = f"sqlite:///{DB_PATH}"

--- a/services/city_service.py
+++ b/services/city_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import random
 from typing import Dict, List
 
-from backend.models.city import City
+from models.city import City
 
 
 class CityService:

--- a/services/contract_negotiation_service.py
+++ b/services/contract_negotiation_service.py
@@ -9,8 +9,8 @@ from sqlalchemy import JSON, Column, Integer, create_engine
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
-from backend.models.label_management_models import NegotiationStage
-from backend.models.record_contract import RecordContract, RoyaltyTier
+from models.label_management_models import NegotiationStage
+from models.record_contract import RecordContract, RoyaltyTier
 from backend.services.economy_service import EconomyService
 
 Base = declarative_base()

--- a/services/course_admin_service.py
+++ b/services/course_admin_service.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from backend.database import DB_PATH
-from backend.models.course import Course
+from models.course import Course
 
 
 class CourseAdminService:

--- a/services/dialogue_service.py
+++ b/services/dialogue_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import List, Optional, Protocol
 
-from backend.models.dialogue import DialogueMessage
+from models.dialogue import DialogueMessage
 from backend.services.moderation_service import moderate_content
 
 

--- a/services/economy_admin_service.py
+++ b/services/economy_admin_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List
 
-from backend.models.economy_config import (
+from models.economy_config import (
     EconomyConfig,
     get_config,
     set_config,

--- a/services/economy_service.py
+++ b/services/economy_service.py
@@ -7,8 +7,8 @@ from typing import Optional
 
 from backend.services.xp_reward_service import xp_reward_service
 
-from backend.models.banking import Loan
-from backend.models.economy_config import get_config
+from models.banking import Loan
+from models.economy_config import get_config
 from backend.utils.logging import get_logger
 
 from sqlalchemy import create_engine, select, or_

--- a/services/event_service.py
+++ b/services/event_service.py
@@ -8,10 +8,10 @@ from typing import Any, Dict, List
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
 from backend.database import DB_PATH
-from backend.models.event import Event
-from backend.models.event_effect import EventEffect
-from backend.models.npc import NPC
-from backend.models.skill import Skill
+from models.event import Event
+from models.event_effect import EventEffect
+from models.npc import NPC
+from models.skill import Skill
 
 from .city_service import city_service
 from .npc_ai_service import npc_ai_service

--- a/services/fan_insight_service.py
+++ b/services/fan_insight_service.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 
 from utils.db import cached_query
 
-from backend.models.analytics import (
+from models.analytics import (
     AgeBucket,
     FanSegmentSummary,
     FanTrends,

--- a/services/fan_service.py
+++ b/services/fan_service.py
@@ -1,7 +1,7 @@
 import sqlite3
 
 from backend.database import DB_PATH
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import skill_service

--- a/services/festival_builder_service.py
+++ b/services/festival_builder_service.py
@@ -6,15 +6,15 @@ from typing import Dict, List, Optional
 from backend.services.economy_service import EconomyService
 from backend.services.legacy_service import LegacyService
 
-from backend.models.festival import FestivalProposal
-from backend.models.festival_builder import (
+from models.festival import FestivalProposal
+from models.festival_builder import (
     FestivalBuilder,
     Slot,
     Sponsor,
     Stage,
     TicketTier,
 )
-from backend.models.ticketing_models import Ticket
+from models.ticketing_models import Ticket
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/gear_service.py
+++ b/services/gear_service.py
@@ -6,7 +6,7 @@ from dataclasses import asdict
 from itertools import chain
 from typing import Dict, List
 
-from backend.models.gear import BaseItem, GearComponent, GearItem, StatModifier
+from models.gear import BaseItem, GearComponent, GearItem, StatModifier
 
 
 class GearService:

--- a/services/gig_service.py
+++ b/services/gig_service.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta
 from backend.database import DB_PATH
 from backend.services import fan_service
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
-from backend.models.learning_method import LearningMethod
+from models.skill import Skill
+from models.learning_method import LearningMethod
 from backend.services.economy_service import EconomyService
 
 try:  # pragma: no cover - optional in minimal environments

--- a/services/image_training_service.py
+++ b/services/image_training_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service

--- a/services/indie_release_service.py
+++ b/services/indie_release_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from backend.models.label_management_models import ClauseTemplate
+from models.label_management_models import ClauseTemplate
 from backend.services.economy_service import EconomyService
 
 

--- a/services/jam_service.py
+++ b/services/jam_service.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import Dict, Optional, Set
 
-from backend.models.jam_session import AudioStream, JamSession
+from models.jam_session import AudioStream, JamSession
 from backend.services.economy_service import EconomyService
 
 STUDIO_RENTAL_CENTS = 100

--- a/services/karma_db.py
+++ b/services/karma_db.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import List, Dict, Any
 
 from backend.database import DB_PATH
-from backend.models.karma_event import KarmaEvent
+from models.karma_event import KarmaEvent
 
 
 class KarmaDB:

--- a/services/lifestyle_service.py
+++ b/services/lifestyle_service.py
@@ -5,7 +5,7 @@ import random
 import sqlite3
 
 from backend.database import DB_PATH
-from backend.models import notification_models
+from models import notification_models
 
 from .skill_service import skill_service
 from .xp_reward_service import xp_reward_service
@@ -19,7 +19,7 @@ EXERCISE_COOLDOWN = timedelta(hours=6)
 EXERCISE_FITNESS_BONUS = 5
 
 
-from backend.models import activity as activity_models
+from models import activity as activity_models
 
 _ACTIVITY_MAP = {
     "gym": activity_models.gym,

--- a/services/live_performance_service.py
+++ b/services/live_performance_service.py
@@ -6,7 +6,7 @@ from typing import Dict, Generator, Iterable, Optional
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
+from models.skill import Skill
 
 from backend.database import DB_PATH
 from backend.services import live_performance_analysis

--- a/services/marketing_ai_service.py
+++ b/services/marketing_ai_service.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 from typing import Dict, List
 
-from backend.models.promotion import Promotion
+from models.promotion import Promotion
 
 # In-memory storage for accepted promotions
 _promotions_db: List[Promotion] = []

--- a/services/merch_service.py
+++ b/services/merch_service.py
@@ -3,7 +3,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.models.merch import CartItem, ProductIn, SKUIn
+from models.merch import CartItem, ProductIn, SKUIn
 from backend.services.economy_service import EconomyError, EconomyService
 from backend.services.payment_service import PaymentError, PaymentService
 from backend.services.legacy_service import LegacyService

--- a/services/music_production_service.py
+++ b/services/music_production_service.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 """Music production utilities influenced by avatar tech savvy."""
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.avatar_service import AvatarService
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 

--- a/services/npc_ai_service.py
+++ b/services/npc_ai_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 from typing import Dict, List, Optional
 
-from backend.models.npc import NPC
+from models.npc import NPC
 
 
 class NPCAIService:

--- a/services/npc_service.py
+++ b/services/npc_service.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import random
 from typing import Dict, List, Optional
 
-from backend.models.npc import NPC
-from backend.models.npc_dialogue import DialogueTree
+from models.npc import NPC
+from models.npc_dialogue import DialogueTree
 
 
 # Simple seasonal event definitions used by ``generate_seasonal_event``.

--- a/services/onboarding_question_service.py
+++ b/services/onboarding_question_service.py
@@ -3,7 +3,7 @@
 import random
 from typing import Dict, List
 
-from backend.models.onboarding import Question
+from models.onboarding import Question
 from backend.seeds.question_seed import QUESTIONS
 
 

--- a/services/online_tutorial_admin_service.py
+++ b/services/online_tutorial_admin_service.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import List, Optional
 
-from backend.models.online_tutorial import OnlineTutorial
+from models.online_tutorial import OnlineTutorial
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/originality_service.py
+++ b/services/originality_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import hashlib
 from typing import Dict, Tuple
 
-from backend.models.lyric_hash import LyricHash
+from models.lyric_hash import LyricHash
 
 
 class OriginalityService:

--- a/services/payment_service.py
+++ b/services/payment_service.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional
 from uuid import uuid4
 
-from backend.models.payment import PremiumCurrency, PurchaseRecord, SubscriptionPlan
+from models.payment import PremiumCurrency, PurchaseRecord, SubscriptionPlan
 from backend.services.economy_service import EconomyService
 
 

--- a/services/peer_learning_service.py
+++ b/services/peer_learning_service.py
@@ -5,7 +5,7 @@ import sqlite3
 from typing import Iterable, List
 
 from backend.database import DB_PATH
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.services.skill_service import skill_service
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 

--- a/services/production_service.py
+++ b/services/production_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
-from backend.models.production import (
+from models.production import (
     MixingSession,
     ReleaseMetadata,
     StudioSession,

--- a/services/quest_admin_service.py
+++ b/services/quest_admin_service.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.models.quest import (
+from models.quest import (
     QuestDB,
     QuestStageDB,
     QuestBranchDB,

--- a/services/quest_service.py
+++ b/services/quest_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from backend.models.quest import Quest, QuestReward, QuestStage
+from models.quest import Quest, QuestReward, QuestStage
 from backend.services.city_service import city_service
 from backend.services.quest_admin_service import QuestAdminService
 from backend.services.xp_event_service import XPEventService

--- a/services/random_event_service.py
+++ b/services/random_event_service.py
@@ -2,9 +2,9 @@ import random
 
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
-from backend.models.random_event import RandomEvent
-from backend.models.random_events import ADDICTION_EVENTS
-from backend.models.skill import Skill
+from models.random_event import RandomEvent
+from models.random_events import ADDICTION_EVENTS
+from models.skill import Skill
 from backend.services.addiction_service import addiction_service
 from backend.services.notifications_service import NotificationsService
 from backend.services.skill_service import skill_service

--- a/services/recording_service.py
+++ b/services/recording_service.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
-from backend.models.learning_method import LearningMethod
-from backend.models.recording_session import RecordingSession
-from backend.models.skill import Skill
+from models.learning_method import LearningMethod
+from models.recording_session import RecordingSession
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.chemistry_service import ChemistryService
 from backend.services.economy_service import EconomyError, EconomyService

--- a/services/reputation_service.py
+++ b/services/reputation_service.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from backend.database import DB_PATH
-from backend.models.reputation import ReputationEvent
+from models.reputation import ReputationEvent
 
 
 class ReputationService:

--- a/services/schedule_service.py
+++ b/services/schedule_service.py
@@ -72,15 +72,15 @@ __all__ = ["save_daily_plan"]
 
 from typing import List, Dict, Iterable
 
-from backend.models import activity as activity_model
-from backend.models import band_schedule as band_schedule_model
-from backend.models import daily_schedule as schedule_model
-from backend.models import next_day_schedule as next_day_model
-from backend.models import default_schedule as default_model
-from backend.models import weekly_schedule as weekly_model
-from backend.models import recurring_schedule as recurring_model
-from backend.models import default_schedule_templates as template_model
-from backend.models import user_settings
+from models import activity as activity_model
+from models import band_schedule as band_schedule_model
+from models import daily_schedule as schedule_model
+from models import next_day_schedule as next_day_model
+from models import default_schedule as default_model
+from models import weekly_schedule as weekly_model
+from models import recurring_schedule as recurring_model
+from models import default_schedule_templates as template_model
+from models import user_settings
 
 
 def _log_schedule_change(user_id: int, date: str, slot: int, before, after) -> None:

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -3,8 +3,8 @@ import sqlite3
 from datetime import date, datetime, timedelta
 
 from backend.database import DB_PATH
-from backend.models import daily_loop
-from backend.models.notification_models import (
+from models import daily_loop
+from models.notification_models import (
     alert_no_plan,
     alert_pending_outcomes,
 )

--- a/services/shop_npc_service.py
+++ b/services/shop_npc_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Dict, List, Optional
 
-from backend.models.npc_dialogue import DialogueNode, DialogueResponse, DialogueTree
+from models.npc_dialogue import DialogueNode, DialogueResponse, DialogueTree
 from backend.services.npc_service import NPCService
 from backend.services.city_shop_service import CityShopService, city_shop_service
 from backend.services.item_service import item_service as default_item_service, ItemService

--- a/services/social_media_training_service.py
+++ b/services/social_media_training_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service

--- a/services/songwriting_service.py
+++ b/services/songwriting_service.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Set
 
-from backend.models.song import Song
-from backend.models.song_draft_version import SongDraftVersion
-from backend.models.songwriting import GenerationMetadata, LyricDraft
-from backend.models.theme import THEMES
+from models.song import Song
+from models.song_draft_version import SongDraftVersion
+from models.songwriting import GenerationMetadata, LyricDraft
+from models.theme import THEMES
 from backend.services.ai_art_service import AIArtService, ai_art_service
 from backend.services.band_service import BandService
 from backend.services.chemistry_service import ChemistryService

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -6,7 +6,7 @@ try:  # pragma: no cover - prefer local stub if available
 except ModuleNotFoundError:  # pragma: no cover - fallback to package
     import aiosqlite  # type: ignore
 from backend.database import DB_PATH
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 from backend.services.song_popularity_service import add_event

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 import sqlite3
 
-from backend.models.tournament import Bracket, Match, Score
+from models.tournament import Bracket, Match, Score
 from backend.services import live_performance_service
 from backend.database import DB_PATH
 

--- a/services/tutor_admin_service.py
+++ b/services/tutor_admin_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from typing import List, Optional
 
 from backend.database import DB_PATH
-from backend.models.tutor import Tutor
+from models.tutor import Tutor
 
 
 class TutorAdminService:

--- a/services/tutor_service.py
+++ b/services/tutor_service.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Dict, Optional
 
-from backend.models.tutor import Tutor
-from backend.models.skill import Skill
-from backend.models.learning_method import LearningMethod, METHOD_PROFILES
+from models.tutor import Tutor
+from models.skill import Skill
+from models.learning_method import LearningMethod, METHOD_PROFILES
 from backend.services.avatar_service import AvatarService
 from backend.services.economy_service import EconomyService
 from backend.services.skill_service import SkillService, skill_service

--- a/services/university_service.py
+++ b/services/university_service.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from typing import List
 
 from backend.database import DB_PATH
-from backend.models.course import Course
-from backend.models.skill import Skill
+from models.course import Course
+from models.skill import Skill
 from backend.services.skill_service import SkillService
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 

--- a/services/venue_sponsorships_service.py
+++ b/services/venue_sponsorships_service.py
@@ -10,7 +10,7 @@ from backend.config.revenue import (
     SPONSOR_IMPRESSION_RATE_CENTS,
     SPONSOR_PAYOUT_SPLIT,
 )
-from backend.models.venue_sponsorship import (
+from models.venue_sponsorship import (
     NegotiationStage,
     SponsorshipNegotiation,
 )

--- a/services/video_service.py
+++ b/services/video_service.py
@@ -4,7 +4,7 @@ import time
 from datetime import datetime
 from typing import Dict, List
 
-from backend.models.video import Video
+from models.video import Video
 from backend.services.economy_service import EconomyService
 from backend.services.media_moderation_service import media_moderation_service
 from backend.services.skill_service import SkillService

--- a/services/vocal_training_service.py
+++ b/services/vocal_training_service.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from backend.models.learning_method import LearningMethod
-from backend.models.skill import Skill
+from models.learning_method import LearningMethod
+from models.skill import Skill
 from backend.seeds.skill_seed import SEED_SKILLS
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service

--- a/services/weather_service.py
+++ b/services/weather_service.py
@@ -5,7 +5,7 @@ import random
 from datetime import date
 from typing import Dict, List, Optional
 
-from backend.models.weather import ClimateZone, Forecast, WeatherEvent
+from models.weather import ClimateZone, Forecast, WeatherEvent
 
 
 class WeatherService:

--- a/services/workshop_admin_service.py
+++ b/services/workshop_admin_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from typing import List, Optional
 
 from backend.database import DB_PATH
-from backend.models.workshop import Workshop
+from models.workshop import Workshop
 
 
 class WorkshopAdminService:

--- a/services/xp_admin_service.py
+++ b/services/xp_admin_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from backend.models.xp_config import (
+from models.xp_config import (
     XPConfig,
     get_config,
     set_config,

--- a/services/xp_reward_service.py
+++ b/services/xp_reward_service.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
-from backend.models.xp_config import get_config
+from models.xp_config import get_config
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/tests/admin/test_admin_skill_routes.py
+++ b/tests/admin/test_admin_skill_routes.py
@@ -11,7 +11,7 @@ sys.path.append(str(BASE))
 sys.path.append(str(BASE / "backend"))
 
 import backend.seeds.skill_seed as skill_seed
-from backend.models import skill_seed_store
+from models import skill_seed_store
 
 
 def test_prerequisites_persist_across_restarts(tmp_path, monkeypatch):

--- a/tests/live_album/test_audio_mixing.py
+++ b/tests/live_album/test_audio_mixing.py
@@ -3,7 +3,7 @@ import sqlite3
 
 import pytest
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services import audio_mixing_service
 from backend.services.live_album_service import LiveAlbumService

--- a/tests/test_exercise_cooldown.py
+++ b/tests/test_exercise_cooldown.py
@@ -4,7 +4,7 @@ import types
 from datetime import datetime, timedelta
 
 import pytest
-from backend.models.activity import gym, running, yoga
+from models.activity import gym, running, yoga
 
 utils_mod = types.ModuleType("utils")
 utils_db_mod = types.ModuleType("utils.db")
@@ -15,7 +15,7 @@ sys.modules["utils.db"] = utils_db_mod
 
 from backend.services import lifestyle_service
 from backend.services.notifications_service import NotificationsService
-from backend.models import notification_models
+from models import notification_models
 
 
 def test_exercise_cooldown(monkeypatch, tmp_path):

--- a/tests/test_gig_skill_multiplier.py
+++ b/tests/test_gig_skill_multiplier.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from backend.services import gig_service as gs
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
+from models.skill import Skill
 from seeds.skill_seed import SKILL_NAME_TO_ID
 
 

--- a/tests/test_image_skills.py
+++ b/tests/test_image_skills.py
@@ -8,7 +8,7 @@ sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
 from backend.seeds.skill_seed import SEED_SKILLS
-from backend.models.learning_method import METHOD_PROFILES, LearningMethod
+from models.learning_method import METHOD_PROFILES, LearningMethod
 from backend.services import fan_interaction_service, fan_service
 from backend.services.image_training_service import (
     Stylist,

--- a/tests/test_live_streaming.py
+++ b/tests/test_live_streaming.py
@@ -1,6 +1,6 @@
 from backend.services import streaming_service as ss
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 

--- a/tests/test_perk_service.py
+++ b/tests/test_perk_service.py
@@ -5,8 +5,8 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
-from backend.models.perk import Perk
-from backend.models.skill import Skill
+from models.perk import Perk
+from models.skill import Skill
 from backend.services.attribute_service import AttributeService
 from backend.services.perk_service import perk_service
 from backend.services.skill_service import SkillService

--- a/tests/test_practice_xp.py
+++ b/tests/test_practice_xp.py
@@ -7,7 +7,7 @@ sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
 from backend.services.skill_service import skill_service
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 
 

--- a/tests/test_skill_category_multiplier.py
+++ b/tests/test_skill_category_multiplier.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from backend.models.skill import Skill
+from models.skill import Skill
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services import gig_service as gs
 from backend.services.skill_service import SkillService, skill_service

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -41,10 +41,10 @@ sys.modules["backend.services.avatar_service"] = types.SimpleNamespace(
     AvatarService=DummyAvatarService
 )
 
-from backend.models.item import Item
-from backend.models.learning_method import LearningMethod
-from backend.models.skill import Skill, SkillSpecialization
-from backend.models.xp_config import XPConfig, get_config, set_config
+from models.item import Item
+from models.learning_method import LearningMethod
+from models.skill import Skill, SkillSpecialization
+from models.xp_config import XPConfig, get_config, set_config
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
 from backend.seeds.skill_seed import SKILL_NAME_TO_ID

--- a/tests/test_tutor_service.py
+++ b/tests/test_tutor_service.py
@@ -3,9 +3,9 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.models.learning_method import METHOD_PROFILES, LearningMethod
-from backend.models.skill import Skill
-from backend.models.tutor import Tutor
+from models.learning_method import METHOD_PROFILES, LearningMethod
+from models.skill import Skill
+from models.tutor import Tutor
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from backend.services.economy_service import EconomyService

--- a/tests/test_xp_reward_baseline.py
+++ b/tests/test_xp_reward_baseline.py
@@ -7,7 +7,7 @@ root_dir = Path(__file__).resolve().parents[1]
 sys.path.append(str(root_dir))
 sys.path.append(str(root_dir / "backend"))
 
-from backend.models.xp_config import XPConfig, set_config  # noqa: E402
+from models.xp_config import XPConfig, set_config  # noqa: E402
 from backend.services import scheduler_service, xp_reward_service  # noqa: E402
 
 


### PR DESCRIPTION
## Summary
- replace `from backend.models` imports with `from models`

## Testing
- `pytest -q` *(fails: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c73d5f61c88325a4827a0339fae339