### PR TITLE
Update jam service test imports to new services path

### DIFF
--- a/backend/tests/jam_sessions/test_jam_service_failure.py
+++ b/backend/tests/jam_sessions/test_jam_service_failure.py
@@ -1,8 +1,8 @@
 import logging
 import pytest
 
-from backend.services.jam_service import JamService
-from backend.services.economy_service import EconomyService
+from services.jam_service import JamService
+from services.economy_service import EconomyService
 
 
 class FailingEconomy(EconomyService):


### PR DESCRIPTION
## Summary
- adjust jam service failure test imports to new `services` module locations

## Testing
- `pytest backend/tests/jam_sessions/test_jam_service_failure.py` *(fails: ModuleNotFoundError: No module named 'backend')*
- `python - <<'PY'
import importlib.util, importlib.machinery
import pathlib
path = pathlib.Path('backend/tests/jam_sessions/test_jam_service_failure.py')
loader = importlib.machinery.SourceFileLoader('test_jam_service_failure', str(path))
spec = importlib.util.spec_from_loader('test_jam_service_failure', loader)
module = importlib.util.module_from_spec(spec)
loader.exec_module(module)
print('Module loaded, JamService is', module.JamService.__name__)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c7d45fb020832591315189a41c6c23