### PR TITLE
Refactor dialogue service imports

### DIFF
--- a/services/dialogue_service.py
+++ b/services/dialogue_service.py
@@ -3,13 +3,8 @@ from __future__ import annotations
 
 from typing import List, Optional, Protocol
 
-
 from models.dialogue import DialogueMessage
-from backend.services.moderation_service import moderate_content
-from backend.models.dialogue import DialogueMessage
 from services.moderation_service import moderate_content
-
-
 
 class LLMProvider(Protocol):
     async def complete(self, history: List[DialogueMessage]) -> str: ...


### PR DESCRIPTION
## Summary
- remove deprecated backend imports in dialogue service
- rely on in-repo moderation and dialogue models

## Testing
- `python -m compile services/dialogue_service.py` *(fails: No module named compile)*
- `python -m py_compile services/dialogue_service.py`
- `PYTHONPATH=. pytest tests/test_addiction.py -q` *(fails: ModuleNotFoundError: No module named 'backend.services')*


------
https://chatgpt.com/codex/tasks/task_e_68c7d0aa1fa48325a12aeed4707e633b