### PR TITLE
Add Netlify site to CORS allowed origins

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -41,7 +41,10 @@ class CORSSettings(BaseModel):
     """Cross-origin resource sharing settings."""
 
     allowed_origins: list[str] = Field(
-        default_factory=lambda: ["*"], env="ROCKMUNDO_CORS_ALLOWED_ORIGINS"
+        default_factory=lambda: [
+            "https://my-rockmundo.netlify.app",
+        ],
+        env="ROCKMUNDO_CORS_ALLOWED_ORIGINS",
     )
 
 


### PR DESCRIPTION
## Summary
- add Netlify frontend URL to CORS allowed origins configuration

## Testing
- `pytest` *(fails: module 'backend' has no attribute '__path__')*

------
https://chatgpt.com/codex/tasks/task_e_68c7e545d60883259c24ca29fb8a2d34