### PR TITLE
refactor: remove redundant backend imports

### DIFF
--- a/services/jam_service.py
+++ b/services/jam_service.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from typing import Dict, Optional, Set
 
 from models.jam_session import AudioStream, JamSession
-from backend.services.economy_service import EconomyService
-from backend.models.jam_session import AudioStream, JamSession
 from services.economy_service import EconomyService
 
 STUDIO_RENTAL_CENTS = 100


### PR DESCRIPTION
## Summary
- remove outdated backend imports in `jam_service` to use local modules

## Testing
- `python -m compile services/jam_service.py` *(fails: No module named compile)*
- `python -m py_compile services/jam_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7d0ac1ec0832591fbc7e968be66b4