### PR TITLE
Remove deprecated jam session backend import

### DIFF
--- a/services/jam_service.py
+++ b/services/jam_service.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from typing import Dict, Optional, Set
 
 from models.jam_session import AudioStream, JamSession
-from backend.services.economy_service import EconomyService
-from backend.models.jam_session import AudioStream, JamSession
 from services.economy_service import EconomyService
 
 STUDIO_RENTAL_CENTS = 100


### PR DESCRIPTION
## Summary
- remove outdated backend jam_session import from JamService
- streamline JamService to use top-level models and services

## Testing
- `python -m compile services/jam_service.py` *(fails: No module named compile)*
- `python -m py_compile services/jam_service.py`
- `pytest` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d0b0c02483259f8a42291db235b3