### PR TITLE
Ensure Rust environment loads in Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && export PATH=\"$HOME/.cargo/bin:$PATH\" && pip install -r requirements.txt && npm ci --prefix frontend && npm run build --prefix frontend"
+  command = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source \"$HOME/.cargo/env\" && pip install -r requirements.txt && npm ci --prefix frontend && npm run build --prefix frontend"
   publish = "frontend/pages"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- install Rust and source cargo env before running dependency steps in Netlify build

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'backend')


------
https://chatgpt.com/codex/tasks/task_e_68c826dd4f4c8325966583b9660ad262