### PR TITLE
refactor: use routes package instead of backend.routes

### DIFF
--- a/backend/tests/achievements/test_achievements.py
+++ b/backend/tests/achievements/test_achievements.py
@@ -32,7 +32,7 @@ core_errors.VenueConflictError = VenueConflictError
 core_errors.TourMinStopsError = TourMinStopsError
 sys.modules["core.errors"] = core_errors
 
-from backend.routes import achievement_routes  # noqa: E402
+from routes import achievement_routes  # noqa: E402
 from backend.services.chart_service import calculate_weekly_chart  # noqa: E402
 from backend.services.tour_service import TourService  # noqa: E402
 

--- a/backend/tests/admin/test_admin_action_logging.py
+++ b/backend/tests/admin/test_admin_action_logging.py
@@ -5,7 +5,7 @@ import tempfile
 
 from fastapi import Request
 
-from backend.routes import admin_media_moderation_routes as media_routes
+from routes import admin_media_moderation_routes as media_routes
 from backend.services.admin_service import AdminService, AdminActionRepository
 from backend.storage.local import LocalStorage
 from backend.services import storage_service

--- a/backend/tests/admin/test_admin_router.py
+++ b/backend/tests/admin/test_admin_router.py
@@ -6,36 +6,36 @@ from fastapi.testclient import TestClient
 
 # Stub all sub-route modules imported by admin_routes to avoid heavy dependencies
 SUB_MODULES = [
-    "backend.routes.admin_analytics_routes",
-    "backend.routes.admin_apprenticeship_routes",
-    "backend.routes.admin_audit_routes",
-    "backend.routes.admin_book_routes",
-    "backend.routes.admin_business_routes",
-    "backend.routes.admin_city_shop_routes",
-    "backend.routes.admin_course_routes",
-    "backend.routes.admin_economy_routes",
-    "backend.routes.admin_item_routes",
-    "backend.routes.admin_drug_routes",
-    "backend.routes.admin_job_routes",
-    "backend.routes.admin_loyalty_routes",
-    "backend.routes.admin_media_moderation_routes",
-    "backend.routes.admin_modding_routes",
-    "backend.routes.admin_monitoring_routes",
-    "backend.routes.admin_music_routes",
-    "backend.routes.admin_name_routes",
-    "backend.routes.admin_npc_dialogue_routes",
-    "backend.routes.admin_npc_routes",
-    "backend.routes.admin_online_tutorial_routes",
-    "backend.routes.admin_player_shop_routes",
-    "backend.routes.admin_quest_routes",
-    "backend.routes.admin_schema_routes",
-    "backend.routes.admin_shop_event_routes",
-    "backend.routes.admin_song_popularity_routes",
-    "backend.routes.admin_tutor_routes",
-    "backend.routes.admin_venue_routes",
-    "backend.routes.admin_workshop_routes",
-    "backend.routes.admin_xp_event_routes",
-    "backend.routes.admin_xp_routes",
+    "routes.admin_analytics_routes",
+    "routes.admin_apprenticeship_routes",
+    "routes.admin_audit_routes",
+    "routes.admin_book_routes",
+    "routes.admin_business_routes",
+    "routes.admin_city_shop_routes",
+    "routes.admin_course_routes",
+    "routes.admin_economy_routes",
+    "routes.admin_item_routes",
+    "routes.admin_drug_routes",
+    "routes.admin_job_routes",
+    "routes.admin_loyalty_routes",
+    "routes.admin_media_moderation_routes",
+    "routes.admin_modding_routes",
+    "routes.admin_monitoring_routes",
+    "routes.admin_music_routes",
+    "routes.admin_name_routes",
+    "routes.admin_npc_dialogue_routes",
+    "routes.admin_npc_routes",
+    "routes.admin_online_tutorial_routes",
+    "routes.admin_player_shop_routes",
+    "routes.admin_quest_routes",
+    "routes.admin_schema_routes",
+    "routes.admin_shop_event_routes",
+    "routes.admin_song_popularity_routes",
+    "routes.admin_tutor_routes",
+    "routes.admin_venue_routes",
+    "routes.admin_workshop_routes",
+    "routes.admin_xp_event_routes",
+    "routes.admin_xp_routes",
 ]
 
 for name in SUB_MODULES:
