### PR TITLE
refactor: update realtime imports

### DIFF
--- a/routes/jam_ws.py
+++ b/routes/jam_ws.py
@@ -3,6 +3,6 @@
 This module simply re-exports the realtime jam gateway router so it can be
 mounted alongside other route modules.
 """
-from backend.realtime.jam_gateway import router
+from realtime.jam_gateway import router
 
 __all__ = ["router"]

--- a/routes/notifications_ws.py
+++ b/routes/notifications_ws.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
 
-from backend.realtime.gateway import (
+from realtime.gateway import (
     _Subscriber,
     get_current_user_id_dep,
     hub,


### PR DESCRIPTION
## Summary
- fix websocket routes to import realtime modules directly

## Testing
- `pytest tests/realtime/test_polling_ws.py -q` *(fails: ModuleNotFoundError: No module named 'backend.realtime')*


------
https://chatgpt.com/codex/tasks/task_e_68c742874b6c8325984c5fd3c68ee13b