### PR TITLE
refactor: drop backend imports in jobs

### DIFF
--- a/jobs/cleanup_event_effects.py
+++ b/jobs/cleanup_event_effects.py
@@ -1,6 +1,6 @@
 """Clear expired event effects from the database."""
 
-from backend.services.event_service import clear_expired_events
+from services.event_service import clear_expired_events
 
 
 def run() -> tuple[int, str]:

--- a/jobs/cleanup_tokens.py
+++ b/jobs/cleanup_tokens.py
@@ -1,13 +1,13 @@
 # cleanup_tokens.py
 """
-Remove expired or revoked token entries from backend.auth tables.
+Remove expired or revoked token entries from auth tables.
 
 Targets tables:
-- access_tokens(jti TEXT PRIMARY KEY, user_id INTEGER NOT NULL,
-  expires_at TEXT NOT NULL, revoked_at TEXT)
-- refresh_tokens(id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER,
-  token_hash TEXT, issued_at TEXT, expires_at TEXT, revoked_at TEXT,
-  user_agent TEXT, ip TEXT)
+    - access_tokens(jti TEXT PRIMARY KEY, user_id INTEGER NOT NULL,
+      expires_at TEXT NOT NULL, revoked_at TEXT)
+    - refresh_tokens(id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER,
+      token_hash TEXT, issued_at TEXT, expires_at TEXT, revoked_at TEXT,
+      user_agent TEXT, ip TEXT)
 
 This job removes rows whose `expires_at` has passed or whose
 `revoked_at` timestamp is in the past.

--- a/jobs/data_hygiene_jobs.py
+++ b/jobs/data_hygiene_jobs.py
@@ -35,7 +35,6 @@ def _detect_db_path() -> str:
     # Preferred: dedicated settings
     for mod_name, attr in (
         ("core.settings", "DB_PATH"),
-        ("backend.settings", "DB_PATH"),
         ("settings", "DB_PATH"),
     ):
         try:
@@ -79,7 +78,6 @@ def get_conn(db_path: Optional[str] = None) -> sqlite3.Connection:
     # Try project-level helpers first
     for mod_name in (
         "core.database",
-        "backend.database",
         "database",
     ):
         try:

--- a/jobs/lifestyle_jobs.py
+++ b/jobs/lifestyle_jobs.py
@@ -1,6 +1,6 @@
 """Scheduler job for daily lifestyle decay and XP rewards."""
 
-from backend.services.lifestyle_scheduler import apply_lifestyle_decay_and_xp_effects
+from services.lifestyle_scheduler import apply_lifestyle_decay_and_xp_effects
 
 
 def run() -> tuple[int, str]:

--- a/jobs/random_events.py
+++ b/jobs/random_events.py
@@ -1,5 +1,5 @@
 """Scheduler job to trigger random events."""
-from backend.services.random_event_service import random_event_service
+from services.random_event_service import random_event_service
 
 
 def run() -> tuple[int, str]:

--- a/jobs/royalty_clearing_job.py
+++ b/jobs/royalty_clearing_job.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import sqlite3
 from typing import Iterable, Tuple
 
-from backend.database import DB_PATH
+from database import DB_PATH
 
 
 def _fetch_outstanding(cur: sqlite3.Cursor) -> Iterable[Tuple[int, int, int, int]]:

--- a/jobs/sponsor_reconciliation_job.py
+++ b/jobs/sponsor_reconciliation_job.py
@@ -6,9 +6,9 @@ import asyncio
 import sqlite3
 from typing import Any, Dict
 
-from backend.services.jobs_royalties import RoyaltyJobsService
-from backend.services.sponsorship_service import SponsorshipService
-from backend.utils.metrics import Counter
+from services.jobs_royalties import RoyaltyJobsService
+from services.sponsorship_service import SponsorshipService
+from utils.metrics import Counter
 
 RECONCILIATION_JOB_FAILURES = Counter(
     "sponsor_reconciliation_failures_total",

--- a/jobs/world_pulse_jobs.py
+++ b/jobs/world_pulse_jobs.py
@@ -10,11 +10,11 @@ import os
 from datetime import date, datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
-from backend.services.season_service import SeasonScheduler
+from services.season_service import SeasonScheduler
 
 try:
     # Preferred: shared project connection helper
-    from backend.database import get_conn  # type: ignore
+    from database import get_conn  # type: ignore
 except Exception:
     # Fallback: local minimal connector for tests or standalone runs
     import sqlite3


### PR DESCRIPTION
## Summary
- stop referencing `backend` packages in job modules
- use top-level `database`, `core`, and `services` packages

## Testing
- `rg 'backend\.' jobs`
- `pytest` *(fails: 50 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c7428a5cc48325a9c80d402035ed44