@@ -43,7 +43,7 @@ for name in SUB_MODULES:
     mod.router = APIRouter()
     sys.modules[name] = mod
 
-from backend.routes import admin_routes
+from routes import admin_routes
 
 
 def test_admin_router_requires_admin(monkeypatch):

--- a/backend/tests/admin/test_audit_logging.py
+++ b/backend/tests/admin/test_audit_logging.py
@@ -5,7 +5,7 @@ from backend.services.admin_audit_service import (
     get_admin_audit_service,
     audit_dependency,
 )
-from backend.routes import admin_media_moderation_routes as media_routes
+from routes import admin_media_moderation_routes as media_routes
 from backend.models.economy_config import set_config, save_config, EconomyConfig
 
 

--- a/backend/tests/admin/test_book_routes.py
+++ b/backend/tests/admin/test_book_routes.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 from fastapi import HTTPException, Request
 
-from backend.routes.admin_book_routes import (
+from routes.admin_book_routes import (
     BookIn,
     create_book,
     delete_book,
@@ -33,10 +33,10 @@ def test_admin_book_routes_crud(monkeypatch, tmp_path):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_book_routes.get_current_user_id", fake_current_user
+        "routes.admin_book_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_book_routes.require_permission", fake_require_permission
+        "routes.admin_book_routes.require_permission", fake_require_permission
     )
 
     # use temporary db

--- a/backend/tests/admin/test_content_preview.py
+++ b/backend/tests/admin/test_content_preview.py
@@ -4,9 +4,9 @@ from copy import deepcopy
 import pytest
 from fastapi import Request
 
-from backend.routes.admin_npc_routes import preview_npc, svc as npc_svc
-from backend.routes.admin_quest_routes import preview_quest, svc as quest_svc
-from backend.routes.admin_economy_routes import (
+from routes.admin_npc_routes import preview_npc, svc as npc_svc
+from routes.admin_quest_routes import preview_quest, svc as quest_svc
+from routes.admin_economy_routes import (
     preview_config,
     svc as econ_svc,
     ConfigUpdateIn,
@@ -23,17 +23,17 @@ async def _role(roles, user_id):
 
 def test_preview_endpoints_do_not_persist(monkeypatch):
     monkeypatch.setattr(
-        "backend.routes.admin_npc_routes.get_current_user_id", _allow
+        "routes.admin_npc_routes.get_current_user_id", _allow
     )
-    monkeypatch.setattr("backend.routes.admin_npc_routes.require_permission", _role)
+    monkeypatch.setattr("routes.admin_npc_routes.require_permission", _role)
     monkeypatch.setattr(
-        "backend.routes.admin_quest_routes.get_current_user_id", _allow
+        "routes.admin_quest_routes.get_current_user_id", _allow
     )
-    monkeypatch.setattr("backend.routes.admin_quest_routes.require_permission", _role)
+    monkeypatch.setattr("routes.admin_quest_routes.require_permission", _role)
     monkeypatch.setattr(
-        "backend.routes.admin_economy_routes.get_current_user_id", _allow
+        "routes.admin_economy_routes.get_current_user_id", _allow
     )
-    monkeypatch.setattr("backend.routes.admin_economy_routes.require_permission", _role)
+    monkeypatch.setattr("routes.admin_economy_routes.require_permission", _role)
 
     req = Request({})
 

--- a/backend/tests/admin/test_course_routes.py
+++ b/backend/tests/admin/test_course_routes.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 from fastapi import HTTPException, Request
 
-from backend.routes.admin_course_routes import (
+from routes.admin_course_routes import (
     CourseIn,
     create_course,
     delete_course,
@@ -34,10 +34,10 @@ def test_course_crud(monkeypatch, tmp_path):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_course_routes.get_current_user_id", fake_current_user
+        "routes.admin_course_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_course_routes.require_permission", fake_require_permission
+        "routes.admin_course_routes.require_permission", fake_require_permission
     )
 
     svc.db_path = str(tmp_path / "courses.db")

--- a/backend/tests/admin/test_drug_routes.py
+++ b/backend/tests/admin/test_drug_routes.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-from backend.routes import admin_drug_routes
+from routes import admin_drug_routes
 
 
 def test_admin_drug_routes_require_admin(monkeypatch):

--- a/backend/tests/admin/test_economy_routes.py
+++ b/backend/tests/admin/test_economy_routes.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 from fastapi import HTTPException, Request
 
-from backend.routes import admin_economy_routes as routes
+from routes import admin_economy_routes as routes
 from backend.services.economy_service import EconomyService
 from backend.models.economy_config import set_config, EconomyConfig
 
@@ -26,10 +26,10 @@ def test_admin_economy_config_updates(monkeypatch, tmp_path):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_economy_routes.get_current_user_id", fake_current_user
+        "routes.admin_economy_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_economy_routes.require_permission", fake_require_permission
+        "routes.admin_economy_routes.require_permission", fake_require_permission
     )
 
     db_file = tmp_path / "econ.db"

--- a/backend/tests/admin/test_media_moderation_queue.py
+++ b/backend/tests/admin/test_media_moderation_queue.py
@@ -2,7 +2,7 @@ import asyncio
 
 from fastapi import Request
 
-from backend.routes import admin_media_moderation_routes as routes
+from routes import admin_media_moderation_routes as routes
 
 
 def _setup(monkeypatch):

--- a/backend/tests/admin/test_monitoring_sessions.py
+++ b/backend/tests/admin/test_monitoring_sessions.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-import backend.routes.admin_monitoring_routes as monitoring_routes
+import routes.admin_monitoring_routes as monitoring_routes
 from backend.services.session_service import SessionService, get_session_service
 
 

--- a/backend/tests/admin/test_music_routes.py
+++ b/backend/tests/admin/test_music_routes.py
@@ -18,7 +18,7 @@ def test_add_and_delete_skill(monkeypatch):
         sys.modules, "backend.seeds.stage_equipment_seed", dummy_equipment_seed
     )
 
-    admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")
+    admin_music_routes = importlib.import_module("routes.admin_music_routes")
 
     async def fake_current_user(req):
         return 1

--- a/backend/tests/admin/test_name_routes.py
+++ b/backend/tests/admin/test_name_routes.py
@@ -18,7 +18,7 @@ def test_append_names_and_generate(tmp_path, monkeypatch):
             return decorator
     monkeypatch.setattr(fastapi, "APIRouter", DummyRouter)
 
-    admin_name_routes = importlib.import_module("backend.routes.admin_name_routes")
+    admin_name_routes = importlib.import_module("routes.admin_name_routes")
 
     monkeypatch.setattr(name_dataset_service, "_DATA_DIR", tmp_path)
     monkeypatch.setattr(name_generator, "DATA_DIR", tmp_path)

--- a/backend/tests/admin/test_npc_dialogue_routes.py
+++ b/backend/tests/admin/test_npc_dialogue_routes.py
@@ -5,8 +5,8 @@ import asyncio
 import pytest
 from fastapi import HTTPException, Request
 
-from backend.routes.admin_npc_routes import create_npc
-from backend.routes.admin_npc_dialogue_routes import edit_dialogue, preview_dialogue, svc
+from routes.admin_npc_routes import create_npc
+from routes.admin_npc_dialogue_routes import edit_dialogue, preview_dialogue, svc
 
 
 def _allow_admin(monkeypatch):
@@ -17,16 +17,16 @@ def _allow_admin(monkeypatch):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_npc_routes.get_current_user_id", fake_current_user
+        "routes.admin_npc_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_npc_routes.require_permission", fake_require_permission
+        "routes.admin_npc_routes.require_permission", fake_require_permission
     )
     monkeypatch.setattr(
-        "backend.routes.admin_npc_dialogue_routes.get_current_user_id", fake_current_user
+        "routes.admin_npc_dialogue_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_npc_dialogue_routes.require_permission", fake_require_permission
+        "routes.admin_npc_dialogue_routes.require_permission", fake_require_permission
     )
 
 

--- a/backend/tests/admin/test_npc_routes.py
+++ b/backend/tests/admin/test_npc_routes.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 from fastapi import HTTPException, Request
 
-from backend.routes.admin_npc_routes import (
+from routes.admin_npc_routes import (
     create_npc,
     delete_npc,
     edit_npc,
@@ -32,10 +32,10 @@ def test_admin_npc_routes_flow(monkeypatch):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_npc_routes.get_current_user_id", fake_current_user
+        "routes.admin_npc_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_npc_routes.require_permission", fake_require_permission
+        "routes.admin_npc_routes.require_permission", fake_require_permission
     )
 
     req = Request({})

--- a/backend/tests/admin/test_quest_routes.py
+++ b/backend/tests/admin/test_quest_routes.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 from fastapi import HTTPException, Request
 
-from backend.routes.admin_quest_routes import (
+from routes.admin_quest_routes import (
     create_quest,
     update_stage,
     preview_quest,
@@ -46,10 +46,10 @@ def test_admin_quest_create_and_update(monkeypatch):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_quest_routes.get_current_user_id", fake_current_user
+        "routes.admin_quest_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_quest_routes.require_permission", fake_require_permission
+        "routes.admin_quest_routes.require_permission", fake_require_permission
     )
 
     req = Request({})
@@ -88,10 +88,10 @@ def test_preview_and_validate_graph(monkeypatch):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_quest_routes.get_current_user_id", fake_current_user
+        "routes.admin_quest_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_quest_routes.require_permission", fake_require_permission
+        "routes.admin_quest_routes.require_permission", fake_require_permission
     )
 
     req = Request({})

--- a/backend/tests/admin/test_skill_persistence.py
+++ b/backend/tests/admin/test_skill_persistence.py
@@ -28,7 +28,7 @@ def test_skills_persist_across_restarts(tmp_path, monkeypatch):
         sys.modules, "backend.seeds.stage_equipment_seed", dummy_equipment_seed
     )
 
-    admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")
+    admin_music_routes = importlib.import_module("routes.admin_music_routes")
 
     async def fake_current_user(req):
         return 1
@@ -53,8 +53,8 @@ def test_skills_persist_across_restarts(tmp_path, monkeypatch):
 
     # Simulate restart by reloading modules
     importlib.reload(skill_seed)
-    del sys.modules["backend.routes.admin_music_routes"]
-    admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")
+    del sys.modules["routes.admin_music_routes"]
+    admin_music_routes = importlib.import_module("routes.admin_music_routes")
 
     assert any(
         s.name == "persisted_skill" and s.prerequisites == {prereq_id: 100}

--- a/backend/tests/admin/test_venue_business_routes.py
+++ b/backend/tests/admin/test_venue_business_routes.py
@@ -3,14 +3,14 @@ import asyncio
 import pytest
 from fastapi import HTTPException, Request
 
-from backend.routes.admin_venue_routes import (
+from routes.admin_venue_routes import (
     create_venue,
     delete_venue,
     edit_venue,
     list_venues,
     svc as venue_svc,
 )
-from backend.routes.admin_business_routes import (
+from routes.admin_business_routes import (
     create_business,
     delete_business,
     edit_business,
@@ -52,16 +52,16 @@ def test_admin_venue_business_flow(monkeypatch):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_venue_routes.get_current_user_id", fake_current_user
+        "routes.admin_venue_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_venue_routes.require_permission", fake_require_permission
+        "routes.admin_venue_routes.require_permission", fake_require_permission
     )
     monkeypatch.setattr(
-        "backend.routes.admin_business_routes.get_current_user_id", fake_current_user
+        "routes.admin_business_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_business_routes.require_permission", fake_require_permission
+        "routes.admin_business_routes.require_permission", fake_require_permission
     )
 
     req = Request({})

--- a/backend/tests/contracts/test_negotiation_flow.py
+++ b/backend/tests/contracts/test_negotiation_flow.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from backend.services.contract_negotiation_service import ContractNegotiationService
 from backend.services.economy_service import EconomyService
-from backend.routes import contract_routes
+from routes import contract_routes
 from backend.models.label_management_models import NegotiationStage
 
 

--- a/backend/tests/live_album/test_live_album_routes.py
+++ b/backend/tests/live_album/test_live_album_routes.py
@@ -4,7 +4,7 @@ import sqlite3
 import pytest
 from fastapi import FastAPI
 
-from backend.routes import live_album_routes
+from routes import live_album_routes
 from backend.services import audio_mixing_service
 
 

--- a/backend/tests/routes/test_songwriting_routes.py
+++ b/backend/tests/routes/test_songwriting_routes.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 
 Path(__file__).resolve().parents[2].joinpath("database").mkdir(exist_ok=True)
 
-from backend.routes import songwriting_routes  # noqa: E402
+from routes import songwriting_routes  # noqa: E402
 from backend.services.originality_service import OriginalityService  # noqa: E402
 from backend.services.songwriting_service import SongwritingService  # noqa: E402
 

--- a/backend/tests/schedule/test_calendar_export.py
+++ b/backend/tests/schedule/test_calendar_export.py
@@ -22,7 +22,7 @@ def setup_app(tmp_path):
     importlib.reload(service_module)
     import backend.services.calendar_export as export_module
     importlib.reload(export_module)
-    import backend.routes.schedule_routes as routes_module
+    import routes.schedule_routes as routes_module
     importlib.reload(routes_module)
 
     app = FastAPI()

--- a/backend/tests/schedule/test_default_plan.py
+++ b/backend/tests/schedule/test_default_plan.py
@@ -27,7 +27,7 @@ def setup_app(tmp_path):
     importlib.reload(schedule_service_module)
     import backend.services.scheduler_service as scheduler_service_module
     importlib.reload(scheduler_service_module)
-    import backend.routes.schedule_routes as routes_module
+    import routes.schedule_routes as routes_module
     importlib.reload(routes_module)
 
     app = FastAPI()

--- a/backend/tests/schedule/test_plan_simulation.py
+++ b/backend/tests/schedule/test_plan_simulation.py
@@ -19,7 +19,7 @@ def setup_app(tmp_path):
     import backend.services.activity_processor as ap_module
     importlib.reload(ap_module)
 
-    import backend.routes.schedule_routes as routes_module
+    import routes.schedule_routes as routes_module
     importlib.reload(routes_module)
 
     app = FastAPI()

--- a/backend/tests/schedule/test_recommendations.py
+++ b/backend/tests/schedule/test_recommendations.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from backend.models.skill import Skill
-from backend.routes import schedule_routes
+from routes import schedule_routes
 from backend.services.plan_service import PlanService
 from backend.services.skill_service import skill_service
 

--- a/backend/tests/schedule/test_recurring_templates.py
+++ b/backend/tests/schedule/test_recurring_templates.py
@@ -29,7 +29,7 @@ def setup_app(tmp_path):
     importlib.reload(schedule_service_module)
     import backend.services.scheduler_service as scheduler_service_module
     importlib.reload(scheduler_service_module)
-    import backend.routes.schedule_routes as routes_module
+    import routes.schedule_routes as routes_module
     importlib.reload(routes_module)
 
     app = FastAPI()

--- a/backend/tests/schedule/test_schedule_completion.py
+++ b/backend/tests/schedule/test_schedule_completion.py
@@ -28,7 +28,7 @@ def setup_app(tmp_path):
     processor_module.DB_PATH = db_file
     importlib.reload(processor_module)
 
-    import backend.routes.schedule_routes as routes_module
+    import routes.schedule_routes as routes_module
     importlib.reload(routes_module)
 
     app = FastAPI()

--- a/backend/tests/schedule/test_schedule_copy.py
+++ b/backend/tests/schedule/test_schedule_copy.py
@@ -18,7 +18,7 @@ def setup_app(tmp_path):
 
     import backend.services.schedule_service as schedule_service_module
     importlib.reload(schedule_service_module)
-    import backend.routes.schedule_routes as routes_module
+    import routes.schedule_routes as routes_module
     importlib.reload(routes_module)
 
     app = FastAPI()

--- a/backend/tests/schedule/test_schedule_history.py
+++ b/backend/tests/schedule/test_schedule_history.py
@@ -20,7 +20,7 @@ def setup_app(tmp_path):
 
     import backend.services.schedule_service as service_module
     importlib.reload(service_module)
-    import backend.routes.schedule_routes as routes_module
+    import routes.schedule_routes as routes_module
     importlib.reload(routes_module)
 
     app = FastAPI()

--- a/backend/tests/schedule/test_schedule_templates.py
+++ b/backend/tests/schedule/test_schedule_templates.py
@@ -24,7 +24,7 @@ def setup_app(tmp_path):
 
     import backend.services.schedule_service as schedule_service_module
     importlib.reload(schedule_service_module)
-    import backend.routes.schedule_routes as routes_module
+    import routes.schedule_routes as routes_module
     importlib.reload(routes_module)
 
     app = FastAPI()

--- a/backend/tests/schedule/test_weekly_plan.py
+++ b/backend/tests/schedule/test_weekly_plan.py
@@ -22,7 +22,7 @@ def setup_app(tmp_path):
     importlib.reload(schedule_service_module)
     import backend.services.report_service as report_service_module
     importlib.reload(report_service_module)
-    import backend.routes.schedule_routes as routes_module
+    import routes.schedule_routes as routes_module
     importlib.reload(routes_module)
 
     app = FastAPI()

--- a/backend/tests/test_song_popularity.py
+++ b/backend/tests/test_song_popularity.py
@@ -85,7 +85,7 @@ def test_forecast_endpoint(client_factory):
         pytest.skip("FastAPI not installed")
     _reset_db()
     app = FastAPI()
-    from backend.routes.song_forecast_routes import router as forecast_router
+    from routes.song_forecast_routes import router as forecast_router
 
     app.include_router(forecast_router)
     add_event(6, 5, "stream")
@@ -112,7 +112,7 @@ def test_get_song_popularity_validation(client_factory):
         pytest.skip("FastAPI not installed")
     _reset_db()
     app = FastAPI()
-    from backend.routes import music_metrics_routes
+    from routes import music_metrics_routes
 
     app.include_router(music_metrics_routes.router)
     client = client_factory(app)

--- a/backend/tests/test_songwriting_ws.py
+++ b/backend/tests/test_songwriting_ws.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 
 Path(__file__).resolve().parents[1].joinpath("database").mkdir(exist_ok=True)
 
-from backend.routes import songwriting_routes  # noqa: E402
+from routes import songwriting_routes  # noqa: E402
 from backend.services.originality_service import OriginalityService  # noqa: E402
 from backend.services.songwriting_service import SongwritingService  # noqa: E402
 

--- a/backend/tests/tour/test_tour.py
+++ b/backend/tests/tour/test_tour.py
@@ -35,7 +35,7 @@ core_errors.VenueConflictError = VenueConflictError
 core_errors.TourMinStopsError = TourMinStopsError
 sys.modules["core.errors"] = core_errors
 
-from backend.routes.tour_routes import router
+from routes.tour_routes import router
 from backend.services.tour_service import TourService
 from backend.services.weather_service import WeatherService
 from backend.services.economy_service import EconomyService
@@ -109,7 +109,7 @@ def test_profit_calculation(svc):
 def test_routes(tmp_path):
     """Basic smoke test invoking the route handlers directly."""
     set_payout(100)
-    from backend.routes import tour_routes as tr
+    from routes import tour_routes as tr
 
     info = tr.create_tour(tr.CreateTourIn(band_id=1, title="RouteTour", start_date="2024", end_date="2024"))
     tid = info["id"]

--- a/patches/main_integration.txt
+++ b/patches/main_integration.txt
@@ -1,7 +1,7 @@
 # File: backend/patches/main_integration.txt
 # Paste these lines into your FastAPI app (e.g., backend/main.py) where you mount routers.
 
-from backend.routes import sponsorship as sponsorship_routes
+from routes import sponsorship as sponsorship_routes
 app.include_router(sponsorship_routes.router)
 
 # Optional: set the DB path for the service without changing your app code:

--- a/routes/admin_npc_dialogue_routes.py
+++ b/routes/admin_npc_dialogue_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from auth.dependencies import get_current_user_id, require_permission
-from backend.routes.admin_npc_routes import svc
+from routes.admin_npc_routes import svc
 from services.admin_audit_service import audit_dependency
 
 router = APIRouter(

--- a/routes/npc_band_routes.py
+++ b/routes/npc_band_routes.py
@@ -1,13 +1,13 @@
 """Deprecated module for NPC band routes.
 
 The old Flask blueprint has been removed in favour of the FastAPI
-implementation in :mod:`backend.routes.admin_npc_routes` and the
+implementation in :mod:`routes.admin_npc_routes` and the
 ``NPCService`` class. This file remains only to avoid import errors.
 """
 
 from warnings import warn
 
 warn(
-    "backend.routes.npc_band_routes is deprecated; use admin_npc_routes instead",
+    "routes.npc_band_routes is deprecated; use admin_npc_routes instead",
     DeprecationWarning,
 )

--- a/tests/admin/test_admin_drug_routes.py
+++ b/tests/admin/test_admin_drug_routes.py
@@ -9,7 +9,7 @@ BASE = Path(__file__).resolve().parents[2]
 sys.path.append(str(BASE))
 sys.path.append(str(BASE / "backend"))
 
-from backend.routes.admin_drug_routes import (
+from routes.admin_drug_routes import (
     DrugCategoryIn,
     DrugIn,
     create_drug_category,
@@ -27,10 +27,10 @@ def test_admin_drug_routes_crud(monkeypatch, tmp_path):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_drug_routes.get_current_user_id", fake_current_user
+        "routes.admin_drug_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_drug_routes.require_permission", fake_require_permission
+        "routes.admin_drug_routes.require_permission", fake_require_permission
     )
 
     svc.db_path = str(tmp_path / "drugs.db")

--- a/tests/admin/test_admin_schema_routes.py
+++ b/tests/admin/test_admin_schema_routes.py
@@ -9,7 +9,7 @@ BASE = Path(__file__).resolve().parents[2]
 sys.path.append(str(BASE))
 sys.path.append(str(BASE / "backend"))
 
-from backend.routes.admin_schema_routes import (  # type: ignore
+from routes.admin_schema_routes import (  # type: ignore
     apprenticeship_schema,
     book_schema,
     course_schema,
@@ -44,10 +44,10 @@ def test_admin_schema_available(monkeypatch, func):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_schema_routes.get_current_user_id", fake_current_user
+        "routes.admin_schema_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_schema_routes.require_permission", fake_require_permission
+        "routes.admin_schema_routes.require_permission", fake_require_permission
     )
 
     req = Request({"type": "http", "headers": []})

--- a/tests/admin/test_admin_skill_routes.py
+++ b/tests/admin/test_admin_skill_routes.py
@@ -33,7 +33,7 @@ def test_prerequisites_persist_across_restarts(tmp_path, monkeypatch):
         sys.modules, "backend.seeds.stage_equipment_seed", dummy_equipment_seed
     )
 
-    admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")
+    admin_music_routes = importlib.import_module("routes.admin_music_routes")
 
     async def fake_current_user(req):
         return 1
@@ -55,8 +55,8 @@ def test_prerequisites_persist_across_restarts(tmp_path, monkeypatch):
 
     # Simulate restart
     importlib.reload(skill_seed)
-    del sys.modules["backend.routes.admin_music_routes"]
-    admin_music_routes = importlib.import_module("backend.routes.admin_music_routes")
+    del sys.modules["routes.admin_music_routes"]
+    admin_music_routes = importlib.import_module("routes.admin_music_routes")
 
     reloaded_skill = next(s for s in skill_seed.SEED_SKILLS if s.id == skill_id)
     assert reloaded_skill.prerequisites.get(2) == 3

--- a/tests/admin/test_apprenticeship_routes.py
+++ b/tests/admin/test_apprenticeship_routes.py
@@ -9,7 +9,7 @@ BASE = Path(__file__).resolve().parents[2]
 sys.path.append(str(BASE))
 sys.path.append(str(BASE / "backend"))
 
-from backend.routes.admin_apprenticeship_routes import (  # type: ignore  # noqa: E402,I001
+from routes.admin_apprenticeship_routes import (  # type: ignore  # noqa: E402,I001
     ApprenticeshipIn,
     create_apprenticeship,
     delete_apprenticeship,
@@ -48,10 +48,10 @@ def test_apprenticeship_routes_crud(monkeypatch, tmp_path):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_apprenticeship_routes.get_current_user_id", fake_current_user
+        "routes.admin_apprenticeship_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_apprenticeship_routes.require_permission", fake_require_permission
+        "routes.admin_apprenticeship_routes.require_permission", fake_require_permission
     )
 
     svc.db_path = str(tmp_path / "apprenticeships.db")

--- a/tests/admin/test_online_tutorial_routes.py
+++ b/tests/admin/test_online_tutorial_routes.py
@@ -10,7 +10,7 @@ BASE = Path(__file__).resolve().parents[2]
 sys.path.append(str(BASE))
 sys.path.append(str(BASE / "backend"))
 
-from backend.routes.admin_online_tutorial_routes import (  # type: ignore
+from routes.admin_online_tutorial_routes import (  # type: ignore
     OnlineTutorialIn,
     create_tutorial,
     delete_tutorial,
@@ -47,11 +47,11 @@ def test_online_tutorial_routes_crud(monkeypatch, tmp_path):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_online_tutorial_routes.get_current_user_id",
+        "routes.admin_online_tutorial_routes.get_current_user_id",
         fake_current_user,
     )
     monkeypatch.setattr(
-        "backend.routes.admin_online_tutorial_routes.require_permission", fake_require_permission
+        "routes.admin_online_tutorial_routes.require_permission", fake_require_permission
     )
 
     svc.db_path = str(tmp_path / "tutorials.db")

--- a/tests/admin/test_tutor_routes.py
+++ b/tests/admin/test_tutor_routes.py
@@ -9,7 +9,7 @@ BASE = Path(__file__).resolve().parents[2]
 sys.path.append(str(BASE))
 sys.path.append(str(BASE / "backend"))
 
-from backend.routes.admin_tutor_routes import (  # type: ignore  # noqa: E402,I001
+from routes.admin_tutor_routes import (  # type: ignore  # noqa: E402,I001
     TutorIn,
     create_tutor,
     delete_tutor,
@@ -45,10 +45,10 @@ def test_tutor_routes_crud(monkeypatch, tmp_path):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_tutor_routes.get_current_user_id", fake_current_user
+        "routes.admin_tutor_routes.get_current_user_id", fake_current_user
     )
     monkeypatch.setattr(
-        "backend.routes.admin_tutor_routes.require_permission", fake_require_permission
+        "routes.admin_tutor_routes.require_permission", fake_require_permission
     )
 
     svc.db_path = str(tmp_path / "tutors.db")

--- a/tests/admin/test_workshop_routes.py
+++ b/tests/admin/test_workshop_routes.py
@@ -12,7 +12,7 @@ BASE = Path(__file__).resolve().parents[2]
 sys.path.append(str(BASE))
 sys.path.append(str(BASE / "backend"))
 
-from backend.routes.admin_workshop_routes import (  # type: ignore  # noqa: E402
+from routes.admin_workshop_routes import (  # type: ignore  # noqa: E402
     WorkshopIn,
     create_workshop,
     delete_workshop,
@@ -48,11 +48,11 @@ def test_workshop_routes_crud(monkeypatch, tmp_path):
         return True
 
     monkeypatch.setattr(
-        "backend.routes.admin_workshop_routes.get_current_user_id",
+        "routes.admin_workshop_routes.get_current_user_id",
         fake_current_user,
     )
     monkeypatch.setattr(
-        "backend.routes.admin_workshop_routes.require_permission",
+        "routes.admin_workshop_routes.require_permission",
         fake_require_permission,
     )
 

--- a/tests/test_jobs_charts_multi_country.py
+++ b/tests/test_jobs_charts_multi_country.py
@@ -23,7 +23,7 @@ sys.modules["backend.services.chart_service"] = chart_service_stub
 
 from backend import database
 from backend.services.jobs_charts import ChartsJobsService
-from backend.routes import chart_routes
+from routes import chart_routes
 
 def _setup_db(tmp_path):
     db = tmp_path / "charts.sqlite"


### PR DESCRIPTION
## Summary
- refactor imports to use `routes` instead of `backend.routes`
- update docstrings and tests to reference `routes.*`

## Testing
- `pytest` *(fails: Interrupted 50 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c73d63ee5c8325935afab772e7349c