### PR TITLE
chore: simplify Netlify build configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,6 @@
 [build]
-  base = "frontend"
-  publish = "build"
-  command = "npm cache clean --force && npm ci && npm run build"
+  command = ""
+  publish = "frontend/pages"
 
 [build.environment]
   NODE_VERSION = "20.11.1"


### PR DESCRIPTION
## Summary
- remove Netlify base path and build command
- point Netlify `publish` to the folder with `index.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c7e50713bc832585a80ca65f92a40a