### PR TITLE
fix: update dialogue message import

### DIFF
--- a/realtime/dialogue_gateway.py
+++ b/realtime/dialogue_gateway.py
@@ -5,9 +5,9 @@ from typing import List
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 
-from backend.models.dialogue import DialogueMessage
-from realtime.gateway import get_current_user_id_dep
 from backend.monitoring.websocket import track_connect, track_disconnect, track_message
+from models.dialogue import DialogueMessage
+from realtime.gateway import get_current_user_id_dep
 from services.dialogue_service import DialogueService
 
 router = APIRouter(prefix="/dialogue", tags=["dialogue"])


### PR DESCRIPTION
## Summary
- fix DialogueMessage import in dialogue gateway

## Testing
- `python -m compile realtime/dialogue_gateway.py` *(fails: No module named compile)*
- `python -m py_compile realtime/dialogue_gateway.py`
- `ruff check realtime/dialogue_gateway.py`
- `pytest tests/realtime -q` *(fails: ModuleNotFoundError: No module named 'monitoring.websocket')*


------
https://chatgpt.com/codex/tasks/task_e_68c7d0af17808325a4000130e83cb5c2