### PR TITLE
Add auth package exports

### DIFF
--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,0 +1,10 @@
+"""Authentication package exports."""
+
+__all__ = [
+    "dependencies",
+    "jwt",
+    "permissions",
+    "rbac",
+    "routes",
+    "service",
+]


### PR DESCRIPTION
## Summary
- add `__all__` definitions for auth submodules
- document the auth package

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c7db74da388325bf6c1bc1b5f34cc6