### PR TITLE
Fix economy service import in jam gateway test

### DIFF
--- a/backend/tests/jam_sessions/test_jam_gateway.py
+++ b/backend/tests/jam_sessions/test_jam_gateway.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 import pytest
 
 from realtime.jam_gateway import jam_ws, jam_service
-from backend.services.economy_service import EconomyService
+from services.economy_service import EconomyService
 
 
 class FakeWebSocket:


### PR DESCRIPTION
## Summary
- fix path for `EconomyService` import in jam session gateway test

## Testing
- `python -m py_compile backend/tests/jam_sessions/test_jam_gateway.py`
- `pytest backend/tests/jam_sessions/test_jam_gateway.py -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c7d46170808325b6984939fdd7ef50