### PR TITLE
Install Rust before building on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,11 @@
 [build]
-  command = ""
+  command = """
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&
+    export PATH=\"$HOME/.cargo/bin:$PATH\" &&
+    pip install -r requirements.txt &&
+    npm ci --prefix frontend &&
+    npm run build --prefix frontend
+  """
   publish = "frontend/pages"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- Ensure Netlify build installs Rust via rustup
- Build frontend and install Python deps after updating PATH

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: module 'backend' has no attribute '__path__')*
- `npm install -g netlify-cli` *(fails: 403 Forbidden - GET https://registry.npmjs.org/netlify-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68c8176ffff083259deca80b0793ab6d