### PR TITLE
Replace backend realtime imports with realtime package

### DIFF
--- a/services/fan_club_service.py
+++ b/services/fan_club_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from backend.realtime.publish import (
+from realtime.publish import (
     publish_fan_club_event_invite,
     publish_fan_club_post,
 )

--- a/services/live_performance_service.py
+++ b/services/live_performance_service.py
@@ -26,7 +26,7 @@ from services.gear_service import gear_service
 from services.setlist_service import get_approved_setlist
 
 try:
-    from backend.realtime.polling import poll_hub
+    from realtime.polling import poll_hub
 except Exception:  # pragma: no cover - optional realtime module
     poll_hub = None  # type: ignore
 

--- a/services/social_service.py
+++ b/services/social_service.py
@@ -5,7 +5,7 @@ import sqlite3
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-from backend.realtime.social_gateway import publish_forum_reply, publish_friend_request
+from realtime.social_gateway import publish_forum_reply, publish_friend_request
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- switch realtime imports in services to use `realtime` package instead of `backend.realtime`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c74289a4748325b04b9091042e3554