### PR TITLE
refactor: update schema imports

### DIFF
--- a/backend/tests/skills/test_attribute_effects.py
+++ b/backend/tests/skills/test_attribute_effects.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import sessionmaker
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from backend.models.skill import Skill
-from backend.schemas.avatar import AvatarCreate
+from schemas.avatar import AvatarCreate
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService
 

--- a/backend/tests/skills/test_discipline_effect.py
+++ b/backend/tests/skills/test_discipline_effect.py
@@ -5,7 +5,7 @@ from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
-from backend.schemas.avatar import AvatarCreate
+from schemas.avatar import AvatarCreate
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService
 

--- a/backend/tests/skills/test_fatigue_system.py
+++ b/backend/tests/skills/test_fatigue_system.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import sessionmaker
 
 from backend.models.learning_method import LearningMethod
 from backend.models.skill import Skill
-from backend.schemas.avatar import AvatarCreate, AvatarUpdate
+from schemas.avatar import AvatarCreate, AvatarUpdate
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService
 

--- a/backend/tests/skills/test_stamina_decay.py
+++ b/backend/tests/skills/test_stamina_decay.py
@@ -6,7 +6,7 @@ from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
 from backend.models.skill import Skill
 from backend.models.learning_method import LearningMethod
-from backend.schemas.avatar import AvatarCreate
+from schemas.avatar import AvatarCreate
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import SkillService
 

--- a/backend/tests/social/test_fan_charisma.py
+++ b/backend/tests/social/test_fan_charisma.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import sessionmaker
 
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
-from backend.schemas.avatar import AvatarCreate
+from schemas.avatar import AvatarCreate
 from backend.services.avatar_service import AvatarService
 from backend.services.fan_club_service import FanClubService
 

--- a/backend/tests/social/test_fan_service_charisma.py
+++ b/backend/tests/social/test_fan_service_charisma.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import sessionmaker
 
 from models.avatar import Base as AvatarBase
 from models.character import Base as CharacterBase, Character
-from backend.schemas.avatar import AvatarCreate
+from schemas.avatar import AvatarCreate
 from backend.services.avatar_service import AvatarService
 from backend.services import fan_service
 

--- a/routes/admin_events_routes.py
+++ b/routes/admin_events_routes.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 from fastapi import APIRouter, Depends
 
 from auth.dependencies import require_permission
-from backend.schemas.events_schemas import (
+from schemas.events_schemas import (
     EndEventSchema,
     EventResponse,
     ScheduleEventSchema,

--- a/routes/admin_music_routes.py
+++ b/routes/admin_music_routes.py
@@ -8,7 +8,7 @@ from auth.dependencies import get_current_user_id, require_permission
 from backend.models.genre import Genre
 from backend.models.skill import Skill
 from backend.models.stage_equipment import StageEquipment
-from backend.schemas.admin_music_schema import (
+from schemas.admin_music_schema import (
     GenreSchema,
     SkillSchema,
     SkillPrerequisitesSchema,

--- a/routes/event_routes.py
+++ b/routes/event_routes.py
@@ -11,7 +11,7 @@ from services.event_service import (
     roll_for_daily_event,
 )
 
-from backend.schemas.events_schemas import EventRollRequest, EventRollResponse
+from schemas.events_schemas import EventRollRequest, EventRollResponse
 
 router = APIRouter()
 

--- a/routes/events_routes.py
+++ b/routes/events_routes.py
@@ -13,7 +13,7 @@ from services.events_service import (
     schedule_event,
 )
 
-from backend.schemas.events_schemas import (
+from schemas.events_schemas import (
     ActiveEventResponse,
     CreateEventSchema,
     EndEventSchema,

--- a/routes/labels_routes.py
+++ b/routes/labels_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends
 
 from auth.dependencies import require_permission
-from backend.schemas.labels_schemas import (
+from schemas.labels_schemas import (
     LabelCreateSchema,
     OfferRequestSchema,
     CounterOfferSchema,

--- a/routes/onboarding_routes.py
+++ b/routes/onboarding_routes.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from backend.schemas.onboarding import (
+from schemas.onboarding import (
     AnswersSchema,
     EvaluationResponse,
     QuestionSchema,

--- a/services/gig_service.py
+++ b/services/gig_service.py
@@ -21,7 +21,7 @@ except Exception:  # pragma: no cover
 
 try:  # pragma: no cover - optional avatar dependency
     from backend.services.avatar_service import AvatarService
-    from backend.schemas.avatar import AvatarUpdate
+    from schemas.avatar import AvatarUpdate
 except Exception:  # pragma: no cover
     class AvatarUpdate:  # type: ignore
         def __init__(self, **kwargs):

--- a/tests/test_gig_persistence.py
+++ b/tests/test_gig_persistence.py
@@ -54,7 +54,7 @@ def test_gig_completion_persists_services(monkeypatch, tmp_path):
         AvatarService as AvatarSvc,
     )
     from backend.services.economy_service import EconomyService as EconSvc
-    from backend.schemas.avatar import AvatarCreate
+    from schemas.avatar import AvatarCreate
     from models.avatar import Base as AvatarBase
     from models import avatar_skin  # noqa: F401
 

--- a/tests/test_tutor_service.py
+++ b/tests/test_tutor_service.py
@@ -12,7 +12,7 @@ from backend.services.economy_service import EconomyService
 from backend.services.skill_service import SkillService
 from backend.services.tutor_service import TutorService
 from backend.services.avatar_service import AvatarService
-from backend.schemas.avatar import AvatarCreate, AvatarUpdate
+from schemas.avatar import AvatarCreate, AvatarUpdate
 
 
 def _setup_services(tmp_path):


### PR DESCRIPTION
## Summary
- refactor tests and routes to import from new `schemas` package instead of `backend.schemas`
- adjust service imports for Avatar schemas

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'backend')

------
https://chatgpt.com/codex/tasks/task_e_68c73d60d5188325ad5b7933f655f41e