### PR TITLE
refactor: import config module directly

### DIFF
--- a/backend/tests/royalties/test_sponsorship_reconciliation.py
+++ b/backend/tests/royalties/test_sponsorship_reconciliation.py
@@ -1,10 +1,9 @@
 import asyncio
 import sqlite3
-from pathlib import Path
 
-from backend.config import revenue
 from backend.jobs import sponsor_reconciliation_job
 from backend.services.sponsorship_service import SponsorshipService
+from config import revenue
 
 
 def _setup_db(db_path: str) -> None:

--- a/backend/tests/royalties/test_venue_sponsorship_payouts.py
+++ b/backend/tests/royalties/test_venue_sponsorship_payouts.py
@@ -1,8 +1,8 @@
 import sqlite3
 
-from backend.config import revenue
 from backend.services.jobs_royalties import RoyaltyJobsService
 from backend.services.venue_sponsorships_service import SponsorshipIn, VenueSponsorshipsService
+from config import revenue
 
 
 def test_venue_sponsorship_payout(tmp_path):

--- a/routes/admin_lifestyle_routes.py
+++ b/routes/admin_lifestyle_routes.py
@@ -4,9 +4,8 @@ from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 
 from auth.dependencies import get_current_user_id, require_permission
+from config import lifestyle as lifestyle_config
 from services.admin_audit_service import audit_dependency
-from backend.config import lifestyle as lifestyle_config
-
 
 router = APIRouter(
     prefix="/lifestyle", tags=["AdminLifestyle"], dependencies=[Depends(audit_dependency)]

--- a/services/ai_manager_service.py
+++ b/services/ai_manager_service.py
@@ -1,4 +1,4 @@
-from backend.config import ENABLE_PR_AI_MANAGER, ENABLE_TOUR_AI_MANAGER
+from config import ENABLE_PR_AI_MANAGER, ENABLE_TOUR_AI_MANAGER
 
 
 # Simulated planner engine

--- a/services/jobs_royalties.py
+++ b/services/jobs_royalties.py
@@ -20,13 +20,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from backend.config.revenue import (
+from backend.utils.metrics import Counter
+from config.revenue import (
     DAILY_STREAM_CAP_PER_USER_PER_SONG,
     SPONSOR_IMPRESSION_RATE_CENTS,
     SPONSOR_PAYOUT_SPLIT,
     STREAM_RATE_MICROCENTS,
 )
-from backend.utils.metrics import Counter
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"
 

--- a/services/sponsorship_service.py
+++ b/services/sponsorship_service.py
@@ -3,13 +3,14 @@ try:  # pragma: no cover - prefer local stub if available
     import utils.aiosqlite_local as aiosqlite
 except ModuleNotFoundError:  # pragma: no cover - fallback to package
     import aiosqlite  # type: ignore
-from typing import Optional, Dict, Any, List
 from datetime import date
+from typing import Any, Dict, List, Optional
 
-from backend.config.revenue import (
+from config.revenue import (
     SPONSOR_IMPRESSION_RATE_CENTS,
     SPONSOR_PAYOUT_SPLIT,
 )
+
 
 def _display_name(venue_name: str, sponsor_name: Optional[str], fmt: str) -> str:
     if not sponsor_name:

--- a/services/venue_sponsorships_service.py
+++ b/services/venue_sponsorships_service.py
@@ -6,13 +6,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.config.revenue import (
-    SPONSOR_IMPRESSION_RATE_CENTS,
-    SPONSOR_PAYOUT_SPLIT,
-)
 from backend.models.venue_sponsorship import (
     NegotiationStage,
     SponsorshipNegotiation,
+)
+from config.revenue import (
+    SPONSOR_IMPRESSION_RATE_CENTS,
+    SPONSOR_PAYOUT_SPLIT,
 )
 
 DB_PATH = Path(__file__).resolve().parents[1] / "rockmundo.db"

--- a/tests/test_lifestyle_config.py
+++ b/tests/test_lifestyle_config.py
@@ -1,5 +1,5 @@
-from backend.config import lifestyle as cfg
 from backend.services.lifestyle_scheduler import lifestyle_xp_modifier
+from config import lifestyle as cfg
 
 
 def test_default_lifestyle_config_values() -> None:


### PR DESCRIPTION
## Summary
- import configuration modules from top-level package

## Testing
- `ruff check backend/tests/royalties/test_sponsorship_reconciliation.py backend/tests/royalties/test_venue_sponsorship_payouts.py routes/admin_lifestyle_routes.py services/ai_manager_service.py services/jobs_royalties.py services/sponsorship_service.py services/venue_sponsorships_service.py tests/test_lifestyle_config.py`
- `pytest` *(fails: ModuleNotFoundError / missing dependencies during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c73d625d208325bf44d530d3bdde57