### PR TITLE
refactor: use relative websocket URL

### DIFF
--- a/frontend/utils/ws.js
+++ b/frontend/utils/ws.js
@@ -2,7 +2,7 @@
 //
 // Usage:
 //   import { connect } from './utils/ws.js';
-//   const conn = connect('ws://localhost:8000/notifications/ws', {
+//   const conn = connect('/notifications/ws', {
 //     onMessage: (msg) => console.log(msg),
 //     pollUrl: '/api/notifications', // fallback endpoint returning JSON list
 //   });
@@ -13,6 +13,10 @@
 import { authFetch } from './auth.js';
 
 export function connect(url, { onMessage, onError, onOpen, pollUrl, pollInterval = 5000 } = {}) {
+  if (!/^wss?:/i.test(url)) {
+    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    url = `${proto}://${window.location.host}${url}`;
+  }
   // If WebSocket is supported and available, prefer it.
   if ('WebSocket' in window) {
     try {


### PR DESCRIPTION
## Summary
- allow websocket helper to accept relative URL
- remove localhost reference in usage example

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm ci` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e546f71883259ed8cc370529e03c