### PR TITLE
docs: update gig service reference

### DIFF
--- a/docs/live3d_prototype.md
+++ b/docs/live3d_prototype.md
@@ -22,4 +22,4 @@ python -m live3d --gig-id 1 --db path/to/gig.db
 ```
 
 The command fetches the gig's completion data using
-`backend.services.gig_service` and displays the attendance as a 3D bar.
+`services.gig_service` and displays the attendance as a 3D bar.


### PR DESCRIPTION
## Summary
- update docs to reference `services.gig_service`

## Testing
- `make docs`
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c7d0ada8648325b25e2a854de6695a