### PR TITLE
Add root index redirect for Netlify

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="refresh" content="0; url=pages/login.html" />
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>Redirecting to <a href="pages/login.html">login page</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `frontend/index.html` to redirect to the login page for Netlify root

## Testing
- `npm test` *(fails: vitest not found; package install 403)*
- `pytest` *(fails: module 'backend' has no attribute '__path__')*


------
https://chatgpt.com/codex/tasks/task_e_68c7e5445db08325b301663812d0cbe2