### PR TITLE
Refactor shop event service test imports

### DIFF
--- a/tests/test_shop_event_service.py
+++ b/tests/test_shop_event_service.py
@@ -7,22 +7,49 @@ from pathlib import Path
 # ensure backend module import
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+# expose select project modules under the ``backend`` namespace for legacy imports
+backend_pkg = types.ModuleType("backend")
+sys.modules["backend"] = backend_pkg
+sys.modules["backend.database"] = __import__("database")
+sys.modules["backend.models"] = types.ModuleType("backend.models")
+for _name in ("event", "event_effect", "npc", "skill"):
+    sys.modules[f"backend.models.{_name}"] = __import__(
+        f"models.{_name}", fromlist=[_name]
+    )
+sys.modules["backend.utils"] = types.ModuleType("backend.utils")
+sys.modules["backend.utils.db"] = types.SimpleNamespace(
+    _init_pool_async=None,
+    aget_conn=None,
+    cached_query=None,
+    get_conn=None,
+    init_pool=None,
+)
+
 fake = types.ModuleType("services.discord_service")
 fake.DiscordServiceError = Exception
 fake.send_message = lambda *args, **kwargs: None
 sys.modules["services.discord_service"] = fake
 
-fake_sched = types.ModuleType("backend.services.scheduler_service")
+fake_sched = types.ModuleType("services.scheduler_service")
 fake_sched.schedule_task = lambda *args, **kwargs: {"status": "ok"}
-sys.modules["backend.services.scheduler_service"] = fake_sched
+sys.modules["services.scheduler_service"] = fake_sched
+
+# stub other service dependencies not needed for shop events
+sys.modules.setdefault("services.city_service", types.SimpleNamespace(city_service=None))
+sys.modules.setdefault("services.npc_ai_service", types.SimpleNamespace(npc_ai_service=None))
+sys.modules.setdefault("services.skill_service", types.SimpleNamespace(skill_service=None))
+sys.modules.setdefault("services.weather_service", types.SimpleNamespace(weather_service=None))
+sys.modules.setdefault(
+    "services.reputation_service", types.SimpleNamespace(reputation_service=None)
+)
 
 fake_seed = types.ModuleType("seeds.skill_seed")
 fake_seed.SKILL_NAME_TO_ID = {}
 sys.modules["seeds.skill_seed"] = fake_seed
 
-import backend.services.event_service as event_service_module  # noqa: E402
+import services.event_service as event_service_module  # noqa: E402
 from backend import database  # noqa: E402
-from backend.services.event_service import (  # noqa: E402
+from services.event_service import (  # noqa: E402
     end_shop_event,
     schedule_shop_event,
     start_shop_event,


### PR DESCRIPTION
## Summary
- update shop event service test to import `services.event_service`
- add backend namespace shims and scheduler stub

## Testing
- `pytest tests/test_shop_event_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7d529b5d48325ba3dd3bcadad9fe9