### PR TITLE
refactor: update backend.core imports

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -24,7 +24,7 @@ import os
 
 # Prefer project's get_conn
 try:
-    from backend.core.db import get_conn  # type: ignore
+    from core.db import get_conn  # type: ignore
 except Exception:
     def get_conn() -> sqlite3.Connection:
         db_path = os.getenv("DB_PATH", "app.db")

--- a/core/startup.py
+++ b/core/startup.py
@@ -11,7 +11,7 @@ import logging
 
 from fastapi import FastAPI
 
-from backend.core.scheduler import register_jobs, run_job
+from core.scheduler import register_jobs, run_job
 
 logger = logging.getLogger(__name__)
 

--- a/jobs/cleanup_idempotency.py
+++ b/jobs/cleanup_idempotency.py
@@ -15,7 +15,7 @@ from typing import Tuple
 
 # Prefer project's shared DB util if present
 try:
-    from backend.core.db import get_conn  # type: ignore
+    from core.db import get_conn  # type: ignore
 except Exception:
     def get_conn() -> sqlite3.Connection:
         db_path = os.getenv("DB_PATH", "app.db")

--- a/jobs/cleanup_rate_limits.py
+++ b/jobs/cleanup_rate_limits.py
@@ -15,7 +15,7 @@ from typing import Tuple
 
 # Prefer project's shared DB util if present
 try:
-    from backend.core.db import get_conn  # type: ignore
+    from core.db import get_conn  # type: ignore
 except Exception:
     def get_conn() -> sqlite3.Connection:
         db_path = os.getenv("DB_PATH", "app.db")

--- a/jobs/cleanup_tokens.py
+++ b/jobs/cleanup_tokens.py
@@ -22,7 +22,7 @@ from typing import Tuple
 
 # Prefer project's shared DB util if present
 try:  # pragma: no cover - optional import
-    from backend.core.db import get_conn  # type: ignore
+    from core.db import get_conn  # type: ignore
 except Exception:  # pragma: no cover - fallback for tests/standalone
     def get_conn() -> sqlite3.Connection:
         db_path = os.getenv("DB_PATH", "app.db")

--- a/jobs/data_hygiene_jobs.py
+++ b/jobs/data_hygiene_jobs.py
@@ -34,7 +34,7 @@ def _detect_db_path() -> str:
     """
     # Preferred: dedicated settings
     for mod_name, attr in (
-        ("backend.core.settings", "DB_PATH"),
+        ("core.settings", "DB_PATH"),
         ("backend.settings", "DB_PATH"),
         ("settings", "DB_PATH"),
     ):
@@ -48,7 +48,7 @@ def _detect_db_path() -> str:
 
     # Next: try to import a get_conn that knows the path
     try:
-        from backend.core.database import DB_PATH as CORE_DB_PATH  # type: ignore
+        from core.database import DB_PATH as CORE_DB_PATH  # type: ignore
         if CORE_DB_PATH:
             return CORE_DB_PATH
     except Exception:
@@ -78,7 +78,7 @@ def get_conn(db_path: Optional[str] = None) -> sqlite3.Connection:
     """
     # Try project-level helpers first
     for mod_name in (
-        "backend.core.database",
+        "core.database",
         "backend.database",
         "database",
     ):

--- a/routes/jobs_routes.py
+++ b/routes/jobs_routes.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException
 from typing import Any
 
-from backend.core.scheduler import register_jobs, list_jobs, run_job
+from core.scheduler import register_jobs, list_jobs, run_job
 
 router = APIRouter()
 

--- a/routes/setlist_routes.py
+++ b/routes/setlist_routes.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from typing import Any, List
 
-from backend.core.setlist_optimizer import optimizer
+from core.setlist_optimizer import optimizer
 
 from services import setlist_service
 

--- a/scripts/apply_dx_responses.py
+++ b/scripts/apply_dx_responses.py
@@ -8,8 +8,8 @@ Usage:
 
 What it does, per *.py in --root:
 - Ensures imports:
-    from backend.core.responses import std_error_responses
-    from backend.core.openapi import add_auth_example
+    from core.responses import std_error_responses
+    from core.openapi import add_auth_example
 - Injects `responses=std_error_responses(),` into every @router.get/post/put/patch/delete decorator if not present.
 - Ensures a tiny helper that iterates router.routes and calls add_auth_example(...) so OpenAPI shows an Authorization header example.
 - Idempotent: safe to re-run; it won't duplicate inserts.
@@ -24,17 +24,17 @@ METHODS = ("get","post","put","patch","delete")
 
 def ensure_imports(text: str) -> str:
     lines = text.splitlines()
-    have_resp = any("from backend.core.responses import std_error_responses" in l for l in lines)
-    have_auth = any("from backend.core.openapi import add_auth_example" in l for l in lines)
+    have_resp = any("from core.responses import std_error_responses" in l for l in lines)
+    have_auth = any("from core.openapi import add_auth_example" in l for l in lines)
     insert_at = 0
     for i,l in enumerate(lines):
         if l.startswith("from ") or l.startswith("import "):
             insert_at = i+1
     to_add = []
     if not have_resp:
-        to_add.append("from backend.core.responses import std_error_responses")
+        to_add.append("from core.responses import std_error_responses")
     if not have_auth:
-        to_add.append("from backend.core.openapi import add_auth_example")
+        to_add.append("from core.openapi import add_auth_example")
     if to_add:
         lines[insert_at:insert_at] = to_add
     return "\n".join(lines)

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -13,8 +13,8 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "backend"))
 
-from backend.core.config import settings  # noqa: E402
-from backend.core.security import hash_password  # noqa: E402
+from core.config import settings  # noqa: E402
+from core.security import hash_password  # noqa: E402
 
 DEMO_EMAIL = "demo@rockmundo.test"
 DEMO_PASSWORD = "demo123"

--- a/tests/test_storage_startup.py
+++ b/tests/test_storage_startup.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
-import backend.core.config as config_module
+import core.config as config_module
 import backend.services.storage_service as storage_service
 
 import os

--- a/tests/test_tour_service_logging.py
+++ b/tests/test_tour_service_logging.py
@@ -11,10 +11,10 @@ sys.path.append(str(ROOT))
 import backend.services as backend_services
 sys.modules.setdefault("services", backend_services)
 
-import backend.core as backend_core
+import core as backend_core
 sys.modules.setdefault("core", backend_core)
 
-import backend.core.errors as core_errors
+import core.errors as core_errors
 sys.modules.setdefault("core.errors", core_errors)
 
 


### PR DESCRIPTION
## Summary
- replace legacy `backend.core` imports with `core.*`
- adjust scripts and tests to use new `core` package paths

## Testing
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c73d64f54c8325b4a0bf1fbad8a27f