### PR TITLE
refactor: update service imports

### DIFF
--- a/realtime/dialogue_gateway.py
+++ b/realtime/dialogue_gateway.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from backend.models.dialogue import DialogueMessage
 from backend.realtime.gateway import get_current_user_id_dep
 from backend.monitoring.websocket import track_connect, track_disconnect, track_message
-from backend.services.dialogue_service import DialogueService
+from services.dialogue_service import DialogueService
 
 router = APIRouter(prefix="/dialogue", tags=["dialogue"])
 

--- a/realtime/jam_gateway.py
+++ b/realtime/jam_gateway.py
@@ -11,7 +11,7 @@ try:  # pragma: no cover - explicit failure if FastAPI missing
 except ModuleNotFoundError as exc:  # pragma: no cover - FastAPI required
     raise ImportError("FastAPI must be installed to use backend.realtime.jam_gateway") from exc
 
-from backend.services.jam_service import JamService
+from services.jam_service import JamService
 from .gateway import get_current_user_id_dep
 from backend.monitoring.websocket import track_connect, track_disconnect, track_message
 


### PR DESCRIPTION
## Summary
- update realtime service imports to new `services` package paths

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*
- `rg 'backend\.services' -n realtime`


------
https://chatgpt.com/codex/tasks/task_e_68c742889cac8325b0ce9dbd0f4d529d