### PR TITLE
chore: proxy API requests to backend

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,12 @@
   REACT_APP_API_BASE = "https://backend.example.com"
 
 [[redirects]]
+  from = "/api/*"
+  to   = "https://backend.example.com/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
## Summary
- add Netlify redirect to forward `/api/*` traffic to the backend service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68c7e5451d1083259fa6e3f217c9843e