### PR TITLE
refactor: update seed imports to new package path

### DIFF
--- a/backend/tests/admin/test_music_routes.py
+++ b/backend/tests/admin/test_music_routes.py
@@ -5,7 +5,7 @@ import types
 
 from fastapi import Request
 
-import backend.seeds.skill_seed as skill_seed
+import seeds.skill_seed as skill_seed
 
 
 def test_add_and_delete_skill(monkeypatch):
@@ -13,9 +13,9 @@ def test_add_and_delete_skill(monkeypatch):
     dummy_equipment_seed = types.SimpleNamespace(
         SEED_STAGE_EQUIPMENT=[], STAGE_EQUIPMENT_NAME_TO_ID={}
     )
-    monkeypatch.setitem(sys.modules, "backend.seeds.genre_seed", dummy_genre_seed)
+    monkeypatch.setitem(sys.modules, "seeds.genre_seed", dummy_genre_seed)
     monkeypatch.setitem(
-        sys.modules, "backend.seeds.stage_equipment_seed", dummy_equipment_seed
+        sys.modules, "seeds.stage_equipment_seed", dummy_equipment_seed
     )
 
     admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")

--- a/backend/tests/admin/test_skill_persistence.py
+++ b/backend/tests/admin/test_skill_persistence.py
@@ -5,7 +5,7 @@ import types
 
 from fastapi import Request
 
-import backend.seeds.skill_seed as skill_seed
+import seeds.skill_seed as skill_seed
 from backend.models import skill_seed_store
 
 
@@ -23,9 +23,9 @@ def test_skills_persist_across_restarts(tmp_path, monkeypatch):
     dummy_equipment_seed = types.SimpleNamespace(
         SEED_STAGE_EQUIPMENT=[], STAGE_EQUIPMENT_NAME_TO_ID={}
     )
-    monkeypatch.setitem(sys.modules, "backend.seeds.genre_seed", dummy_genre_seed)
+    monkeypatch.setitem(sys.modules, "seeds.genre_seed", dummy_genre_seed)
     monkeypatch.setitem(
-        sys.modules, "backend.seeds.stage_equipment_seed", dummy_equipment_seed
+        sys.modules, "seeds.stage_equipment_seed", dummy_equipment_seed
     )
 
     admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")

--- a/backend/tests/production/test_production_skills_bonus.py
+++ b/backend/tests/production/test_production_skills_bonus.py
@@ -1,7 +1,7 @@
 from backend.services.music_production_service import MusicProductionService
 from backend.services.skill_service import skill_service
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 class DummyAvatar:

--- a/backend/tests/production/test_sound_design_production.py
+++ b/backend/tests/production/test_sound_design_production.py
@@ -1,7 +1,7 @@
 from backend.services.music_production_service import MusicProductionService
 from backend.services.skill_service import skill_service
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 class DummyAvatar:

--- a/backend/tests/recording/test_session_skill_effects.py
+++ b/backend/tests/recording/test_session_skill_effects.py
@@ -1,5 +1,5 @@
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.recording_service import RecordingService
 from backend.services.skill_service import skill_service
 

--- a/backend/tests/rehearsal/test_peer_learning_service.py
+++ b/backend/tests/rehearsal/test_peer_learning_service.py
@@ -5,7 +5,7 @@ from backend.services import scheduler_service
 from backend.services.rehearsal_service import RehearsalService
 from backend.services.peer_learning_service import peer_learning_service
 from backend.services.skill_service import skill_service
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 def _setup(tmp_path):

--- a/routes/admin_music_routes.py
+++ b/routes/admin_music_routes.py
@@ -1,9 +1,9 @@
 from typing import List
 
-import backend.seeds.genre_seed as genre_seed
-import backend.seeds.skill_seed as skill_seed
+import seeds.genre_seed as genre_seed
+import seeds.skill_seed as skill_seed
 from backend.models.skill_seed_store import load_skills, save_skills
-import backend.seeds.stage_equipment_seed as equipment_seed
+import seeds.stage_equipment_seed as equipment_seed
 from auth.dependencies import get_current_user_id, require_permission
 from backend.models.genre import Genre
 from backend.models.skill import Skill

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -34,7 +34,7 @@ def run_python_seeds(conn: sqlite3.Connection) -> None:
     for path in SEEDS_DIR.glob("*.py"):
         if path.name.startswith("__"):
             continue
