### PR TITLE
Specify Python version and upgrade Pydantic

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,7 @@
   publish = "frontend/pages"
 
 [build.environment]
+  PYTHON_VERSION = "3.12"
   NODE_VERSION = "20.11.1"
   REACT_APP_API_BASE = "https://backend.example.com"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ redis
 alembic
 statsmodels
 pandas
-pydantic==2.5.3
+pydantic==2.9.2
 email-validator
 pytest
 aiosqlite


### PR DESCRIPTION
## Summary
- ensure Netlify uses Python 3.12 during builds
- bump Pydantic to 2.9.2 to obtain Python 3.13 wheels

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pydantic==2.9.2)*
- `pytest` *(fails: 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c826dd8f1483258a0680e98a99989c