### PR TITLE
refactor: simplify job imports

### DIFF
--- a/backend/tests/analytics/test_seasonal_scores.py
+++ b/backend/tests/analytics/test_seasonal_scores.py
@@ -2,8 +2,8 @@ import sqlite3
 
 import pytest
 
-from backend.jobs.world_pulse_jobs import run_daily
 from backend.services.season_service import activate_season
+from jobs.world_pulse_jobs import run_daily
 
 DDL = """
 PRAGMA foreign_keys = ON;

--- a/backend/tests/auth/test_token_cleanup.py
+++ b/backend/tests/auth/test_token_cleanup.py
@@ -1,9 +1,7 @@
 import sqlite3
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
-from backend.jobs import cleanup_tokens
+from jobs import cleanup_tokens
 
 
 def _iso(dt: datetime) -> str:

--- a/backend/tests/royalties/test_sponsorship_reconciliation.py
+++ b/backend/tests/royalties/test_sponsorship_reconciliation.py
@@ -1,10 +1,9 @@
 import asyncio
 import sqlite3
-from pathlib import Path
 
 from backend.config import revenue
-from backend.jobs import sponsor_reconciliation_job
 from backend.services.sponsorship_service import SponsorshipService
+from jobs import sponsor_reconciliation_job
 
 
 def _setup_db(db_path: str) -> None:

--- a/backend/tests/services/test_song_service.py
+++ b/backend/tests/services/test_song_service.py
@@ -1,8 +1,8 @@
 import pytest
 
 from backend.services.song_service import SongService
-from backend.jobs.royalty_clearing_job import run as royalty_run
 from backend.utils.db import aget_conn
+from jobs.royalty_clearing_job import run as royalty_run
 
 
 async def setup_db(path):

--- a/backend/tests/test_backup_rotation.py
+++ b/backend/tests/test_backup_rotation.py
@@ -3,7 +3,8 @@ import os
 import sqlite3
 import time
 
-from backend.jobs import backup_db
+from jobs import backup_db
+
 
 def test_backup_rotation(tmp_path):
     db = tmp_path / "app.db"

--- a/backend/tests/test_data_hygiene_jobs.py
+++ b/backend/tests/test_data_hygiene_jobs.py
@@ -2,15 +2,13 @@
 # Tests for data hygiene cleanup behavior
 from __future__ import annotations
 
-import os
 import sqlite3
-import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
-from backend.jobs.data_hygiene_jobs import cleanup_expired_records, backup_sqlite_with_rotation
+from jobs.data_hygiene_jobs import backup_sqlite_with_rotation, cleanup_expired_records
 
 
 def _mk_db(tmp_path: Path) -> str:

--- a/backend/tests/test_world_pulse_jobs.py
+++ b/backend/tests/test_world_pulse_jobs.py
@@ -5,7 +5,7 @@ import sqlite3
 
 import pytest
 
-from backend.jobs.world_pulse_jobs import run_daily, run_weekly
+from jobs.world_pulse_jobs import run_daily, run_weekly
 
 DDL = """
 PRAGMA foreign_keys = ON;

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -15,12 +15,12 @@ Expose:
 """
 
 from __future__ import annotations
+
 import asyncio
+import os
+import sqlite3
 from datetime import datetime, timezone
 from typing import Callable, Dict, Optional
-
-import sqlite3
-import os
 
 # Prefer project's get_conn
 try:
@@ -35,16 +35,15 @@ except Exception:
         return conn
 
 # Import job modules
-from backend.jobs import (
+from jobs import (
+    backup_db,
+    cleanup_event_effects,
     cleanup_idempotency,
     cleanup_rate_limits,
     cleanup_tokens,
-    backup_db,
-    cleanup_event_effects,
-    random_events,
     lifestyle_jobs,
+    random_events,
 )  # type: ignore
-
 
 JobFunc = Callable[[], tuple[int, str]]
 

--- a/jobs/world_pulse_jobs.py
+++ b/jobs/world_pulse_jobs.py
@@ -383,7 +383,7 @@ def run_yearly(today: Optional[str] = None, conn_override=None):
 
 
 if __name__ == "__main__":
-    # Handy CLI: python -m backend.jobs.world_pulse_jobs daily 2025-08-25
+    # Handy CLI: python -m jobs.world_pulse_jobs daily 2025-08-25
     import sys
     cmd = sys.argv[1] if len(sys.argv) >= 2 else "daily"
     arg = sys.argv[2] if len(sys.argv) >= 3 else None


### PR DESCRIPTION
## Summary
- import job modules from `jobs` package instead of `backend.jobs`
- update tests and scheduler to align with new job module path
- correct world pulse CLI comment for new module path

## Testing
- `ruff check core/scheduler.py backend/tests/services/test_song_service.py backend/tests/test_world_pulse_jobs.py backend/tests/royalties/test_sponsorship_reconciliation.py backend/tests/auth/test_token_cleanup.py backend/tests/test_data_hygiene_jobs.py backend/tests/test_backup_rotation.py backend/tests/analytics/test_seasonal_scores.py jobs/world_pulse_jobs.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c73d66d6948325aed7dd4d75c9d536