### PR TITLE
chore: inline netlify build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,5 @@
 [build]
-  command = """
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&
-    export PATH=\"$HOME/.cargo/bin:$PATH\" &&
-    pip install -r requirements.txt &&
-    npm ci --prefix frontend &&
-    npm run build --prefix frontend
-  """
+  command = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && export PATH=\"$HOME/.cargo/bin:$PATH\" && pip install -r requirements.txt && npm ci --prefix frontend && npm run build --prefix frontend"
   publish = "frontend/pages"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- inline Netlify build command with escaped quotes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68c824410fa08325b93fa810c309090d