### PR TITLE
Refactor NPC seasonal test imports

### DIFF
--- a/tests/test_npc_seasonal_events.py
+++ b/tests/test_npc_seasonal_events.py
@@ -7,11 +7,10 @@ from pathlib import Path
 # Ensure the backend package is importable when tests run standalone
 root_dir = Path(__file__).resolve().parents[1]
 sys.path.append(str(root_dir))
-sys.path.append(str(root_dir / "backend"))
 
-import backend.services.npc_service as npc_service_module
-from backend.services.npc_service import NPCService
-from backend.services import scheduler_service
+import services.npc_service as npc_service_module
+from services.npc_service import NPCService
+from services import scheduler_service
 
 
 def _setup_scheduler(tmp_path):


### PR DESCRIPTION
## Summary
- simplify NPC seasonal event test imports
- drop unused backend path manipulation

## Testing
- `pytest tests/test_npc_seasonal_events.py -q` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68c7d52d5d348325aed76caa7c51c2ac