-        module = import_module(f"backend.seeds.{path.stem}")
+        module = import_module(f"seeds.{path.stem}")
         seed_fn = getattr(module, "seed", None)
         if callable(seed_fn):
             print(f"Running seed from {path.name}")

--- a/services/audio_mixing_service.py
+++ b/services/audio_mixing_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import List
 
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 
 

--- a/services/business_service.py
+++ b/services/business_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 
 from .economy_service import EconomyError, EconomyService

--- a/services/business_training_service.py
+++ b/services/business_training_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict
 
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service
 

--- a/services/fan_interaction_service.py
+++ b/services/fan_interaction_service.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from backend.database import DB_PATH
 from backend.services import fan_service
 from backend.services.skill_service import skill_service
-from backend.seeds.skill_seed import SEED_SKILLS
+from seeds.skill_seed import SEED_SKILLS
 
 FASHION_SKILL = next(s for s in SEED_SKILLS if s.name == "fashion")
 IMAGE_MANAGEMENT_SKILL = next(

--- a/services/fan_service.py
+++ b/services/fan_service.py
@@ -2,7 +2,7 @@ import sqlite3
 
 from backend.database import DB_PATH
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.avatar_service import AvatarService
 from backend.services.skill_service import skill_service
 

--- a/services/image_training_service.py
+++ b/services/image_training_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict
 
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service
 

--- a/services/music_production_service.py
+++ b/services/music_production_service.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 """Music production utilities influenced by avatar tech savvy."""
 
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.avatar_service import AvatarService
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 
 

--- a/services/onboarding_question_service.py
+++ b/services/onboarding_question_service.py
@@ -4,7 +4,7 @@ import random
 from typing import Dict, List
 
 from backend.models.onboarding import Question
-from backend.seeds.question_seed import QUESTIONS
+from seeds.question_seed import QUESTIONS
 
 
 class OnboardingQuestionService:

--- a/services/peer_learning_service.py
+++ b/services/peer_learning_service.py
@@ -7,7 +7,7 @@ from typing import Iterable, List
 from backend.database import DB_PATH
 from backend.models.skill import Skill
 from backend.services.skill_service import skill_service
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 
 PERFORMANCE_SKILL = Skill(
     id=SKILL_NAME_TO_ID["performance"],

--- a/services/recording_service.py
+++ b/services/recording_service.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 from backend.models.learning_method import LearningMethod
 from backend.models.recording_session import RecordingSession
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.chemistry_service import ChemistryService
 from backend.services.economy_service import EconomyError, EconomyService
 from backend.services.skill_service import skill_service

--- a/services/social_media_training_service.py
+++ b/services/social_media_training_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service
 

--- a/services/streaming_service.py
+++ b/services/streaming_service.py
@@ -7,7 +7,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback to package
     import aiosqlite  # type: ignore
 from backend.database import DB_PATH
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import skill_service
 from backend.services.song_popularity_service import add_event
 

--- a/services/university_service.py
+++ b/services/university_service.py
@@ -11,7 +11,7 @@ from backend.database import DB_PATH
 from backend.models.course import Course
 from backend.models.skill import Skill
 from backend.services.skill_service import SkillService
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 class UniversityService:

--- a/services/video_service.py
+++ b/services/video_service.py
@@ -8,7 +8,7 @@ from backend.models.video import Video
 from backend.services.economy_service import EconomyService
 from backend.services.media_moderation_service import media_moderation_service
 from backend.services.skill_service import SkillService
-from backend.seeds.skill_seed import SEED_SKILLS
+from seeds.skill_seed import SEED_SKILLS
 from backend.utils.metrics import _REGISTRY, Histogram
 
 if "service_latency_ms" in _REGISTRY:

--- a/services/vocal_training_service.py
+++ b/services/vocal_training_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from backend.models.learning_method import LearningMethod
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SEED_SKILLS
+from seeds.skill_seed import SEED_SKILLS
 from backend.services.skill_service import SkillService
 from backend.services.skill_service import skill_service as default_skill_service
 

--- a/tests/admin/test_admin_skill_routes.py
+++ b/tests/admin/test_admin_skill_routes.py
@@ -10,7 +10,7 @@ BASE = Path(__file__).resolve().parents[2]
 sys.path.append(str(BASE))
 sys.path.append(str(BASE / "backend"))
 
-import backend.seeds.skill_seed as skill_seed
+import seeds.skill_seed as skill_seed
 from backend.models import skill_seed_store
 
 
@@ -28,9 +28,9 @@ def test_prerequisites_persist_across_restarts(tmp_path, monkeypatch):
     dummy_equipment_seed = types.SimpleNamespace(
         SEED_STAGE_EQUIPMENT=[], STAGE_EQUIPMENT_NAME_TO_ID={}
     )
-    monkeypatch.setitem(sys.modules, "backend.seeds.genre_seed", dummy_genre_seed)
+    monkeypatch.setitem(sys.modules, "seeds.genre_seed", dummy_genre_seed)
     monkeypatch.setitem(
-        sys.modules, "backend.seeds.stage_equipment_seed", dummy_equipment_seed
+        sys.modules, "seeds.stage_equipment_seed", dummy_equipment_seed
     )
 
     admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")

--- a/tests/admin/test_apprenticeship_routes.py
+++ b/tests/admin/test_apprenticeship_routes.py
@@ -17,7 +17,7 @@ from backend.routes.admin_apprenticeship_routes import (  # type: ignore  # noqa
     update_apprenticeship,
     svc,
 )
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID  # noqa: E402
+from seeds.skill_seed import SKILL_NAME_TO_ID  # noqa: E402
 
 
 def test_apprenticeship_routes_require_admin():

--- a/tests/live_album/test_audio_mixing.py
+++ b/tests/live_album/test_audio_mixing.py
@@ -4,7 +4,7 @@ import sqlite3
 import pytest
 
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services import audio_mixing_service
 from backend.services.live_album_service import LiveAlbumService
 from backend.services.skill_service import skill_service

--- a/tests/test_image_skills.py
+++ b/tests/test_image_skills.py
@@ -7,7 +7,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
-from backend.seeds.skill_seed import SEED_SKILLS
+from seeds.skill_seed import SEED_SKILLS
 from backend.models.learning_method import METHOD_PROFILES, LearningMethod
 from backend.services import fan_interaction_service, fan_service
 from backend.services.image_training_service import (

--- a/tests/test_live_streaming.py
+++ b/tests/test_live_streaming.py
@@ -1,7 +1,7 @@
 from backend.services import streaming_service as ss
 from backend.services.skill_service import skill_service
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 def test_live_stream_skill_improves_quality():

--- a/tests/test_practice_xp.py
+++ b/tests/test_practice_xp.py
@@ -8,7 +8,7 @@ sys.path.append(str(ROOT / "backend"))
 
 from backend.services.skill_service import skill_service
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 def _setup_gig_db(db_path: Path) -> None:

--- a/tests/test_skill_category_multiplier.py
+++ b/tests/test_skill_category_multiplier.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from backend.models.skill import Skill
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services import gig_service as gs
 from backend.services.skill_service import SkillService, skill_service
 from backend.services.recording_service import RecordingService

--- a/tests/test_skill_seed.py
+++ b/tests/test_skill_seed.py
@@ -5,7 +5,7 @@ BASE = Path(__file__).resolve().parents[1]
 sys.path.append(str(BASE))
 sys.path.append(str(BASE / "backend"))
 
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID  # noqa: E402
+from seeds.skill_seed import SKILL_NAME_TO_ID  # noqa: E402
 
 
 def test_skill_name_to_id_unique_values():

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -45,9 +45,9 @@ from backend.models.item import Item
 from backend.models.learning_method import LearningMethod
 from backend.models.skill import Skill, SkillSpecialization
 from backend.models.xp_config import XPConfig, get_config, set_config
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.skill_service import SkillService
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 from backend.services.vocal_training_service import VocalTrainingService
 from backend.services.recording_service import RecordingService
 item_service = None  # set in _setup_device

--- a/tests/test_university_service.py
+++ b/tests/test_university_service.py
@@ -9,7 +9,7 @@ sys.path.append(str(root_dir / "backend"))
 
 from backend.services.university_service import UniversityService
 from backend.services.skill_service import SkillService
-from backend.seeds.skill_seed import SKILL_NAME_TO_ID
+from seeds.skill_seed import SKILL_NAME_TO_ID
 
 
 def _setup_course(db: Path) -> None:


### PR DESCRIPTION
## Summary
- refactor seed imports to use new `seeds` package
- update dynamic seed loading to new path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c73d614bb88325a2d89d244f3e5b0e